### PR TITLE
Fully abstract and implement the EnclaveApi, (i.e. E-Call API)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5624,10 +5624,18 @@ name = "substratee-enclave-api"
 version = "0.8.0"
 dependencies = [
  "frame-support",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall",
  "parity-scale-codec 2.1.3",
+ "serde_json",
+ "sgx_crypto_helper",
  "sgx_types",
+ "sgx_urts",
+ "sp-core",
+ "sp-finality-grandpa",
+ "sp-runtime",
  "substratee-enclave-api-ffi",
+ "substratee-settings",
  "thiserror",
 ]
 

--- a/primitives/enclave-api/Cargo.toml
+++ b/primitives/enclave-api/Cargo.toml
@@ -5,14 +5,23 @@ authors = ["clangenbacher <christian.langenbacher@scs.ch>"]
 edition = "2018"
 
 [dependencies]
-thiserror = "1.0.25"
-codec = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
+thiserror   = "1.0.25"
+log 	    = "0.4"
+serde_json 	= "1.0"
+codec       = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types           = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_urts            = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper 	= { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
-frame-support = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
+frame-support       = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-core             = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-finality-grandpa = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sp-runtime          = { version = "3.0.0", git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
-substratee-enclave-api-ffi = { path = "ffi" }
+substratee-enclave-api-ffi  = { path = "ffi" }
+substratee-settings         = { path = "../settings" }
+
 
 [dev-dependencies]
 mockall = { version = "0.10.1" }

--- a/primitives/enclave-api/ffi/Cargo.toml
+++ b/primitives/enclave-api/ffi/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types   = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }

--- a/primitives/enclave-api/ffi/build.rs
+++ b/primitives/enclave-api/ffi/build.rs
@@ -1,0 +1,42 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use std::env;
+
+fn main() {
+    let sdk_dir = env::var("SGX_SDK").unwrap_or_else(|_| "/opt/intel/sgxsdk".to_string());
+    let is_sim = env::var("SGX_MODE").unwrap_or_else(|_| "HW".to_string());
+
+    // NOTE: if the crate is a workspace member rustc-paths are relative from the root directory
+    println!("cargo:rustc-link-search=native=./lib");
+    println!("cargo:rustc-link-lib=static=Enclave_u");
+
+    println!("cargo:rustc-link-search=native={}/lib64", sdk_dir);
+    println!("cargo:rustc-link-lib=static=sgx_uprotected_fs");
+    match is_sim.as_ref() {
+        "SW" => {
+            println!("cargo:rustc-link-lib=dylib=sgx_urts_sim");
+            println!("cargo:rustc-link-lib=dylib=sgx_uae_service_sim");
+        }
+        _ => {
+            // HW by default
+            println!("cargo:rustc-link-lib=dylib=sgx_urts");
+            println!("cargo:rustc-link-lib=dylib=sgx_uae_service");
+        }
+    }
+}

--- a/primitives/enclave-api/ffi/src/lib.rs
+++ b/primitives/enclave-api/ffi/src/lib.rs
@@ -1,27 +1,116 @@
 ///! FFI's that call into the enclave. These functions need to be added to the
 /// enclave edl file and be implemented within the enclave.
-
-use sgx_types::{sgx_enclave_id_t, sgx_status_t};
+use sgx_types::{c_int, sgx_enclave_id_t, sgx_quote_sign_type_t, sgx_status_t};
 
 extern "C" {
-	pub fn call_rpc_methods(
-		eid: sgx_enclave_id_t,
-		retval: *mut sgx_status_t,
-		request: *const u8,
-		request_len: u32,
-		response: *mut u8,
-		response_len: u32,
-	) -> sgx_status_t;
 
-	pub fn mock_register_enclave_xt(
-		eid: sgx_enclave_id_t,
-		retval: *mut sgx_status_t,
-		genesis_hash: *const u8,
-		genesis_hash_size: u32,
-		nonce: *const u32,
-		w_url: *const u8,
-		w_url_size: u32,
-		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
-	) -> sgx_status_t;
+    pub fn init(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+
+    pub fn get_state(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        cyphertext: *const u8,
+        cyphertext_size: u32,
+        shard: *const u8,
+        shard_size: u32,
+        value: *mut u8,
+        value_size: u32,
+    ) -> sgx_status_t;
+
+    pub fn init_chain_relay(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        genesis_hash: *const u8,
+        genesis_hash_size: usize,
+        authority_list: *const u8,
+        authority_list_size: usize,
+        authority_proof: *const u8,
+        authority_proof_size: usize,
+        latest_header: *mut u8,
+        latest_header_size: usize,
+    ) -> sgx_status_t;
+
+    pub fn produce_blocks(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        blocks: *const u8,
+        blocks_size: usize,
+        nonce: *const u32,
+    ) -> sgx_status_t;
+
+    pub fn get_rsa_encryption_pubkey(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        pubkey: *mut u8,
+        pubkey_size: u32,
+    ) -> sgx_status_t;
+
+    pub fn get_ecc_signing_pubkey(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        pubkey: *mut u8,
+        pubkey_size: u32,
+    ) -> sgx_status_t;
+
+    pub fn get_mrenclave(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        mrenclave: *mut u8,
+        mrenclave_size: u32,
+    ) -> sgx_status_t;
+
+    pub fn perform_ra(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        genesis_hash: *const u8,
+        genesis_hash_size: u32,
+        nonce: *const u32,
+        w_url: *const u8,
+        w_url_size: u32,
+        unchecked_extrinsic: *mut u8,
+        unchecked_extrinsic_size: u32,
+    ) -> sgx_status_t;
+
+    pub fn dump_ra_to_disk(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+
+    pub fn test_main_entrance(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+
+    pub fn call_rpc_methods(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        request: *const u8,
+        request_len: u32,
+        response: *mut u8,
+        response_len: u32,
+    ) -> sgx_status_t;
+
+    pub fn mock_register_enclave_xt(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        genesis_hash: *const u8,
+        genesis_hash_size: u32,
+        nonce: *const u32,
+        w_url: *const u8,
+        w_url_size: u32,
+        unchecked_extrinsic: *mut u8,
+        unchecked_extrinsic_size: u32,
+    ) -> sgx_status_t;
+
+    pub fn run_key_provisioning_server(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        socket_fd: c_int,
+        sign_type: sgx_quote_sign_type_t,
+        skip_ra: c_int,
+    ) -> sgx_status_t;
+
+    pub fn request_key_provisioning(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        socket_fd: c_int,
+        sign_type: sgx_quote_sign_type_t,
+        skip_ra: c_int,
+    ) -> sgx_status_t;
+
+    pub fn initialize_pool(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
 }

--- a/primitives/enclave-api/src/direct_request.rs
+++ b/primitives/enclave-api/src/direct_request.rs
@@ -1,0 +1,66 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::error::Error;
+use crate::{Enclave, EnclaveResult};
+use frame_support::ensure;
+use sgx_types::sgx_status_t;
+use substratee_enclave_api_ffi as ffi;
+
+pub trait DirectRequest: Send + Sync + 'static {
+    // Todo: Vec<u8> shall be replaced by D: Decode, E: Encode but this is currently
+    // not compatible with the direct_api_server...
+    fn rpc(&self, request: Vec<u8>) -> EnclaveResult<Vec<u8>>;
+
+    fn initialize_pool(&self) -> EnclaveResult<()>;
+}
+
+impl DirectRequest for Enclave {
+    fn rpc(&self, request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+        let response_len = 8192;
+        let mut response: Vec<u8> = vec![0u8; response_len as usize];
+
+        let res = unsafe {
+            ffi::call_rpc_methods(
+                self.eid,
+                &mut retval,
+                request.as_ptr(),
+                request.len() as u32,
+                response.as_mut_ptr(),
+                response_len,
+            )
+        };
+
+        ensure!(res == sgx_status_t::SGX_SUCCESS, Error::Sgx(res));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(response)
+    }
+
+    fn initialize_pool(&self) -> EnclaveResult<()> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let result = unsafe { ffi::initialize_pool(self.eid, &mut retval) };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(())
+    }
+}

--- a/primitives/enclave-api/src/enclave_base.rs
+++ b/primitives/enclave-api/src/enclave_base.rs
@@ -1,0 +1,211 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::error::Error;
+use crate::{Enclave, EnclaveResult};
+use codec::{Decode, Encode};
+use frame_support::ensure;
+use log::*;
+use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
+use sgx_types::*;
+use sp_core::ed25519;
+use sp_finality_grandpa::VersionedAuthorityList;
+use sp_runtime::traits::Header;
+use substratee_enclave_api_ffi as ffi;
+use substratee_settings::worker::{
+    HEADER_MAX_SIZE, MR_ENCLAVE_SIZE, SHIELDING_KEY_SIZE, SIGNING_KEY_SIZE, STATE_VALUE_MAX_SIZE,
+};
+
+/// Trait for base/common Enclave API functions
+pub trait EnclaveBase: Send + Sync + 'static {
+    /// initialize the enclave (needs to be called once at application startup)
+    fn init(&self) -> EnclaveResult<()>;
+
+    /// initialize the chain relay (needs to be called once at application startup)
+    fn init_chain_relay<SpHeader: Header>(
+        &self,
+        genesis_header: SpHeader,
+        authority_list: VersionedAuthorityList,
+        authority_proof: Vec<Vec<u8>>,
+    ) -> EnclaveResult<SpHeader>;
+
+    fn get_state(&self, cyphertext: Vec<u8>, shard: Vec<u8>) -> EnclaveResult<Vec<u8>>;
+
+    fn get_rsa_shielding_pubkey(&self) -> EnclaveResult<Rsa3072PubKey>;
+
+    fn get_ecc_signing_pubkey(&self) -> EnclaveResult<ed25519::Public>;
+
+    fn get_mrenclave(&self) -> EnclaveResult<[u8; MR_ENCLAVE_SIZE]>;
+}
+
+/// EnclaveApi implementation for Enclave struct
+impl EnclaveBase for Enclave {
+    fn init(&self) -> EnclaveResult<()> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let result = unsafe { ffi::init(self.eid, &mut retval) };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(())
+    }
+
+    fn init_chain_relay<SpHeader: Header>(
+        &self,
+        genesis_header: SpHeader,
+        authority_list: VersionedAuthorityList,
+        authority_proof: Vec<Vec<u8>>,
+    ) -> EnclaveResult<SpHeader> {
+        let encoded_genesis_header = genesis_header.encode();
+        let authority_proof_encoded = authority_proof.encode();
+
+        // Todo: this is a bit ugly but the common `encode()` is not implemented for authority list
+        let latest_header_encoded = authority_list.using_encoded(|authorities| {
+            init_chain_relay_ffi(
+                self.eid,
+                authorities.to_vec(),
+                encoded_genesis_header,
+                authority_proof_encoded,
+            )
+        })?;
+
+        let latest: SpHeader = Decode::decode(&mut latest_header_encoded.as_slice()).unwrap();
+        info!("Latest Header {:?}", latest);
+
+        Ok(latest)
+    }
+
+    fn get_state(&self, cyphertext: Vec<u8>, shard: Vec<u8>) -> EnclaveResult<Vec<u8>> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let value_size = STATE_VALUE_MAX_SIZE;
+        let mut value = vec![0u8; value_size as usize];
+
+        let result = unsafe {
+            ffi::get_state(
+                self.eid,
+                &mut retval,
+                cyphertext.as_ptr(),
+                cyphertext.len() as u32,
+                shard.as_ptr(),
+                shard.len() as u32,
+                value.as_mut_ptr(),
+                value.len() as u32,
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(value)
+    }
+
+    fn get_rsa_shielding_pubkey(&self) -> EnclaveResult<Rsa3072PubKey> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let pubkey_size = SHIELDING_KEY_SIZE;
+        let mut pubkey = vec![0u8; pubkey_size as usize];
+
+        let result = unsafe {
+            ffi::get_rsa_encryption_pubkey(
+                self.eid,
+                &mut retval,
+                pubkey.as_mut_ptr(),
+                pubkey.len() as u32,
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        let rsa_pubkey: Rsa3072PubKey = serde_json::from_slice(pubkey.as_slice()).unwrap();
+        debug!("got RSA pubkey {:?}", rsa_pubkey);
+        Ok(rsa_pubkey)
+    }
+
+    fn get_ecc_signing_pubkey(&self) -> EnclaveResult<ed25519::Public> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+        let mut pubkey = [0u8; SIGNING_KEY_SIZE as usize];
+
+        let result = unsafe {
+            ffi::get_ecc_signing_pubkey(
+                self.eid,
+                &mut retval,
+                pubkey.as_mut_ptr(),
+                pubkey.len() as u32,
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(ed25519::Public::from_raw(pubkey))
+    }
+
+    fn get_mrenclave(&self) -> EnclaveResult<[u8; MR_ENCLAVE_SIZE]> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+        let mut mr_enclave = [0u8; MR_ENCLAVE_SIZE as usize];
+
+        let result = unsafe {
+            ffi::get_mrenclave(
+                self.eid,
+                &mut retval,
+                mr_enclave.as_mut_ptr(),
+                mr_enclave.len() as u32,
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(mr_enclave)
+    }
+}
+
+fn init_chain_relay_ffi(
+    enclave_id: sgx_enclave_id_t,
+    authorities_vec: Vec<u8>,
+    encoded_genesis_header: Vec<u8>,
+    authority_proof_encoded: Vec<u8>,
+) -> EnclaveResult<Vec<u8>> {
+    let mut retval = sgx_status_t::SGX_SUCCESS;
+
+    let latest_header_size = HEADER_MAX_SIZE;
+    let mut latest_header = vec![0u8; latest_header_size as usize];
+
+    let result = unsafe {
+        ffi::init_chain_relay(
+            enclave_id,
+            &mut retval,
+            encoded_genesis_header.as_ptr(),
+            encoded_genesis_header.len(),
+            authorities_vec.as_ptr(),
+            authorities_vec.len(),
+            authority_proof_encoded.as_ptr(),
+            authority_proof_encoded.len(),
+            latest_header.as_mut_ptr(),
+            latest_header.len(),
+        )
+    };
+
+    ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+    ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+    Ok(latest_header)
+}

--- a/primitives/enclave-api/src/enclave_test.rs
+++ b/primitives/enclave-api/src/enclave_test.rs
@@ -1,0 +1,43 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::error::Error;
+use crate::{Enclave, EnclaveResult};
+use frame_support::ensure;
+use log::*;
+use sgx_types::sgx_status_t;
+use substratee_enclave_api_ffi as ffi;
+
+pub trait EnclaveTest: Send + Sync + 'static {
+    fn test_main_entrance(&self) -> EnclaveResult<()>;
+}
+
+impl EnclaveTest for Enclave {
+    fn test_main_entrance(&self) -> EnclaveResult<()> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let result = unsafe { ffi::test_main_entrance(self.eid, &mut retval) };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        debug!("[+] successfully executed enclave test main");
+
+        Ok(())
+    }
+}

--- a/primitives/enclave-api/src/error.rs
+++ b/primitives/enclave-api/src/error.rs
@@ -1,11 +1,12 @@
-use codec::{Error as CodecError};
+use codec::Error as CodecError;
 use sgx_types::sgx_status_t;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("{0}")]
-	Codec(#[from] CodecError),
-	#[error("Enclave Error: {0}")]
-	Sgx(sgx_status_t)
+    #[error("{0}")]
+    Codec(#[from] CodecError),
+    #[error("Enclave Error: {0}")]
+    Sgx(sgx_status_t),
+    #[error("Error, other: {0}")]
+    Other(Box<dyn std::error::Error + Sync + Send>),
 }
-

--- a/primitives/enclave-api/src/lib.rs
+++ b/primitives/enclave-api/src/lib.rs
@@ -12,101 +12,36 @@
 //! ffi function.
 //!
 
-use frame_support::ensure;
-use sgx_types::{sgx_enclave_id_t, sgx_status_t};
-
 use crate::error::Error;
-use codec::Encode;
-use frame_support::sp_runtime::app_crypto::sp_core::H256;
+use sgx_types::*;
+use sgx_urts::SgxEnclave;
 
-use substratee_enclave_api_ffi as ffi;
-
+pub mod direct_request;
+pub mod enclave_base;
+pub mod enclave_test;
 pub mod error;
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct Enclave {
-    eid: sgx_enclave_id_t,
-}
-
-impl Enclave {
-    pub fn new(eid: sgx_enclave_id_t) -> Self {
-        Enclave { eid }
-    }
-}
+pub mod remote_attestation;
+pub mod side_chain;
+pub mod teerex_api;
+pub mod utils;
 
 pub type EnclaveResult<T> = Result<T, Error>;
 
-pub trait EnclaveApi: Send + Sync + 'static {
-    // Todo: Vec<u8> shall be replaced by D: Decode, E: Encode but this is currently
-    // not compatible with the direct_api_server...
-    fn rpc(&self, request: Vec<u8>) -> EnclaveResult<Vec<u8>>;
+#[derive(Clone, Debug, Default)]
+pub struct Enclave {
+    eid: sgx_enclave_id_t,
+    sgx_enclave: SgxEnclave,
 }
 
-pub trait TeeRexApi: Send + Sync + 'static {
-    /// Register enclave xt with an empty attestation report.
-    fn mock_register_xt(
-        &self,
-        genesis_hash: H256,
-        nonce: u32,
-        w_url: &str,
-    ) -> EnclaveResult<Vec<u8>>;
-}
-
-impl EnclaveApi for Enclave {
-    fn rpc(&self, request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
-        let mut retval = sgx_status_t::SGX_SUCCESS;
-        let response_len = 8192;
-        let mut response: Vec<u8> = vec![0u8; response_len as usize];
-
-        let res = unsafe {
-            ffi::call_rpc_methods(
-                self.eid,
-                &mut retval,
-                request.as_ptr(),
-                request.len() as u32,
-                response.as_mut_ptr(),
-                response_len,
-            )
-        };
-
-        ensure!(res == sgx_status_t::SGX_SUCCESS, Error::Sgx(res));
-        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
-        Ok(response)
+impl Enclave {
+    pub fn new(sgx_enclave: SgxEnclave) -> Self {
+        Enclave {
+            eid: sgx_enclave.geteid(),
+            sgx_enclave,
+        }
     }
-}
 
-impl TeeRexApi for Enclave {
-    fn mock_register_xt(
-        &self,
-        genesis_hash: H256,
-        nonce: u32,
-        w_url: &str,
-    ) -> EnclaveResult<Vec<u8>> {
-        let mut retval = sgx_status_t::SGX_SUCCESS;
-        let response_len = 8192;
-        let mut response: Vec<u8> = vec![0u8; response_len as usize];
-
-        let url = w_url.encode();
-        let gen = genesis_hash.as_bytes().to_vec();
-
-        let res = unsafe {
-            ffi::mock_register_enclave_xt(
-                self.eid,
-                &mut retval,
-                gen.as_ptr(),
-                gen.len() as u32,
-                &nonce,
-                url.as_ptr(),
-                url.len() as u32,
-                response.as_mut_ptr(),
-                response_len,
-            )
-        };
-
-        ensure!(res == sgx_status_t::SGX_SUCCESS, Error::Sgx(res));
-        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
-        Ok(response)
+    pub fn destroy(self) {
+        self.sgx_enclave.destroy()
     }
 }

--- a/primitives/enclave-api/src/remote_attestation.rs
+++ b/primitives/enclave-api/src/remote_attestation.rs
@@ -1,0 +1,260 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::error::Error;
+use crate::{utils, Enclave, EnclaveResult};
+use frame_support::ensure;
+use sgx_types::*;
+use substratee_enclave_api_ffi as ffi;
+use substratee_settings::worker::EXTRINSIC_MAX_SIZE;
+
+/// general remote attestation methods
+pub trait RemoteAttestation {
+    fn perform_ra(
+        &self,
+        genesis_hash: Vec<u8>,
+        nonce: u32,
+        w_url: Vec<u8>,
+    ) -> EnclaveResult<Vec<u8>>;
+
+    fn dump_ra_to_disk(&self) -> EnclaveResult<()>;
+}
+
+/// call-backs that are made from inside the enclave (using o-call), to e-calls again inside the enclave
+pub trait RemoteAttestationCallBacks {
+    fn init_quote(&self) -> EnclaveResult<(sgx_target_info_t, sgx_epid_group_id_t)>;
+
+    fn calc_quote_size(&self, revocation_list: Vec<u8>) -> EnclaveResult<u32>;
+
+    fn get_quote(
+        &self,
+        revocation_list: Vec<u8>,
+        report: sgx_report_t,
+        quote_type: sgx_quote_sign_type_t,
+        spid: sgx_spid_t,
+        quote_nonce: sgx_quote_nonce_t,
+        quote_length: u32,
+    ) -> EnclaveResult<(sgx_report_t, Vec<u8>)>;
+
+    fn get_update_info(
+        &self,
+        platform_blob: sgx_platform_info_t,
+        enclave_trusted: i32,
+    ) -> EnclaveResult<sgx_update_info_bit_t>;
+}
+
+/// TLS remote attestations methods
+pub trait TlsRemoteAttestation {
+    fn run_key_provisioning_server(
+        &self,
+        socket_fd: c_int,
+        sign_type: sgx_quote_sign_type_t,
+        skip_ra: bool,
+    ) -> EnclaveResult<()>;
+
+    fn request_key_provisioning(
+        &self,
+        socket_fd: c_int,
+        sign_type: sgx_quote_sign_type_t,
+        skip_ra: bool,
+    ) -> EnclaveResult<()>;
+}
+
+impl RemoteAttestation for Enclave {
+    fn perform_ra(
+        &self,
+        genesis_hash: Vec<u8>,
+        nonce: u32,
+        w_url: Vec<u8>,
+    ) -> EnclaveResult<Vec<u8>> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let unchecked_extrinsic_size = EXTRINSIC_MAX_SIZE;
+        let mut unchecked_extrinsic: Vec<u8> = vec![0u8; unchecked_extrinsic_size as usize];
+
+        let result = unsafe {
+            ffi::perform_ra(
+                self.eid,
+                &mut retval,
+                genesis_hash.as_ptr(),
+                genesis_hash.len() as u32,
+                &nonce,
+                w_url.as_ptr(),
+                w_url.len() as u32,
+                unchecked_extrinsic.as_mut_ptr(),
+                unchecked_extrinsic.len() as u32,
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(unchecked_extrinsic)
+    }
+
+    fn dump_ra_to_disk(&self) -> EnclaveResult<()> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let result = unsafe { ffi::dump_ra_to_disk(self.eid, &mut retval) };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(())
+    }
+}
+
+impl RemoteAttestationCallBacks for Enclave {
+    fn init_quote(&self) -> EnclaveResult<(sgx_target_info_t, sgx_epid_group_id_t)> {
+        let mut ti: sgx_target_info_t = sgx_target_info_t::default();
+        let mut eg: sgx_epid_group_id_t = sgx_epid_group_id_t::default();
+
+        let result = unsafe {
+            sgx_init_quote(
+                &mut ti as *mut sgx_target_info_t,
+                &mut eg as *mut sgx_epid_group_id_t,
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+
+        Ok((ti, eg))
+    }
+
+    fn calc_quote_size(&self, revocation_list: Vec<u8>) -> EnclaveResult<u32> {
+        let mut real_quote_len: u32 = 0;
+
+        let (p_sig_rl, sig_rl_size) = utils::vec_to_c_pointer_with_len(revocation_list);
+
+        let result =
+            unsafe { sgx_calc_quote_size(p_sig_rl, sig_rl_size, &mut real_quote_len as *mut u32) };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+
+        Ok(real_quote_len)
+    }
+
+    fn get_quote(
+        &self,
+        revocation_list: Vec<u8>,
+        report: sgx_report_t,
+        quote_type: sgx_quote_sign_type_t,
+        spid: sgx_spid_t,
+        quote_nonce: sgx_quote_nonce_t,
+        quote_length: u32,
+    ) -> EnclaveResult<(sgx_report_t, Vec<u8>)> {
+        let (p_sig_rl, sig_rl_size) = utils::vec_to_c_pointer_with_len(revocation_list);
+        let p_report = &report as *const sgx_report_t;
+        let p_spid = &spid as *const sgx_spid_t;
+        let p_nonce = &quote_nonce as *const sgx_quote_nonce_t;
+
+        let mut qe_report = sgx_report_t::default();
+        let p_qe_report = &mut qe_report as *mut sgx_report_t;
+
+        let mut return_quote_buf = vec![0u8; quote_length as usize];
+        let p_quote = return_quote_buf.as_mut_ptr();
+
+        let ret = unsafe {
+            sgx_get_quote(
+                p_report,
+                quote_type,
+                p_spid,
+                p_nonce,
+                p_sig_rl,
+                sig_rl_size,
+                p_qe_report,
+                p_quote as *mut sgx_quote_t,
+                quote_length,
+            )
+        };
+
+        ensure!(ret == sgx_status_t::SGX_SUCCESS, Error::Sgx(ret));
+
+        Ok((qe_report, return_quote_buf))
+    }
+
+    fn get_update_info(
+        &self,
+        platform_blob: sgx_platform_info_t,
+        enclave_trusted: i32,
+    ) -> EnclaveResult<sgx_update_info_bit_t> {
+        let mut update_info: sgx_update_info_bit_t = sgx_update_info_bit_t::default();
+
+        let result = unsafe {
+            sgx_report_attestation_status(
+                &platform_blob as *const sgx_platform_info_t,
+                enclave_trusted,
+                &mut update_info as *mut sgx_update_info_bit_t,
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+
+        Ok(update_info)
+    }
+}
+
+impl TlsRemoteAttestation for Enclave {
+    fn run_key_provisioning_server(
+        &self,
+        socket_fd: c_int,
+        sign_type: sgx_quote_sign_type_t,
+        skip_ra: bool,
+    ) -> EnclaveResult<()> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let result = unsafe {
+            ffi::run_key_provisioning_server(
+                self.eid,
+                &mut retval,
+                socket_fd,
+                sign_type,
+                skip_ra.into(),
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(())
+    }
+
+    fn request_key_provisioning(
+        &self,
+        socket_fd: c_int,
+        sign_type: sgx_quote_sign_type_t,
+        skip_ra: bool,
+    ) -> EnclaveResult<()> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let result = unsafe {
+            ffi::request_key_provisioning(
+                self.eid,
+                &mut retval,
+                socket_fd,
+                sign_type,
+                skip_ra.into(),
+            )
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(())
+    }
+}

--- a/primitives/enclave-api/src/side_chain.rs
+++ b/primitives/enclave-api/src/side_chain.rs
@@ -1,0 +1,43 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::error::Error;
+use crate::{Enclave, EnclaveResult};
+use frame_support::ensure;
+use sgx_types::sgx_status_t;
+use substratee_enclave_api_ffi as ffi;
+
+/// trait for handling blocks on the side chain
+pub trait SideChain: Send + Sync + 'static {
+    fn produce_blocks(&self, blocks: Vec<u8>, nonce: u32) -> EnclaveResult<()>;
+}
+
+impl SideChain for Enclave {
+    fn produce_blocks(&self, blocks: Vec<u8>, nonce: u32) -> EnclaveResult<()> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+
+        let result = unsafe {
+            ffi::produce_blocks(self.eid, &mut retval, blocks.as_ptr(), blocks.len(), &nonce)
+        };
+
+        ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(())
+    }
+}

--- a/primitives/enclave-api/src/teerex_api.rs
+++ b/primitives/enclave-api/src/teerex_api.rs
@@ -1,0 +1,70 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use crate::error::Error;
+use crate::{Enclave, EnclaveResult};
+use codec::Encode;
+use frame_support::ensure;
+use frame_support::sp_runtime::app_crypto::sp_core::H256;
+use sgx_types::*;
+use substratee_enclave_api_ffi as ffi;
+
+pub trait TeerexApi: Send + Sync + 'static {
+    /// Register enclave xt with an empty attestation report.
+    fn mock_register_xt(
+        &self,
+        genesis_hash: H256,
+        nonce: u32,
+        w_url: &str,
+    ) -> EnclaveResult<Vec<u8>>;
+}
+
+impl TeerexApi for Enclave {
+    fn mock_register_xt(
+        &self,
+        genesis_hash: H256,
+        nonce: u32,
+        w_url: &str,
+    ) -> EnclaveResult<Vec<u8>> {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+        let response_len = 8192;
+        let mut response: Vec<u8> = vec![0u8; response_len as usize];
+
+        let url = w_url.encode();
+        let gen = genesis_hash.as_bytes().to_vec();
+
+        let res = unsafe {
+            ffi::mock_register_enclave_xt(
+                self.eid,
+                &mut retval,
+                gen.as_ptr(),
+                gen.len() as u32,
+                &nonce,
+                url.as_ptr(),
+                url.len() as u32,
+                response.as_mut_ptr(),
+                response_len,
+            )
+        };
+
+        ensure!(res == sgx_status_t::SGX_SUCCESS, Error::Sgx(res));
+        ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+        Ok(response)
+    }
+}

--- a/primitives/enclave-api/src/utils.rs
+++ b/primitives/enclave-api/src/utils.rs
@@ -1,0 +1,27 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use std::ptr;
+
+pub fn vec_to_c_pointer_with_len<A>(input: Vec<A>) -> (*const A, u32) {
+    if input.is_empty() {
+        (ptr::null(), 0)
+    } else {
+        (input.as_ptr(), input.len() as u32)
+    }
+}

--- a/primitives/settings/src/lib.rs
+++ b/primitives/settings/src/lib.rs
@@ -20,63 +20,71 @@
 #![no_std]
 
 pub mod files {
-	// used by worker
-	pub static ENCLAVE_TOKEN: &str = "enclave.token";
-	pub static ENCLAVE_FILE: &str = "enclave.signed.so";
-	pub static SHIELDING_KEY_FILE: &str = "enclave-shielding-pubkey.json";
-	pub static SIGNING_KEY_FILE: &str = "enclave-signing-pubkey.bin";
+    // used by worker
+    pub static ENCLAVE_TOKEN: &str = "enclave.token";
+    pub static ENCLAVE_FILE: &str = "enclave.signed.so";
+    pub static SHIELDING_KEY_FILE: &str = "enclave-shielding-pubkey.json";
+    pub static SIGNING_KEY_FILE: &str = "enclave-signing-pubkey.bin";
 
-	// used by enclave
-	pub const RSA3072_SEALED_KEY_FILE: &str = "rsa3072_key_sealed.bin";
-	pub const SEALED_SIGNER_SEED_FILE: &str = "ed25519_key_sealed.bin";
-	pub const AES_KEY_FILE_AND_INIT_V: &str = "aes_key_sealed.bin";
-	pub const CHAIN_RELAY_DB: &str = "chain_relay_db.bin";
+    // used by enclave
+    pub const RSA3072_SEALED_KEY_FILE: &str = "rsa3072_key_sealed.bin";
+    pub const SEALED_SIGNER_SEED_FILE: &str = "ed25519_key_sealed.bin";
+    pub const AES_KEY_FILE_AND_INIT_V: &str = "aes_key_sealed.bin";
+    pub const CHAIN_RELAY_DB: &str = "chain_relay_db.bin";
 
-	pub const RA_DUMP_CERT_DER_FILE: &str = "ra_dump_cert.der";
+    pub const RA_DUMP_CERT_DER_FILE: &str = "ra_dump_cert.der";
 
-	// used by worker and enclave
-	pub const SHARDS_PATH: &str = "./shards";
-	pub const ENCRYPTED_STATE_FILE: &str = "state.bin";
+    // used by worker and enclave
+    pub const SHARDS_PATH: &str = "./shards";
+    pub const ENCRYPTED_STATE_FILE: &str = "state.bin";
 
-	#[cfg(feature = "production")]
-	pub static RA_SPID_FILE: &str = "spid_production.txt";
-	#[cfg(feature = "production")]
-	pub static RA_API_KEY_FILE: &str = "key_production.txt";
+    #[cfg(feature = "production")]
+    pub static RA_SPID_FILE: &str = "spid_production.txt";
+    #[cfg(feature = "production")]
+    pub static RA_API_KEY_FILE: &str = "key_production.txt";
 
-	#[cfg(not(feature = "production"))]
-	pub static RA_SPID_FILE: &str = "spid.txt";
-	#[cfg(not(feature = "production"))]
-	pub static RA_API_KEY_FILE: &str = "key.txt";
+    #[cfg(not(feature = "production"))]
+    pub static RA_SPID_FILE: &str = "spid.txt";
+    #[cfg(not(feature = "production"))]
+    pub static RA_API_KEY_FILE: &str = "key.txt";
 }
 
 /// Settings concerning the worker
 pub mod worker {
-	// the maximum size of any extrinsic that the enclave will ever generate in B
-	pub static EXTRINSIC_MAX_SIZE: usize = 4196;
-	// the maximum size of a value that will be queried from the state in B
-	pub static STATE_VALUE_MAX_SIZE: usize = 1024;
+    // the maximum size of any extrinsic that the enclave will ever generate in B
+    pub const EXTRINSIC_MAX_SIZE: usize = 4196;
+    // the maximum size of a value that will be queried from the state in B
+    pub const STATE_VALUE_MAX_SIZE: usize = 1024;
+    // the maximum size of the header
+    pub const HEADER_MAX_SIZE: usize = 200;
+    // maximum size of shielding key
+    pub const SHIELDING_KEY_SIZE: usize = 8192;
+    // maximum size of signing key
+    pub const SIGNING_KEY_SIZE: usize = 32;
+    // size of the MR enclave
+    pub const MR_ENCLAVE_SIZE: usize = 32;
 }
 
 /// Settings concerning the enclave
 pub mod enclave {
-	// timeouts for getter and call execution
-	pub static CALL_TIMEOUT: i64 = 300; // timeout in ms
-	pub static GETTER_TIMEOUT: i64 = 300; // timeout in ms
+    // timeouts for getter and call execution
+    pub static CALL_TIMEOUT: i64 = 300; // timeout in ms
+    pub static GETTER_TIMEOUT: i64 = 300; // timeout in ms
 }
 
 /// Settings concerning the node
 pub mod node {
-	// you may have to update these indices upon new builds of the runtime
-	// you can get the index from metadata, counting modules starting with zero
-	pub static SUBSTRATEE_REGISTRY_MODULE: u8 = 8u8;
-	pub static REGISTER_ENCLAVE: u8 = 0u8;
-	//pub static UNREGISTER_ENCLAVE: u8 = 1u8;
-	pub static CALL_WORKER: u8 = 2u8;
-	pub static CALL_CONFIRMED: u8 = 3u8;
-	pub static BLOCK_CONFIRMED: u8 = 4u8;
-	pub static SHIELD_FUNDS: u8 = 5u8;
+    // you may have to update these indices upon new builds of the runtime
+    // you can get the index from metadata, counting modules starting with zero
+    pub static SUBSTRATEE_REGISTRY_MODULE: u8 = 8u8;
+    pub static REGISTER_ENCLAVE: u8 = 0u8;
+    //pub static UNREGISTER_ENCLAVE: u8 = 1u8;
+    pub static CALL_WORKER: u8 = 2u8;
+    pub static CALL_CONFIRMED: u8 = 3u8;
+    pub static BLOCK_CONFIRMED: u8 = 4u8;
+    pub static SHIELD_FUNDS: u8 = 5u8;
 
-	// bump this to be consistent with SubstraTEE-node runtime
-	pub static RUNTIME_SPEC_VERSION: u32 = 1;
-	pub static RUNTIME_TRANSACTION_VERSION: u32 = 1;
+    // bump this to be consistent with SubstraTEE-node runtime
+    pub static RUNTIME_SPEC_VERSION: u32 = 1;
+    pub static RUNTIME_TRANSACTION_VERSION: u32 = 1;
 }

--- a/worker/rpc/server/src/lib.rs
+++ b/worker/rpc/server/src/lib.rs
@@ -25,21 +25,22 @@ use log::debug;
 use parity_scale_codec::Encode;
 use tokio::net::ToSocketAddrs;
 
-use substratee_enclave_api::EnclaveApi;
+use std::sync::Arc;
+use substratee_enclave_api::direct_request::DirectRequest;
 use substratee_worker_primitives::block::SignedBlock;
 use substratee_worker_primitives::RpcRequest;
 
 #[cfg(test)]
-mod tests;
-#[cfg(test)]
 mod mock;
+#[cfg(test)]
+mod tests;
 
 pub async fn run_server<Enclave>(
     addr: impl ToSocketAddrs,
-    enclave: Enclave,
+    enclave: Arc<Enclave>,
 ) -> anyhow::Result<SocketAddr>
 where
-    Enclave: EnclaveApi,
+    Enclave: DirectRequest,
 {
     let mut server = WsServerBuilder::default().build(addr).await?;
 

--- a/worker/rpc/server/src/mock.rs
+++ b/worker/rpc/server/src/mock.rs
@@ -1,45 +1,51 @@
 use parity_scale_codec::Encode;
 
-use substratee_enclave_api::{EnclaveApi, EnclaveResult};
-use substratee_worker_primitives::block::{SignedBlock, Block};
-use substratee_worker_primitives::{ShardIdentifier, RpcResponse};
 use sp_core::crypto::AccountId32;
+use substratee_enclave_api::direct_request::DirectRequest;
+use substratee_enclave_api::EnclaveResult;
+use substratee_worker_primitives::block::{Block, SignedBlock};
+use substratee_worker_primitives::{RpcResponse, ShardIdentifier};
 
 pub struct TestEnclave;
 
-impl EnclaveApi for TestEnclave {
-	fn rpc(&self, _request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
-		Ok(RpcResponse {
-			jsonrpc: "mock_response".into(),
-			result: "null".encode(),
-			id: 1
-		}.encode())
-	}
+impl DirectRequest for TestEnclave {
+    fn rpc(&self, _request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
+        Ok(RpcResponse {
+            jsonrpc: "mock_response".into(),
+            result: "null".encode(),
+            id: 1,
+        }
+        .encode())
+    }
+
+    fn initialize_pool(&self) -> EnclaveResult<()> {
+        unreachable!()
+    }
 }
 
 // todo: this is a duplicate that is also defined in the worker. We should extract an independent
 // test-utils crate because here we don't want to depend on the worker itself.
 pub fn test_sidechain_block() -> SignedBlock {
-	use sp_core::{H256, Pair};
+    use sp_core::{Pair, H256};
 
-	let signer_pair = sp_core::ed25519::Pair::from_string("//Alice", None).unwrap();
-	let author: AccountId32 = signer_pair.public().into();
-	let block_number: u64 = 0;
-	let parent_hash = H256::random();
-	let layer_one_head = H256::random();
-	let signed_top_hashes = vec![];
-	let encrypted_payload: Vec<u8> = vec![];
-	let shard = ShardIdentifier::default();
+    let signer_pair = sp_core::ed25519::Pair::from_string("//Alice", None).unwrap();
+    let author: AccountId32 = signer_pair.public().into();
+    let block_number: u64 = 0;
+    let parent_hash = H256::random();
+    let layer_one_head = H256::random();
+    let signed_top_hashes = vec![];
+    let encrypted_payload: Vec<u8> = vec![];
+    let shard = ShardIdentifier::default();
 
-	// when
-	let block = Block::construct_block(
-		author,
-		block_number,
-		parent_hash.clone(),
-		layer_one_head.clone(),
-		shard.clone(),
-		signed_top_hashes.clone(),
-		encrypted_payload.clone(),
-	);
-	block.sign(&signer_pair)
+    // when
+    let block = Block::construct_block(
+        author,
+        block_number,
+        parent_hash.clone(),
+        layer_one_head.clone(),
+        shard.clone(),
+        signed_top_hashes.clone(),
+        encrypted_payload.clone(),
+    );
+    block.sign(&signer_pair)
 }

--- a/worker/rpc/server/src/tests.rs
+++ b/worker/rpc/server/src/tests.rs
@@ -1,11 +1,11 @@
 use log::info;
 
 use super::*;
-use parity_scale_codec::Decode;
 use jsonrpsee::{
     types::{to_json_value, traits::Client},
     ws_client::WsClientBuilder,
 };
+use parity_scale_codec::Decode;
 
 use mock::{test_sidechain_block, TestEnclave};
 use substratee_worker_primitives::RpcResponse;
@@ -17,7 +17,9 @@ fn init() {
 #[tokio::test]
 async fn test_client_calls() {
     init();
-    let addr = run_server("127.0.0.1:0", TestEnclave).await.unwrap();
+    let addr = run_server("127.0.0.1:0", Arc::new(TestEnclave))
+        .await
+        .unwrap();
     info!("ServerAddress: {:?}", addr);
 
     let url = format!("ws://{}", addr);

--- a/worker/src/enclave/api.rs
+++ b/worker/src/enclave/api.rs
@@ -16,99 +16,17 @@
 */
 
 use log::*;
+use sgx_types::*;
+use sgx_urts::SgxEnclave;
 /// keep this api free from chain-specific types!
 use std::io::{Read, Write};
 use std::{fs::File, path::PathBuf};
+use substratee_enclave_api::enclave_base::EnclaveBase;
+use substratee_enclave_api::error::Error as EnclaveApiError;
+use substratee_enclave_api::{Enclave, EnclaveResult};
+use substratee_settings::files::{ENCLAVE_FILE, ENCLAVE_TOKEN};
 
-use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
-use sgx_types::*;
-use sgx_urts::SgxEnclave;
-
-use codec::{Decode, Encode};
-use my_node_runtime::Header;
-use substratee_node_primitives::SignedBlock;
-use sp_core::ed25519;
-use sp_finality_grandpa::VersionedAuthorityList;
-
-use substratee_settings::{
-    worker::{EXTRINSIC_MAX_SIZE, STATE_VALUE_MAX_SIZE},
-    files::{ENCLAVE_FILE, ENCLAVE_TOKEN}
-};
-
-extern "C" {
-    fn init(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
-
-    fn get_state(
-        eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
-        cyphertext: *const u8,
-        cyphertext_size: u32,
-        shard: *const u8,
-        shard_size: u32,
-        value: *mut u8,
-        value_size: u32,
-    ) -> sgx_status_t;
-
-    fn init_chain_relay(
-        eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
-        genesis_hash: *const u8,
-        genesis_hash_size: usize,
-        authority_list: *const u8,
-        authority_list_size: usize,
-        authority_proof: *const u8,
-        authority_proof_size: usize,
-        latest_header: *mut u8,
-        latest_header_size: usize,
-    ) -> sgx_status_t;
-
-    fn produce_blocks(
-        eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
-        blocks: *const u8,
-        blocks_size: usize,
-        nonce: *const u32,
-    ) -> sgx_status_t;
-
-    fn get_rsa_encryption_pubkey(
-        eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
-        pubkey: *mut u8,
-        pubkey_size: u32,
-    ) -> sgx_status_t;
-
-    fn get_ecc_signing_pubkey(
-        eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
-        pubkey: *mut u8,
-        pubkey_size: u32,
-    ) -> sgx_status_t;
-
-    fn get_mrenclave(
-        eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
-        mrenclave: *mut u8,
-        mrenclave_size: u32,
-    ) -> sgx_status_t;
-
-    fn perform_ra(
-        eid: sgx_enclave_id_t,
-        retval: *mut sgx_status_t,
-        genesis_hash: *const u8,
-        genesis_hash_size: u32,
-        nonce: *const u32,
-        w_url: *const u8,
-        w_url_size: u32,
-        unchecked_extrinsic: *mut u8,
-        unchecked_extrinsic_size: u32,
-    ) -> sgx_status_t;
-
-    fn dump_ra_to_disk(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
-
-    fn test_main_entrance(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
-}
-
-pub fn enclave_init() -> SgxResult<SgxEnclave> {
+pub fn enclave_init() -> EnclaveResult<Enclave> {
     const LEN: usize = 1024;
     let mut launch_token = [0; LEN];
     let mut launch_token_updated = 0;
@@ -167,11 +85,12 @@ pub fn enclave_init() -> SgxResult<SgxEnclave> {
         &mut launch_token,
         &mut launch_token_updated,
         &mut misc_attr,
-    ))?;
+    ))
+    .map_err(EnclaveApiError::Sgx)?;
 
     // Step 3: save the launch token if it is updated
     if use_token && launch_token_updated != 0 {
-        // reopen the file with write capablity
+        // reopen the file with write capability
         match File::create(&token_file) {
             Ok(mut f) => match f.write_all(&launch_token) {
                 Ok(()) => info!("[+] Saved updated launch token!"),
@@ -183,214 +102,9 @@ pub fn enclave_init() -> SgxResult<SgxEnclave> {
         }
     }
 
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    // call the enclave's init fn
-    let result = unsafe { init(enclave.geteid(), &mut status) };
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    Ok(enclave)
-}
+    // create an enclave API and initialize it
+    let enclave_api = Enclave::new(enclave);
+    enclave_api.init()?;
 
-pub fn enclave_init_chain_relay(
-    eid: sgx_enclave_id_t,
-    genesis_header: Header,
-    authority_list: VersionedAuthorityList,
-    authority_proof: Vec<Vec<u8>>,
-) -> SgxResult<Header> {
-    let mut latest_header = vec![0u8; 200];
-
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result = unsafe {
-        // Todo: this is a bit ugly but the common `encode()` is not implemented for authority list
-        authority_list.using_encoded(|authorities| {
-            init_chain_relay(
-                eid,
-                &mut status,
-                genesis_header.encode().as_ptr(),
-                genesis_header.encode().len(),
-                authorities.as_ptr(),
-                authorities.len(),
-                authority_proof.encode().as_ptr(),
-                authority_proof.encode().len(),
-                latest_header.as_mut_ptr(),
-                latest_header.len(),
-            )
-        })
-    };
-
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    let latest: Header = Decode::decode(&mut latest_header.as_slice()).unwrap();
-    info!("Latest Header {:?}", latest);
-
-    Ok(latest)
-}
-
-/// Starts block production within enclave
-///
-/// Returns the produced blocks
-pub fn enclave_produce_blocks(
-    eid: sgx_enclave_id_t,
-    blocks_to_sync: Vec<SignedBlock>,
-    tee_nonce: u32,
-) -> SgxResult<()> {
-    let mut status = sgx_status_t::SGX_SUCCESS;
-
-    let result = unsafe {
-        blocks_to_sync
-            .using_encoded(|b| produce_blocks(eid, &mut status, b.as_ptr(), b.len(), &tee_nonce))
-    };
-
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-
-    Ok(())
-}
-
-pub fn enclave_signing_key(eid: sgx_enclave_id_t) -> SgxResult<ed25519::Public> {
-    let pubkey_size = 32;
-    let mut pubkey = [0u8; 32];
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result =
-        unsafe { get_ecc_signing_pubkey(eid, &mut status, pubkey.as_mut_ptr(), pubkey_size) };
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-
-    Ok(ed25519::Public::from_raw(pubkey))
-}
-
-pub fn enclave_shielding_key(eid: sgx_enclave_id_t) -> SgxResult<Rsa3072PubKey> {
-    let pubkey_size = 8192;
-    let mut pubkey = vec![0u8; pubkey_size as usize];
-
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result =
-        unsafe { get_rsa_encryption_pubkey(eid, &mut status, pubkey.as_mut_ptr(), pubkey_size) };
-
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-
-    let rsa_pubkey: Rsa3072PubKey = serde_json::from_slice(pubkey.as_slice()).unwrap();
-    debug!("got RSA pubkey {:?}", rsa_pubkey);
-    Ok(rsa_pubkey)
-}
-
-pub fn enclave_query_state(
-    eid: sgx_enclave_id_t,
-    cyphertext: Vec<u8>,
-    shard: Vec<u8>,
-) -> SgxResult<Vec<u8>> {
-    let value_size = STATE_VALUE_MAX_SIZE;
-    let mut value = vec![0u8; value_size as usize];
-
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result = unsafe {
-        get_state(
-            eid,
-            &mut status,
-            cyphertext.as_ptr(),
-            cyphertext.len() as u32,
-            shard.as_ptr(),
-            shard.len() as u32,
-            value.as_mut_ptr(),
-            value_size as u32,
-        )
-    };
-
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    debug!("got state value: {:?}", hex::encode(value.clone()));
-    Ok(value)
-}
-
-pub fn enclave_mrenclave(eid: sgx_enclave_id_t) -> SgxResult<[u8; 32]> {
-    let mut m = [0u8; 32];
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result = unsafe { get_mrenclave(eid, &mut status, m.as_mut_ptr(), m.len() as u32) };
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    Ok(m)
-}
-
-pub fn enclave_dump_ra(eid: sgx_enclave_id_t) -> SgxResult<()> {
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result = unsafe { dump_ra_to_disk(eid, &mut status) };
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    Ok(())
-}
-
-pub fn enclave_perform_ra(
-    eid: sgx_enclave_id_t,
-    genesis_hash: Vec<u8>,
-    nonce: u32,
-    w_url: Vec<u8>,
-) -> SgxResult<Vec<u8>> {
-    let unchecked_extrinsic_size = EXTRINSIC_MAX_SIZE;
-    let mut unchecked_extrinsic: Vec<u8> = vec![0u8; unchecked_extrinsic_size as usize];
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result = unsafe {
-        perform_ra(
-            eid,
-            &mut status,
-            genesis_hash.as_ptr(),
-            genesis_hash.len() as u32,
-            &nonce,
-            w_url.as_ptr(),
-            w_url.len() as u32,
-            unchecked_extrinsic.as_mut_ptr(),
-            unchecked_extrinsic_size as u32,
-        )
-    };
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    Ok(unchecked_extrinsic)
-}
-
-pub fn enclave_test(eid: sgx_enclave_id_t) -> SgxResult<()> {
-    let mut status = sgx_status_t::SGX_SUCCESS;
-    let result = unsafe { test_main_entrance(eid, &mut status) };
-    if status != sgx_status_t::SGX_SUCCESS {
-        return Err(status);
-    }
-    if result != sgx_status_t::SGX_SUCCESS {
-        return Err(result);
-    }
-    Ok(())
+    Ok(enclave_api)
 }

--- a/worker/src/tests/direct_request_mock.rs
+++ b/worker/src/tests/direct_request_mock.rs
@@ -1,0 +1,31 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use substratee_enclave_api::direct_request::DirectRequest;
+use substratee_enclave_api::EnclaveResult;
+
+pub struct DirectRequestMock;
+
+impl DirectRequest for DirectRequestMock {
+    fn rpc(&self, request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
+        Ok(request)
+    }
+
+    fn initialize_pool(&self) -> EnclaveResult<()> {
+        Ok(())
+    }
+}

--- a/worker/src/tests/ecalls.rs
+++ b/worker/src/tests/ecalls.rs
@@ -15,22 +15,24 @@
 
 */
 
-use crate::enclave::api::enclave_query_state;
 use crate::init_shard;
 use crate::tests::commons::test_trusted_getter_signed;
 use codec::Encode;
-use sp_keyring::AccountKeyring;
-
-use sgx_types::*;
+use log::*;
 use sp_core::hash::H256;
+use sp_keyring::AccountKeyring;
+use substratee_enclave_api::enclave_base::EnclaveBase;
 
 /// Todo: this is broken. In the test it tries to read nonexistent `chain_relay_db.bin`
 /// Tackle in: https://github.com/scs/substraTEE-worker/issues/246
-pub fn get_state_works(eid: sgx_enclave_id_t) {
+pub fn get_state_works<E: EnclaveBase>(enclave_api: &E) {
     let alice = AccountKeyring::Alice;
     let trusted_getter_signed = test_trusted_getter_signed(alice).encode();
     let shard = H256::default();
     init_shard(&shard);
-    let res = enclave_query_state(eid, trusted_getter_signed, shard.encode()).unwrap();
+    let res = enclave_api
+        .get_state(trusted_getter_signed, shard.encode())
+        .unwrap();
+    debug!("got state value: {:?}", hex::encode(res.clone()));
     println!("get_state returned {:?}", res);
 }

--- a/worker/src/tests/enclave_api_mock.rs
+++ b/worker/src/tests/enclave_api_mock.rs
@@ -1,0 +1,58 @@
+/*
+    Copyright 2019 Supercomputing Systems AG
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
+use sp_core::ed25519;
+use sp_finality_grandpa::VersionedAuthorityList;
+use sp_runtime::traits::Header;
+use substratee_enclave_api::enclave_base::EnclaveBase;
+use substratee_enclave_api::EnclaveResult;
+use substratee_settings::worker::MR_ENCLAVE_SIZE;
+
+/// mock for EnclaveBase - use in tests
+pub struct EnclaveBaseMock;
+
+impl EnclaveBase for EnclaveBaseMock {
+    fn init(&self) -> EnclaveResult<()> {
+        Ok(())
+    }
+
+    fn init_chain_relay<SpHeader: Header>(
+        &self,
+        genesis_header: SpHeader,
+        _authority_list: VersionedAuthorityList,
+        _authority_proof: Vec<Vec<u8>>,
+    ) -> EnclaveResult<SpHeader> {
+        Ok(genesis_header)
+    }
+
+    fn get_state(&self, _cyphertext: Vec<u8>, _shard: Vec<u8>) -> EnclaveResult<Vec<u8>> {
+        Ok(Vec::<u8>::new())
+    }
+
+    fn get_rsa_shielding_pubkey(&self) -> EnclaveResult<Rsa3072PubKey> {
+        unreachable!()
+    }
+
+    fn get_ecc_signing_pubkey(&self) -> EnclaveResult<ed25519::Public> {
+        unreachable!()
+    }
+
+    fn get_mrenclave(&self) -> EnclaveResult<[u8; MR_ENCLAVE_SIZE]> {
+        Ok([1u8; MR_ENCLAVE_SIZE])
+    }
+}

--- a/worker/src/tests/worker.rs
+++ b/worker/src/tests/worker.rs
@@ -6,6 +6,7 @@ use crate::config::Config;
 use crate::tests::commons::local_worker_config;
 use crate::tests::mock::{enclaves, TestNodeApi, W2_URL};
 use crate::worker::Worker as WorkerGen;
+use std::sync::Arc;
 
 type TestWorker = WorkerGen<Config, TestNodeApi, (), ()>;
 
@@ -20,7 +21,7 @@ fn worker_rw_lock_works() {
         *w = Some(TestWorker::new(
             local_worker_config(W2_URL.into()),
             TestNodeApi,
-            (),
+            Arc::new(()),
             (),
         ));
     }

--- a/worker/src/utils.rs
+++ b/worker/src/utils.rs
@@ -1,63 +1,78 @@
-use substratee_stf::ShardIdentifier;
-use clap::ArgMatches;
-use base58::{FromBase58, ToBase58};
-use log::{info, debug};
-use crate::enclave::api::{enclave_init, enclave_mrenclave};
-use std::path::Path;
+/*
+    Copyright 2019 Supercomputing Systems AG
+    Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
 
-pub fn extract_shard(m: &ArgMatches<'_>) -> ShardIdentifier {
-	match m.value_of("shard") {
-		Some(value) => {
-			let shard_vec = value.from_base58().expect("shard must be hex encoded");
-			let mut shard = [0u8; 32];
-			shard.copy_from_slice(&shard_vec[..]);
-			shard.into()
-		}
-		_ => {
-			let enclave = enclave_init().unwrap();
-			let mrenclave = enclave_mrenclave(enclave.geteid()).unwrap();
-			info!(
-				"no shard specified. using mrenclave as id: {}",
-				mrenclave.to_base58()
-			);
-			ShardIdentifier::from_slice(&mrenclave[..])
-		}
-	}
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+use base58::{FromBase58, ToBase58};
+use clap::ArgMatches;
+use log::{debug, info};
+use std::path::Path;
+use substratee_enclave_api::enclave_base::EnclaveBase;
+use substratee_stf::ShardIdentifier;
+
+pub fn extract_shard<E: EnclaveBase>(m: &ArgMatches<'_>, enclave_api: &E) -> ShardIdentifier {
+    match m.value_of("shard") {
+        Some(value) => {
+            let shard_vec = value.from_base58().expect("shard must be hex encoded");
+            let mut shard = [0u8; 32];
+            shard.copy_from_slice(&shard_vec[..]);
+            shard.into()
+        }
+        _ => {
+            let mrenclave = enclave_api.get_mrenclave().unwrap();
+            info!(
+                "no shard specified. using mrenclave as id: {}",
+                mrenclave.to_base58()
+            );
+            ShardIdentifier::from_slice(&mrenclave[..])
+        }
+    }
 }
 
 pub fn hex_encode(data: Vec<u8>) -> String {
-	let mut hex_str = hex::encode(data);
-	hex_str.insert_str(0, "0x");
-	hex_str
+    let mut hex_str = hex::encode(data);
+    hex_str.insert_str(0, "0x");
+    hex_str
 }
 
 pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) {
-	if data.len() > writable.len() {
-		panic!("not enough bytes in output buffer for return value");
-	}
-	let (left, right) = writable.split_at_mut(data.len());
-	left.clone_from_slice(&data);
-	// fill the right side with whitespace
-	right.iter_mut().for_each(|x| *x = 0x20);
+    if data.len() > writable.len() {
+        panic!("not enough bytes in output buffer for return value");
+    }
+    let (left, right) = writable.split_at_mut(data.len());
+    left.clone_from_slice(&data);
+    // fill the right side with whitespace
+    right.iter_mut().for_each(|x| *x = 0x20);
 }
 
-
 pub fn check_files() {
-	use substratee_settings::files::{
-		SIGNING_KEY_FILE, SHIELDING_KEY_FILE, ENCLAVE_FILE,
-		RA_SPID_FILE, RA_API_KEY_FILE,
-	};
-	debug!("*** Check files");
-	let files = vec![
-		ENCLAVE_FILE,
-		SHIELDING_KEY_FILE,
-		SIGNING_KEY_FILE,
-		RA_SPID_FILE,
-		RA_API_KEY_FILE,
-	];
-	for f in files.iter() {
-		if !Path::new(f).exists() {
-			panic!("file doesn't exist: {}", f);
-		}
-	}
+    use substratee_settings::files::{
+        ENCLAVE_FILE, RA_API_KEY_FILE, RA_SPID_FILE, SHIELDING_KEY_FILE, SIGNING_KEY_FILE,
+    };
+    debug!("*** Check files");
+    let files = vec![
+        ENCLAVE_FILE,
+        SHIELDING_KEY_FILE,
+        SIGNING_KEY_FILE,
+        RA_SPID_FILE,
+        RA_API_KEY_FILE,
+    ];
+    for f in files.iter() {
+        if !Path::new(f).exists() {
+            panic!("file doesn't exist: {}", f);
+        }
+    }
 }


### PR DESCRIPTION
All e-calls into the enclave are abstracted away behind traits that are part of the separate 'enclave-api' crate.

The entire e-call interface is split up into multiple traits.

Is based on #312 and requires that PR to be merged first.

- [x] Merge #312
- [x] Re-target this PR to master
- [ ] Rebase this branch onto master and merge