### PR TITLE
remove dyn keyword showcase

### DIFF
--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -672,3 +672,11 @@ pub enum WorkerRequest {
 pub enum WorkerResponse<V: Encode + Decode> {
     ChainStorage(Vec<u8>, Option<V>, Option<Vec<Vec<u8>>>), // (storage_key, storage_value, storage_proof)
 }
+
+#[no_mangle]
+pub extern "C" fn ocall_sgx_init_quote(
+    ret_ti: *mut sgx_target_info_t,
+    ret_gid: *mut sgx_epid_group_id_t,
+) -> sgx_status_t {
+    ocall_bridge::ffi::init_quote::sgx_init_quote(ret_ti, ret_gid, OCallBridge::get_ra_api())
+}

--- a/worker/src/ocall_bridge/ffi/init_quote.rs
+++ b/worker/src/ocall_bridge/ffi/init_quote.rs
@@ -21,15 +21,15 @@ use log::*;
 use sgx_types::{sgx_epid_group_id_t, sgx_status_t, sgx_target_info_t};
 use std::sync::Arc;
 
-#[no_mangle]
-pub extern "C" fn ocall_sgx_init_quote(
-    ret_ti: *mut sgx_target_info_t,
-    ret_gid: *mut sgx_epid_group_id_t,
-) -> sgx_status_t {
-    sgx_init_quote(ret_ti, ret_gid, Bridge::get_ra_api()) // inject the RA API (global state)
-}
+// #[no_mangle]
+// pub extern "C" fn ocall_sgx_init_quote(
+//     ret_ti: *mut sgx_target_info_t,
+//     ret_gid: *mut sgx_epid_group_id_t,
+// ) -> sgx_status_t {
+//     sgx_init_quote(ret_ti, ret_gid, Bridge::get_ra_api()) // inject the RA API (global state)
+// }
 
-fn sgx_init_quote(
+pub(crate) fn sgx_init_quote(
     ret_ti: *mut sgx_target_info_t,
     ret_gid: *mut sgx_epid_group_id_t,
     ra_api: Arc<dyn RemoteAttestationOCall>,

--- a/worker/src/ocall_bridge/mod.rs
+++ b/worker/src/ocall_bridge/mod.rs
@@ -20,5 +20,5 @@ pub mod bridge_api;
 pub mod component_factory;
 
 mod attestation_ocall_impl;
-mod ffi;
+pub mod ffi;
 mod on_chain_ocall_impl;


### PR DESCRIPTION
For a tiny overhead in the main file, we can get rid of the dyn keyword.