### PR TITLE
worker ocall abstraction onchain

### DIFF
--- a/local-setup/launch.py
+++ b/local-setup/launch.py
@@ -35,6 +35,7 @@ def setup_worker(work_dir: str, source_dir: str, std_err: Union[None, int, IO]):
 
 def run_node(config):
     node_cmd = [config["node"]["bin"]] + config["node"]["flags"]
+    print(f'Run node with command: {node_cmd}')
     return Popen(node_cmd, stdout=node_log, stderr=STDOUT, bufsize=1)
 
 

--- a/worker/src/error.rs
+++ b/worker/src/error.rs
@@ -1,18 +1,20 @@
-use codec::{Error as CodecError};
+use codec::Error as CodecError;
 use substrate_api_client::ApiClientError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("{0}")]
-	Codec(#[from] CodecError),
-	#[error("{0}")]
-	ApiClientError(#[from] ApiClientError),
-	#[error("{0}")]
-	JsonRpSeeClient(#[from] jsonrpsee::types::Error),
-	#[error("{0}")]
-	Serialization(#[from] serde_json::Error),
-	#[error("{0}")]
-	FromUtf8Error(#[from] std::string::FromUtf8Error),
-	#[error("Custom Error: {0}")]
-	Custom(Box<dyn std::error::Error>),
+    #[error("{0}")]
+    Codec(#[from] CodecError),
+    #[error("{0}")]
+    ApiClientError(#[from] ApiClientError),
+    #[error("{0}")]
+    JsonRpSeeClient(#[from] jsonrpsee::types::Error),
+    #[error("{0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("{0}")]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    #[error("Application setup error!")]
+    ApplicationSetupError,
+    #[error("Custom Error: {0}")]
+    Custom(Box<dyn std::error::Error>),
 }

--- a/worker/src/globals/mod.rs
+++ b/worker/src/globals/mod.rs
@@ -16,9 +16,5 @@
 
 */
 
-pub mod bridge_api;
-pub mod component_factory;
-
-mod ffi;
-mod remote_attestation_ocall;
-mod worker_on_chain_ocall;
+pub mod tokio_handle;
+pub mod worker;

--- a/worker/src/globals/tokio_handle.rs
+++ b/worker/src/globals/tokio_handle.rs
@@ -1,0 +1,87 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+use tokio::runtime::Handle;
+
+lazy_static! {
+    static ref TOKIO_HANDLE: RwLock<Option<tokio::runtime::Runtime>> = RwLock::new(None);
+}
+
+/// Wrapper for accessing a tokio handle
+pub trait GetTokioHandle {
+    fn get_handle(&self) -> Handle;
+}
+
+/// implementation, using a static global variable internally
+///
+pub struct GlobalTokioHandle;
+
+/// these are the static (global) accessors
+/// reduce their usage where possible and use an instance of TokioHandleAccessorImpl or the trait
+impl GlobalTokioHandle {
+    /// this needs to be called once at application startup!
+    pub fn initialize() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        *TOKIO_HANDLE.write() = Some(rt);
+    }
+
+    /// static / global getter of the handle (try to keep private!, use trait to access handle)
+    fn read_handle() -> Handle {
+        TOKIO_HANDLE
+            .read()
+            .as_ref()
+            .expect("Tokio handle has not been initialized!")
+            .handle()
+            .clone()
+    }
+}
+
+impl GetTokioHandle for GlobalTokioHandle {
+    fn get_handle(&self) -> Handle {
+        GlobalTokioHandle::read_handle()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[tokio::test]
+    async fn given_initialized_tokio_handle_when_runtime_goes_out_of_scope_then_async_handle_is_valid(
+    ) {
+        // initialize the global handle
+        // be aware that if you write more tests here, the global state will be shared across multiple threads
+        // which cargo test spawns. So it can lead to failing tests.
+        // solution: either get rid of the global state, or write all test functionality in this single test function
+        {
+            GlobalTokioHandle::initialize();
+        }
+
+        let handle = GlobalTokioHandle.get_handle();
+
+        let result = handle
+            .spawn_blocking(|| format!("now running on a worker thread"))
+            .await;
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap().is_empty())
+    }
+}

--- a/worker/src/globals/worker.rs
+++ b/worker/src/globals/worker.rs
@@ -1,0 +1,58 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::config::Config;
+use crate::worker::Worker as WorkerGen;
+use lazy_static::lazy_static;
+use parking_lot::{RwLock, RwLockReadGuard};
+use sp_core::sr25519;
+use substrate_api_client::Api;
+use substratee_enclave_api::Enclave;
+use substratee_worker_api::direct_client::DirectClient;
+
+pub type Worker = WorkerGen<Config, Api<sr25519::Pair>, Enclave, DirectClient>;
+
+lazy_static! {
+    static ref WORKER: RwLock<Option<Worker>> = RwLock::new(None);
+}
+
+/// Trait for accessing a worker instance
+/// Prefer injecting this trait instead of using the associated functions of WorkerAccessorImpl
+pub trait GetWorker {
+    fn get_worker<'a>(&self) -> RwLockReadGuard<'a, Option<Worker>>;
+}
+
+pub struct GlobalWorker;
+
+/// these are the static (global) accessors
+/// reduce their usage where possible and use an instance of WorkerAccessorImpl or the trait
+impl GlobalWorker {
+    pub fn reset_worker(worker: Worker) {
+        *WORKER.write() = Some(worker);
+    }
+
+    fn read_worker<'a>() -> RwLockReadGuard<'a, Option<Worker>> {
+        WORKER.read()
+    }
+}
+
+impl GetWorker for GlobalWorker {
+    fn get_worker<'a>(&self) -> RwLockReadGuard<'a, Option<Worker>> {
+        GlobalWorker::read_worker()
+    }
+}

--- a/worker/src/node_api_factory.rs
+++ b/worker/src/node_api_factory.rs
@@ -1,0 +1,63 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use lazy_static::lazy_static;
+use parking_lot::RwLock;
+use sp_core::sr25519;
+use substrate_api_client::Api;
+
+#[cfg(test)]
+use mockall::predicate::*;
+#[cfg(test)]
+use mockall::*;
+
+lazy_static! {
+    // todo: replace with &str, but use &str in api-client first
+    static ref NODE_URL: RwLock<String> = RwLock::new("".to_string());
+}
+
+/// trait to create a node API, based on a node URL
+#[cfg_attr(test, automock)]
+pub trait CreateNodeApi {
+    fn create_api(&self) -> Api<sr25519::Pair>;
+}
+
+pub struct GlobalUrlNodeApiFactory;
+
+impl GlobalUrlNodeApiFactory {
+    /// creates a new instance and initializes the global state
+    pub fn new(url: String) -> Self {
+        GlobalUrlNodeApiFactory::write_node_url(url);
+
+        GlobalUrlNodeApiFactory
+    }
+
+    fn write_node_url(url: String) {
+        *NODE_URL.write() = url;
+    }
+
+    fn read_node_url() -> String {
+        NODE_URL.read().clone()
+    }
+}
+
+impl CreateNodeApi for GlobalUrlNodeApiFactory {
+    fn create_api(&self) -> Api<sr25519::Pair> {
+        Api::<sr25519::Pair>::new(GlobalUrlNodeApiFactory::read_node_url()).unwrap()
+    }
+}

--- a/worker/src/ocall_bridge/ffi/get_ias_socket.rs
+++ b/worker/src/ocall_bridge/ffi/get_ias_socket.rs
@@ -16,7 +16,7 @@
 
 */
 
-use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationOCall};
+use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationBridge};
 use log::*;
 use sgx_types::{c_int, sgx_status_t};
 use std::sync::Arc;
@@ -26,7 +26,7 @@ pub extern "C" fn ocall_get_ias_socket(ret_fd: *mut c_int) -> sgx_status_t {
     get_ias_socket(ret_fd, Bridge::get_ra_api()) // inject the RA API (global state)
 }
 
-fn get_ias_socket(ret_fd: *mut c_int, ra_api: Arc<dyn RemoteAttestationOCall>) -> sgx_status_t {
+fn get_ias_socket(ret_fd: *mut c_int, ra_api: Arc<dyn RemoteAttestationBridge>) -> sgx_status_t {
     debug!("    Entering ocall_get_ias_socket");
     let socket_result = ra_api.get_ias_socket();
 
@@ -48,14 +48,14 @@ fn get_ias_socket(ret_fd: *mut c_int, ra_api: Arc<dyn RemoteAttestationOCall>) -
 mod tests {
 
     use super::*;
-    use crate::ocall_bridge::bridge_api::{MockRemoteAttestationOCall, OCallBridgeError};
+    use crate::ocall_bridge::bridge_api::{MockRemoteAttestationBridge, OCallBridgeError};
     use std::sync::Arc;
 
     #[test]
     fn get_socket_sets_pointer_result() {
         let expected_socket = 4321i32;
 
-        let mut ra_ocall_api_mock = MockRemoteAttestationOCall::new();
+        let mut ra_ocall_api_mock = MockRemoteAttestationBridge::new();
         ra_ocall_api_mock
             .expect_get_ias_socket()
             .times(1)
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn given_error_from_ocall_impl_then_return_sgx_error() {
-        let mut ra_ocall_api_mock = MockRemoteAttestationOCall::new();
+        let mut ra_ocall_api_mock = MockRemoteAttestationBridge::new();
         ra_ocall_api_mock
             .expect_get_ias_socket()
             .times(1)

--- a/worker/src/ocall_bridge/ffi/get_quote.rs
+++ b/worker/src/ocall_bridge/ffi/get_quote.rs
@@ -16,7 +16,7 @@
 
 */
 
-use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationOCall};
+use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationBridge};
 use log::*;
 use sgx_types::{sgx_quote_nonce_t, sgx_quote_sign_type_t, sgx_report_t, sgx_spid_t, sgx_status_t};
 use std::slice;
@@ -62,7 +62,7 @@ fn get_quote(
     p_quote: *mut u8,
     maxlen: u32,
     p_quote_len: *mut u32,
-    ra_api: Arc<dyn RemoteAttestationOCall>,
+    ra_api: Arc<dyn RemoteAttestationBridge>,
 ) -> sgx_status_t {
     debug!("    Entering ocall_get_quote");
 

--- a/worker/src/ocall_bridge/ffi/get_update_info.rs
+++ b/worker/src/ocall_bridge/ffi/get_update_info.rs
@@ -16,7 +16,7 @@
 
 */
 
-use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationOCall};
+use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationBridge};
 use log::*;
 use sgx_types::{sgx_platform_info_t, sgx_status_t, sgx_update_info_bit_t};
 use std::sync::Arc;
@@ -39,7 +39,7 @@ fn get_update_info(
     p_platform_blob: *const sgx_platform_info_t,
     enclave_trusted: i32,
     p_update_info: *mut sgx_update_info_bit_t,
-    ra_api: Arc<dyn RemoteAttestationOCall>,
+    ra_api: Arc<dyn RemoteAttestationBridge>,
 ) -> sgx_status_t {
     debug!("    Entering ocall_get_update_info");
 

--- a/worker/src/ocall_bridge/ffi/init_quote.rs
+++ b/worker/src/ocall_bridge/ffi/init_quote.rs
@@ -16,7 +16,7 @@
 
 */
 
-use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationOCall};
+use crate::ocall_bridge::bridge_api::{Bridge, RemoteAttestationBridge};
 use log::*;
 use sgx_types::{sgx_epid_group_id_t, sgx_status_t, sgx_target_info_t};
 use std::sync::Arc;
@@ -32,7 +32,7 @@ pub extern "C" fn ocall_sgx_init_quote(
 fn sgx_init_quote(
     ret_ti: *mut sgx_target_info_t,
     ret_gid: *mut sgx_epid_group_id_t,
-    ra_api: Arc<dyn RemoteAttestationOCall>,
+    ra_api: Arc<dyn RemoteAttestationBridge>,
 ) -> sgx_status_t {
     debug!("    Entering ocall_sgx_init_quote");
     let init_result = match ra_api.init_quote() {
@@ -55,12 +55,12 @@ fn sgx_init_quote(
 mod tests {
 
     use super::*;
-    use crate::ocall_bridge::bridge_api::MockRemoteAttestationOCall;
+    use crate::ocall_bridge::bridge_api::MockRemoteAttestationBridge;
     use std::sync::Arc;
 
     #[test]
     fn init_quote_sets_results() {
-        let mut ra_ocall_api_mock = MockRemoteAttestationOCall::new();
+        let mut ra_ocall_api_mock = MockRemoteAttestationBridge::new();
         ra_ocall_api_mock
             .expect_init_quote()
             .times(1)

--- a/worker/src/ocall_bridge/ffi/mod.rs
+++ b/worker/src/ocall_bridge/ffi/mod.rs
@@ -24,3 +24,5 @@ pub mod get_ias_socket;
 pub mod get_quote;
 pub mod get_update_info;
 pub mod init_quote;
+pub mod send_block_and_confirmation;
+pub mod worker_request;

--- a/worker/src/ocall_bridge/ffi/send_block_and_confirmation.rs
+++ b/worker/src/ocall_bridge/ffi/send_block_and_confirmation.rs
@@ -1,0 +1,73 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::ocall_bridge::bridge_api::{Bridge, WorkerOnChainBridge};
+use log::*;
+use sgx_types::sgx_status_t;
+use std::slice;
+use std::sync::Arc;
+use std::vec::Vec;
+
+/// # Safety
+///
+/// FFI are always unsafe
+#[no_mangle]
+pub unsafe extern "C" fn ocall_send_block_and_confirmation(
+    confirmations: *const u8,
+    confirmations_size: u32,
+    signed_blocks_ptr: *const u8,
+    signed_blocks_size: u32,
+) -> sgx_status_t {
+    send_block_and_confirmation(
+        confirmations,
+        confirmations_size,
+        signed_blocks_ptr,
+        signed_blocks_size,
+        Bridge::get_oc_api(),
+    )
+}
+
+fn send_block_and_confirmation(
+    confirmations: *const u8,
+    confirmations_size: u32,
+    signed_blocks_ptr: *const u8,
+    signed_blocks_size: u32,
+    oc_api: Arc<dyn WorkerOnChainBridge>,
+) -> sgx_status_t {
+    let confirmations_vec: Vec<u8> = unsafe {
+        Vec::from(slice::from_raw_parts(
+            confirmations,
+            confirmations_size as usize,
+        ))
+    };
+
+    let signed_blocks_vec: Vec<u8> = unsafe {
+        Vec::from(slice::from_raw_parts(
+            signed_blocks_ptr,
+            signed_blocks_size as usize,
+        ))
+    };
+
+    match oc_api.send_block_and_confirmation(confirmations_vec, signed_blocks_vec) {
+        Ok(_) => sgx_status_t::SGX_SUCCESS,
+        Err(e) => {
+            error!("send block and confirmation failed: {:?}", e);
+            sgx_status_t::SGX_ERROR_UNEXPECTED
+        }
+    }
+}

--- a/worker/src/ocall_bridge/ffi/worker_request.rs
+++ b/worker/src/ocall_bridge/ffi/worker_request.rs
@@ -1,0 +1,61 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::ocall_bridge::bridge_api::{Bridge, WorkerOnChainBridge};
+use crate::utils::write_slice_and_whitespace_pad;
+use log::*;
+use sgx_types::sgx_status_t;
+use std::slice;
+use std::sync::Arc;
+use std::vec::Vec;
+
+/// # Safety
+///
+/// FFI are always unsafe
+#[no_mangle]
+pub unsafe extern "C" fn ocall_worker_request(
+    request: *const u8,
+    req_size: u32,
+    response: *mut u8,
+    resp_size: u32,
+) -> sgx_status_t {
+    worker_request(request, req_size, response, resp_size, Bridge::get_oc_api())
+}
+
+fn worker_request(
+    request: *const u8,
+    req_size: u32,
+    response: *mut u8,
+    resp_size: u32,
+    oc_api: Arc<dyn WorkerOnChainBridge>,
+) -> sgx_status_t {
+    let request_vec: Vec<u8> =
+        unsafe { Vec::from(slice::from_raw_parts(request, req_size as usize)) };
+
+    match oc_api.worker_request(request_vec) {
+        Ok(r) => {
+            let resp_slice = unsafe { slice::from_raw_parts_mut(response, resp_size as usize) };
+            write_slice_and_whitespace_pad(resp_slice, r);
+            sgx_status_t::SGX_SUCCESS
+        }
+        Err(e) => {
+            error!("Worker request failed: {:?}", e);
+            sgx_status_t::SGX_ERROR_UNEXPECTED
+        }
+    }
+}

--- a/worker/src/ocall_bridge/remote_attestation_ocall.rs
+++ b/worker/src/ocall_bridge/remote_attestation_ocall.rs
@@ -17,7 +17,7 @@
 */
 
 use crate::ocall_bridge::bridge_api::{
-    OCallBridgeError, OCallBridgeResult, RemoteAttestationOCall,
+    OCallBridgeError, OCallBridgeResult, RemoteAttestationBridge,
 };
 use frame_support::ensure;
 use log::*;
@@ -26,11 +26,11 @@ use std::net::{SocketAddr, TcpStream};
 use std::os::unix::io::IntoRawFd;
 use std::ptr;
 
-pub struct RemoteAttestationOCallImpl {
+pub struct RemoteAttestationOCall {
     // TODO as a member here we need the e-call API trait, so we can use it instead of making the e-call directly
 }
 
-impl RemoteAttestationOCall for RemoteAttestationOCallImpl {
+impl RemoteAttestationBridge for RemoteAttestationOCall {
     fn init_quote(&self) -> OCallBridgeResult<(sgx_target_info_t, sgx_epid_group_id_t)> {
         // TODO this translation to unsafe C-API should be moved to the EnclaveApi / ECall API
         let mut ti: sgx_target_info_t = sgx_target_info_t::default();

--- a/worker/src/ocall_bridge/worker_on_chain_ocall.rs
+++ b/worker/src/ocall_bridge/worker_on_chain_ocall.rs
@@ -1,0 +1,170 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::node_api_factory::CreateNodeApi;
+use crate::ocall_bridge::bridge_api::{OCallBridgeError, OCallBridgeResult, WorkerOnChainBridge};
+use crate::sync_block_gossiper::GossipBlocks;
+use crate::utils::hex_encode;
+use crate::{WorkerRequest, WorkerResponse};
+use codec::{Decode, Encode};
+use log::*;
+use sp_core::storage::StorageKey;
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+use std::vec::Vec;
+use substrate_api_client::XtStatus;
+use substratee_worker_primitives::block::SignedBlock as SignedSidechainBlock;
+
+pub struct WorkerOnChainOCall<F, S> {
+    node_api_factory: Arc<F>,
+    block_gossiper: Arc<S>,
+}
+
+impl<F, S> WorkerOnChainOCall<F, S> {
+    pub fn new(node_api_factory: Arc<F>, block_gossiper: Arc<S>) -> Self {
+        WorkerOnChainOCall {
+            node_api_factory,
+            block_gossiper,
+        }
+    }
+}
+
+impl<F, S> WorkerOnChainBridge for WorkerOnChainOCall<F, S>
+where
+    F: CreateNodeApi,
+    S: GossipBlocks,
+{
+    fn worker_request(&self, request: Vec<u8>) -> OCallBridgeResult<Vec<u8>> {
+        debug!("    Entering ocall_worker_request");
+
+        let requests: Vec<WorkerRequest> = Decode::decode(&mut request.as_slice()).unwrap();
+        if requests.is_empty() {
+            debug!("requests is empty, returning empty vector");
+            return Ok(Vec::<u8>::new().encode());
+        }
+
+        let api = self.node_api_factory.create_api();
+
+        let resp: Vec<WorkerResponse<Vec<u8>>> = requests
+            .into_iter()
+            .map(|req| match req {
+                WorkerRequest::ChainStorage(key, hash) => WorkerResponse::ChainStorage(
+                    key.clone(),
+                    api.get_opaque_storage_by_key_hash(StorageKey(key.clone()), hash)
+                        .unwrap(),
+                    api.get_storage_proof_by_keys(vec![StorageKey(key)], hash)
+                        .unwrap()
+                        .map(|read_proof| {
+                            read_proof.proof.into_iter().map(|bytes| bytes.0).collect()
+                        }),
+                ),
+            })
+            .collect();
+
+        let encoded_response: Vec<u8> = resp.encode();
+
+        Ok(encoded_response)
+    }
+
+    fn send_block_and_confirmation(
+        &self,
+        confirmations: Vec<u8>,
+        signed_blocks: Vec<u8>,
+    ) -> OCallBridgeResult<()> {
+        debug!("    Entering ocall_send_block_and_confirmation");
+
+        // TODO: improve error handling, using a mut status is not good design?
+        let mut status: OCallBridgeResult<()> = Ok(());
+        let api = self.node_api_factory.create_api();
+
+        // send confirmations to layer one
+        let confirmation_calls: Vec<Vec<u8>> = match Decode::decode(&mut confirmations.as_slice()) {
+            Ok(calls) => calls,
+            Err(_) => {
+                status = Err(OCallBridgeError::SendBlockAndConfirmation(
+                    "Could not decode confirmation calls".to_string(),
+                ));
+                vec![vec![]]
+            }
+        };
+
+        if !confirmation_calls.is_empty() {
+            println!(
+                "Enclave wants to send {} extrinsics",
+                confirmation_calls.len()
+            );
+            for call in confirmation_calls.into_iter() {
+                api.send_extrinsic(hex_encode(call), XtStatus::Ready)
+                    .unwrap();
+            }
+            // await next block to avoid #37
+            let (events_in, events_out) = channel();
+            api.subscribe_events(events_in).unwrap();
+            let _ = events_out.recv().unwrap();
+            let _ = events_out.recv().unwrap();
+            // FIXME: we should unsubscribe here or the thread will throw a SendError because the channel is destroyed
+        }
+
+        // handle blocks
+        let signed_blocks: Vec<SignedSidechainBlock> =
+            match Decode::decode(&mut signed_blocks.as_slice()) {
+                Ok(blocks) => blocks,
+                Err(_) => {
+                    status = Err(OCallBridgeError::SendBlockAndConfirmation(
+                        "Could not decode confirmation calls".to_string(),
+                    ));
+                    vec![]
+                }
+            };
+
+        println! {"Received blocks: {:?}", signed_blocks};
+
+        if let Err(e) = self.block_gossiper.gossip_blocks(signed_blocks) {
+            error!("Error gossiping blocks: {:?}", e);
+            // Fixme: returning an error here results in a `HeaderAncestryMismatch` error.
+            // status = sgx_status_t::SGX_ERROR_UNEXPECTED;
+        }
+        // TODO: M8.3: Store blocks
+
+        status
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::node_api_factory::MockCreateNodeApi;
+    use crate::sync_block_gossiper::MockGossipBlocks;
+
+    #[test]
+    fn given_empty_worker_request_when_submitting_then_return_empty_response() {
+        let mock_node_api_factory = Arc::new(MockCreateNodeApi::new());
+        let mock_block_gossiper = Arc::new(MockGossipBlocks::new());
+
+        let on_chain_ocall = WorkerOnChainOCall::new(mock_node_api_factory, mock_block_gossiper);
+
+        let response = on_chain_ocall
+            .worker_request(Vec::<u8>::new().encode())
+            .unwrap();
+
+        assert!(!response.is_empty()); // the encoded empty vector is not empty
+        let decoded_response: Vec<u8> = Decode::decode(&mut response.as_slice()).unwrap();
+        assert!(decoded_response.is_empty()); // decode the response, and we get an empty vector again
+    }
+}

--- a/worker/src/sync_block_gossiper.rs
+++ b/worker/src/sync_block_gossiper.rs
@@ -1,0 +1,69 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::error::Error;
+use crate::globals::tokio_handle::GetTokioHandle;
+use crate::globals::worker::GetWorker;
+use crate::worker::{WorkerResult, WorkerT};
+use log::*;
+use std::sync::Arc;
+use substratee_worker_primitives::block::SignedBlock as SignedSidechainBlock;
+
+#[cfg(test)]
+use mockall::predicate::*;
+#[cfg(test)]
+use mockall::*;
+
+/// Allows to gossip blocks, does it in a synchronous (i.e. blocking) manner
+#[cfg_attr(test, automock)]
+pub trait GossipBlocks {
+    fn gossip_blocks(&self, blocks: Vec<SignedSidechainBlock>) -> WorkerResult<()>;
+}
+
+pub struct SyncBlockGossiper<T, W> {
+    tokio_handle: Arc<T>,
+    worker: Arc<W>,
+}
+
+impl<T, W> SyncBlockGossiper<T, W> {
+    pub fn new(tokio_handle: Arc<T>, worker: Arc<W>) -> Self {
+        SyncBlockGossiper {
+            tokio_handle,
+            worker,
+        }
+    }
+}
+
+impl<T, W> GossipBlocks for SyncBlockGossiper<T, W>
+where
+    T: GetTokioHandle,
+    W: GetWorker,
+{
+    fn gossip_blocks(&self, blocks: Vec<SignedSidechainBlock>) -> WorkerResult<()> {
+        match self.worker.get_worker().as_ref() {
+            Some(w) => {
+                let handle = self.tokio_handle.get_handle();
+                handle.block_on(w.gossip_blocks(blocks))
+            }
+            None => {
+                error!("Failed to get worker instance");
+                Err(Error::ApplicationSetupError)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is based on #293 - draft review for now

Refactor the abstractions for the onchain ocalls. This required some additional refactoring of our global variables in the main file (see https://github.com/integritee-network/worker/blob/344b53796636868c96430fbbc6dfdccbc00d3af0/worker/src/main.rs#L91-L96 ). Access to these is now wrapped in separate `Accessor` traits. These can be injected and so the nature of the global variables can be hidden.

This now started building the object dependency tree, that we initialize upon application startup and then distribute to wherever it is needed. Unfortunately, because of the nature of the ocalls (and because we can't pass all of the state into the enclave), we still need that global state outside the enclave.

A diagram of this refactoring:

![ocall_onchain_refactoring](https://user-images.githubusercontent.com/9334190/124778657-6a0c6e80-df41-11eb-88dc-da5cae7120e7.png)

