### PR TITLE
Add Ipfs Ocall API and impl to the ocall bridge

### DIFF
--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -69,7 +69,6 @@ mod config;
 mod enclave;
 mod error;
 mod globals;
-mod ipfs;
 mod node_api_factory;
 mod ocall_bridge;
 mod sync_block_gossiper;

--- a/worker/src/ocall_bridge/component_factory.rs
+++ b/worker/src/ocall_bridge/component_factory.rs
@@ -17,21 +17,14 @@
 */
 
 use crate::node_api_factory::CreateNodeApi;
-use crate::ocall_bridge::bridge_api::{RemoteAttestationBridge, WorkerOnChainBridge};
+use crate::ocall_bridge::bridge_api::{
+    GetOCallBridgeComponents, IpfsBridge, RemoteAttestationBridge, WorkerOnChainBridge,
+};
+use crate::ocall_bridge::ipfs_ocall::IpfsOCall;
 use crate::ocall_bridge::remote_attestation_ocall::RemoteAttestationOCall;
 use crate::ocall_bridge::worker_on_chain_ocall::WorkerOnChainOCall;
 use crate::sync_block_gossiper::GossipBlocks;
 use std::sync::Arc;
-
-/// Factory trait (abstract factory) that creates instances
-/// of all the components of the OCall Bridge
-pub trait GetOCallBridgeComponents {
-    /// remote attestation OCall API
-    fn get_ra_api(&self) -> Arc<dyn RemoteAttestationBridge>;
-
-    /// on chain OCall API
-    fn get_oc_api(&self) -> Arc<dyn WorkerOnChainBridge>;
-}
 
 /// Concrete implementation, should be moved out of the OCall Bridge, into the worker
 /// since the OCall bridge itself should not know any concrete types to ensure
@@ -64,5 +57,9 @@ where
             self.node_api_factory.clone(),
             self.block_gossiper.clone(),
         ))
+    }
+
+    fn get_ipfs_api(&self) -> Arc<dyn IpfsBridge> {
+        Arc::new(IpfsOCall {})
     }
 }

--- a/worker/src/ocall_bridge/ffi/ipfs.rs
+++ b/worker/src/ocall_bridge/ffi/ipfs.rs
@@ -1,0 +1,84 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::ocall_bridge::bridge_api::IpfsBridge;
+use crate::ocall_bridge::bridge_api::{Bridge, Cid};
+use log::*;
+use sgx_types::sgx_status_t;
+use std::slice;
+use std::sync::Arc;
+
+/// C-API exposed for o-call from enclave
+#[no_mangle]
+pub unsafe extern "C" fn ocall_write_ipfs(
+    enc_state: *const u8,
+    enc_state_size: u32,
+    cid: *mut u8,
+    cid_size: u32,
+) -> sgx_status_t {
+    write_ipfs(
+        enc_state,
+        enc_state_size,
+        cid,
+        cid_size,
+        Bridge::get_ipfs_api(),
+    )
+}
+
+/// C-API exposed for o-call from enclave
+#[no_mangle]
+pub unsafe extern "C" fn ocall_read_ipfs(cid: *const u8, cid_size: u32) -> sgx_status_t {
+    read_ipfs(cid, cid_size, Bridge::get_ipfs_api())
+}
+
+fn write_ipfs(
+    enc_state: *const u8,
+    enc_state_size: u32,
+    cid: *mut u8,
+    cid_size: u32,
+    ipfs_api: Arc<dyn IpfsBridge>,
+) -> sgx_status_t {
+    let state = unsafe { slice::from_raw_parts(enc_state, enc_state_size as usize) };
+    let cid = unsafe { slice::from_raw_parts_mut(cid, cid_size as usize) };
+
+    return match ipfs_api.write_to_ipfs(state) {
+        Ok(r) => {
+            cid.clone_from_slice(&r);
+            sgx_status_t::SGX_SUCCESS
+        }
+        Err(e) => {
+            error!("OCall to write_ipfs failed: {:?}", e);
+            sgx_status_t::SGX_ERROR_UNEXPECTED
+        }
+    };
+}
+
+fn read_ipfs(cid: *const u8, cid_size: u32, ipfs_api: Arc<dyn IpfsBridge>) -> sgx_status_t {
+    let _cid = unsafe { slice::from_raw_parts(cid, cid_size as usize) };
+
+    let mut cid: Cid = [0; 46];
+    cid.clone_from_slice(_cid);
+
+    match ipfs_api.read_from_ipfs(cid) {
+        Ok(_) => sgx_status_t::SGX_SUCCESS,
+        Err(e) => {
+            error!("OCall to read_ipfs failed: {:?}", e);
+            sgx_status_t::SGX_ERROR_UNEXPECTED
+        }
+    }
+}

--- a/worker/src/ocall_bridge/ffi/mod.rs
+++ b/worker/src/ocall_bridge/ffi/mod.rs
@@ -24,5 +24,6 @@ pub mod get_ias_socket;
 pub mod get_quote;
 pub mod get_update_info;
 pub mod init_quote;
+pub mod ipfs;
 pub mod send_block_and_confirmation;
 pub mod worker_request;

--- a/worker/src/ocall_bridge/mod.rs
+++ b/worker/src/ocall_bridge/mod.rs
@@ -20,5 +20,6 @@ pub mod bridge_api;
 pub mod component_factory;
 
 mod ffi;
+mod ipfs_ocall;
 mod remote_attestation_ocall;
 mod worker_on_chain_ocall;

--- a/worker/src/ocall_bridge/worker_on_chain_ocall.rs
+++ b/worker/src/ocall_bridge/worker_on_chain_ocall.rs
@@ -126,7 +126,7 @@ where
                 Ok(blocks) => blocks,
                 Err(_) => {
                     status = Err(OCallBridgeError::SendBlockAndConfirmation(
-                        "Could not decode confirmation calls".to_string(),
+                        "Could not decode signed blocks".to_string(),
                     ));
                     vec![]
                 }


### PR DESCRIPTION
Add the IPFS o-calls to the OCallBridge. Quite a 'small' change set, following the same pattern as we have seen and discussed in #299.

Only a draft PR, since this has to be rebased and retargeted to master, once #299 is merged

- [x] Merge #299 
- [x] Re-target this PR to master
- [x] Rebase this branch onto master and merge