### PR TITLE
Move WorkerRequest and WorkerResponse to worker primitives

### DIFF
--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -31,10 +31,7 @@ extern crate sgx_tstd as std;
 use crate::{
 	error::{Error, Result},
 	ocall::{
-		ocall_api::{
-			EnclaveAttestationOCallApi, EnclaveOnChainOCallApi, EnclaveRpcOCallApi, WorkerRequest,
-			WorkerResponse,
-		},
+		ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi, EnclaveRpcOCallApi},
 		ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
 		rpc_ocall::EnclaveRpcOCall,
 	},
@@ -84,7 +81,7 @@ use substratee_stf::{
 };
 use substratee_worker_primitives::{
 	block::{Block as SidechainBlock, SignedBlock as SignedSidechainBlock},
-	BlockHash,
+	BlockHash, WorkerRequest, WorkerResponse,
 };
 use utils::write_slice_and_whitespace_pad;
 

--- a/enclave/src/ocall/ocall_api.rs
+++ b/enclave/src/ocall/ocall_api.rs
@@ -20,7 +20,8 @@ use core::fmt::Debug;
 use sgx_types::*;
 use std::vec::Vec;
 use substratee_worker_primitives::{
-	block::SignedBlock as SignedSidechainBlock, TrustedOperationStatus,
+	block::SignedBlock as SignedSidechainBlock, TrustedOperationStatus, WorkerRequest,
+	WorkerResponse,
 };
 
 /// Trait for the enclave to make o-calls related to remote attestation
@@ -56,19 +57,6 @@ pub trait EnclaveRpcOCallApi: Clone + Debug + Send + Sync + Default {
 	) -> SgxResult<()>;
 
 	fn send_state<H: Encode>(&self, hash: H, value_opt: Option<Vec<u8>>) -> SgxResult<()>;
-}
-
-pub type Hash = sp_core::H256;
-
-// TODO: this is redundantly defined in worker/src/main.rs
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
-pub enum WorkerRequest {
-	ChainStorage(Vec<u8>, Option<Hash>), // (storage_key, at_block)
-}
-
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
-pub enum WorkerResponse<V: Encode + Decode> {
-	ChainStorage(Vec<u8>, Option<V>, Option<Vec<Vec<u8>>>), // (storage_key, storage_value, storage_proof)
 }
 
 /// trait for o-calls related to on-chain interactions

--- a/enclave/src/ocall/on_chain_ocall.rs
+++ b/enclave/src/ocall/on_chain_ocall.rs
@@ -17,17 +17,16 @@
 */
 
 use crate::{
-	ocall::{
-		ffi,
-		ocall_api::{EnclaveOnChainOCallApi, WorkerRequest, WorkerResponse},
-	},
+	ocall::{ffi, ocall_api::EnclaveOnChainOCallApi},
 	rpc::author::alloc::prelude::v1::Vec,
 };
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use log::*;
 use sgx_types::*;
-use substratee_worker_primitives::block::SignedBlock as SignedSidechainBlock;
+use substratee_worker_primitives::{
+	block::SignedBlock as SignedSidechainBlock, WorkerRequest, WorkerResponse,
+};
 
 #[derive(Clone, Debug)]
 pub struct EnclaveOnChainOCall;

--- a/enclave/src/test/on_chain_ocall_tests.rs
+++ b/enclave/src/test/on_chain_ocall_tests.rs
@@ -17,12 +17,13 @@
 */
 
 use crate::ocall::{
-	ocall_api::{EnclaveOnChainOCallApi, WorkerRequest, WorkerResponse},
+	ocall_api::EnclaveOnChainOCallApi,
 	ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
 };
 use log::*;
 use std::vec::Vec;
 use substrate_api_client::utils::storage_key;
+use substratee_worker_primitives::{WorkerRequest, WorkerResponse};
 
 #[allow(unused)]
 fn test_ocall_worker_request() {

--- a/primitives/worker/src/lib.rs
+++ b/primitives/worker/src/lib.rs
@@ -102,3 +102,13 @@ impl RpcRequest {
 		serde_json::to_string(&direct_invocation_call).unwrap()
 	}
 }
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+pub enum WorkerRequest {
+	ChainStorage(Vec<u8>, Option<BlockHash>), // (storage_key, at_block)
+}
+
+#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+pub enum WorkerResponse<V: Encode + Decode> {
+	ChainStorage(Vec<u8>, Option<V>, Option<Vec<Vec<u8>>>), // (storage_key, storage_value, storage_proof)
+}

--- a/worker/src/main.rs
+++ b/worker/src/main.rs
@@ -640,13 +640,3 @@ fn ensure_account_has_funds(api: &mut Api<sr25519::Pair>, accountid: &AccountId3
 		api.signer = signer_orig;
 	}
 }
-
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
-pub enum WorkerRequest {
-	ChainStorage(Vec<u8>, Option<Hash>), // (storage_key, at_block)
-}
-
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
-pub enum WorkerResponse<V: Encode + Decode> {
-	ChainStorage(Vec<u8>, Option<V>, Option<Vec<Vec<u8>>>), // (storage_key, storage_value, storage_proof)
-}

--- a/worker/src/ocall_bridge/worker_on_chain_ocall.rs
+++ b/worker/src/ocall_bridge/worker_on_chain_ocall.rs
@@ -21,7 +21,6 @@ use crate::{
 	ocall_bridge::bridge_api::{OCallBridgeError, OCallBridgeResult, WorkerOnChainBridge},
 	sync_block_gossiper::GossipBlocks,
 	utils::hex_encode,
-	WorkerRequest, WorkerResponse,
 };
 use codec::{Decode, Encode};
 use log::*;
@@ -31,7 +30,9 @@ use std::{
 	vec::Vec,
 };
 use substrate_api_client::XtStatus;
-use substratee_worker_primitives::block::SignedBlock as SignedSidechainBlock;
+use substratee_worker_primitives::{
+	block::SignedBlock as SignedSidechainBlock, WorkerRequest, WorkerResponse,
+};
 
 pub struct WorkerOnChainOCall<F, S> {
 	node_api_factory: Arc<F>,


### PR DESCRIPTION
Allows us to share the definitions, and remove the duplicates in the untrusted worker and enclave

Closes #142