### PR TITLE
[enclave] increase TCSNUM to 8

### DIFF
--- a/enclave/Enclave.config.production.xml
+++ b/enclave/Enclave.config.production.xml
@@ -4,7 +4,7 @@
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
   <HeapMaxSize>0x20000000</HeapMaxSize>
-  <TCSNum>4</TCSNum>
+  <TCSNum>8</TCSNum>
   <TCSPolicy>0</TCSPolicy> <!-- 0 = Thread Control Structure (TCS) is bound to the untrusted thread -->
   <DisableDebug>1</DisableDebug>
   <MiscSelect>0</MiscSelect>

--- a/enclave/Enclave.config.xml
+++ b/enclave/Enclave.config.xml
@@ -4,7 +4,7 @@
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
   <HeapMaxSize>0x20000000</HeapMaxSize>
-  <TCSNum>4</TCSNum>
+  <TCSNum>8</TCSNum>
   <TCSPolicy>0</TCSPolicy> <!-- 0 = Thread Control Structure (TCS) is bound to the untrusted thread -->
   <DisableDebug>0</DisableDebug>
   <MiscSelect>0</MiscSelect>


### PR DESCRIPTION
This increases the amount of trusted threads that can be launched, and should fix the jenkins CI.

I do this now, as I don't exactly know, how long it takes to finish GitHub actions CI.

When jenkins is happy again, we can start merging all the PRs.

Closes: #304
