### PR TITLE
Introduce 'test' feature, endow accounts in STF only in test feature

### DIFF
--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["staticlib"]
 [features]
 default = []
 production = ['substratee-settings/production']
+test = ['substratee-stf/test']
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 sgx_tse       = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }

--- a/enclave/Makefile
+++ b/enclave/Makefile
@@ -38,6 +38,12 @@ else
 	CARGO_TARGET := --release
 endif
 
+ifeq ($(SGX_PRODUCTION), 1)
+	ENCLAVE_FEATURES =
+else
+	ENCLAVE_FEATURES = --features=test
+endif
+
 .PHONY: all
 
 all: $(Rust_Enclave_Name)
@@ -47,6 +53,6 @@ ifeq ($(XARGO_SGX), 1)
 	RUST_TARGET_PATH=$(Rust_Target_Path) xargo build --target x86_64-unknown-linux-sgx $(CARGO_TARGET)
 	cp ./target/x86_64-unknown-linux-sgx/$(OUTPUT_PATH)/libsubstratee_worker_enclave.a ../lib/libenclave.a
 else
-	cargo build $(CARGO_TARGET)
+	cargo build $(CARGO_TARGET) $(ENCLAVE_FEATURES)
 	cp ./target/$(OUTPUT_PATH)/libsubstratee_worker_enclave.a ../lib/libenclave.a
 endif

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -75,7 +75,8 @@ use substratee_settings::{
 	},
 };
 use substratee_stf::{
-	sgx::{shards_key_hash, storage_hashes_to_update_per_shard, OpaqueCall},
+	stf_sgx::OpaqueCall,
+	stf_sgx_primitives::{shards_key_hash, storage_hashes_to_update_per_shard},
 	AccountId, Getter, ShardIdentifier, State as StfState, StatePayload, Stf, TrustedCall,
 	TrustedCallSigned, TrustedGetterSigned,
 };
@@ -102,8 +103,21 @@ pub mod rpc;
 pub mod tls_ra;
 pub mod top_pool;
 
+#[cfg(feature = "test")]
 pub mod test;
+
+#[cfg(feature = "test")]
 pub mod tests;
+
+#[cfg(not(feature = "test"))]
+use sgx_types::size_t;
+
+// this is a 'dummy' for production mode
+#[cfg(not(feature = "test"))]
+#[no_mangle]
+pub extern "C" fn test_main_entrance() -> size_t {
+	unreachable!("Tests are not available when compiled in production mode.")
+}
 
 pub const CERTEXPIRYDAYS: i64 = 90i64;
 

--- a/enclave/src/tests.rs
+++ b/enclave/src/tests.rs
@@ -58,30 +58,30 @@ use substratee_stf::{
 #[no_mangle]
 pub extern "C" fn test_main_entrance() -> size_t {
 	rsgx_unit_tests!(
-		top_pool::base_pool::test_should_import_transaction_to_ready,
-		top_pool::base_pool::test_should_not_import_same_transaction_twice,
-		top_pool::base_pool::test_should_import_transaction_to_future_and_promote_it_later,
-		top_pool::base_pool::test_should_promote_a_subgraph,
-		top_pool::base_pool::test_should_handle_a_cycle,
-		top_pool::base_pool::test_can_track_heap_size,
-		top_pool::base_pool::test_should_handle_a_cycle_with_low_priority,
-		top_pool::base_pool::test_should_remove_invalid_transactions,
-		top_pool::base_pool::test_should_prune_ready_transactions,
-		top_pool::base_pool::test_transaction_debug,
-		top_pool::base_pool::test_transaction_propagation,
-		top_pool::base_pool::test_should_reject_future_transactions,
-		top_pool::base_pool::test_should_clear_future_queue,
-		top_pool::base_pool::test_should_accept_future_transactions_when_explicitly_asked_to,
-		top_pool::primitives::test_h256,
-		top_pool::pool::test_should_validate_and_import_transaction,
-		top_pool::pool::test_should_reject_if_temporarily_banned,
-		top_pool::pool::test_should_notify_about_pool_events,
-		top_pool::pool::test_should_clear_stale_transactions,
-		top_pool::pool::test_should_ban_mined_transactions,
+		top_pool::base_pool::tests::test_should_import_transaction_to_ready,
+		top_pool::base_pool::tests::test_should_not_import_same_transaction_twice,
+		top_pool::base_pool::tests::test_should_import_transaction_to_future_and_promote_it_later,
+		top_pool::base_pool::tests::test_should_promote_a_subgraph,
+		top_pool::base_pool::tests::test_should_handle_a_cycle,
+		top_pool::base_pool::tests::test_can_track_heap_size,
+		top_pool::base_pool::tests::test_should_handle_a_cycle_with_low_priority,
+		top_pool::base_pool::tests::test_should_remove_invalid_transactions,
+		top_pool::base_pool::tests::test_should_prune_ready_transactions,
+		top_pool::base_pool::tests::test_transaction_debug,
+		top_pool::base_pool::tests::test_transaction_propagation,
+		top_pool::base_pool::tests::test_should_reject_future_transactions,
+		top_pool::base_pool::tests::test_should_clear_future_queue,
+		top_pool::base_pool::tests::test_should_accept_future_transactions_when_explicitly_asked_to,
+		top_pool::primitives::tests::test_h256,
+		top_pool::pool::tests::test_should_validate_and_import_transaction,
+		top_pool::pool::tests::test_should_reject_if_temporarily_banned,
+		top_pool::pool::tests::test_should_notify_about_pool_events,
+		top_pool::pool::tests::test_should_clear_stale_transactions,
+		top_pool::pool::tests::test_should_ban_mined_transactions,
 		//FIXME: This test sometimes fails, sometimes succeeds..
 		//top_pool::pool::test_should_limit_futures,
-		top_pool::pool::test_should_error_if_reject_immediately,
-		top_pool::pool::test_should_reject_transactions_with_no_provides,
+		top_pool::pool::tests::test_should_error_if_reject_immediately,
+		top_pool::pool::tests::test_should_reject_transactions_with_no_provides,
 		top_pool::ready::tests::test_should_replace_transaction_that_provides_the_same_tag,
 		top_pool::ready::tests::test_should_replace_multiple_transactions_correctly,
 		top_pool::ready::tests::test_should_return_best_transactions_in_correct_order,
@@ -91,9 +91,9 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		top_pool::rotator::tests::test_should_clear_banned,
 		top_pool::rotator::tests::test_should_garbage_collect,
 		top_pool::tracked_map::tests::test_basic,
-		state::test_write_and_load_state_works,
-		state::test_sgx_state_decode_encode_works,
-		state::test_encrypt_decrypt_state_type_works,
+		state::tests::test_write_and_load_state_works,
+		state::tests::test_sgx_state_decode_encode_works,
+		state::tests::test_encrypt_decrypt_state_type_works,
 		test_time_is_overdue,
 		test_time_is_not_overdue,
 		test_compose_block_and_confirmation,
@@ -107,9 +107,9 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		test_executing_call_updates_account_nonce,
 		test_invalid_nonce_call_is_not_executed,
 		test_non_root_shielding_call_is_not_executed,
-		substratee_stf::sgx::tests::apply_state_diff_works,
-		substratee_stf::sgx::tests::apply_state_diff_returns_storage_hash_mismatch_err,
-		substratee_stf::sgx::tests::apply_state_diff_returns_invalid_storage_diff_err,
+		substratee_stf::stf_sgx::tests::apply_state_diff_works,
+		substratee_stf::stf_sgx::tests::apply_state_diff_returns_storage_hash_mismatch_err,
+		substratee_stf::stf_sgx::tests::apply_state_diff_returns_invalid_storage_diff_err,
 		rpc::worker_api_direct::tests::sidechain_import_block_is_ok,
 		rpc::worker_api_direct::tests::sidechain_import_block_returns_invalid_param_err,
 		rpc::worker_api_direct::tests::sidechain_import_block_returns_decode_err,
@@ -200,7 +200,7 @@ fn test_compose_block_and_confirmation() {
 	assert!(stripped_opaque_call.starts_with(&block_hash_encoded));
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -252,7 +252,7 @@ fn test_submit_trusted_call_to_top_pool() {
 	assert_eq!(call_one, call_two);
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -297,7 +297,7 @@ fn test_submit_trusted_getter_to_top_pool() {
 	assert_eq!(getter_one, getter_two);
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -366,7 +366,7 @@ fn test_differentiate_getter_and_call_works() {
 	assert_eq!(getter_one, getter_two);
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -451,7 +451,7 @@ fn test_create_block_and_confirmation_works() {
 	assert!(stripped_opaque_call.starts_with(&block_hash_encoded));
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -480,9 +480,9 @@ fn test_create_state_diff() {
 	let account_with_money = pair_with_money.public();
 	let account_without_money = signer_without_money.public();
 	let account_with_money_key_hash =
-		substratee_stf::sgx::account_key_hash(&account_with_money.into());
+		substratee_stf::stf_sgx_primitives::account_key_hash(&account_with_money.into());
 	let account_without_money_key_hash =
-		substratee_stf::sgx::account_key_hash(&account_without_money.into());
+		substratee_stf::stf_sgx_primitives::account_key_hash(&account_without_money.into());
 
 	let _prev_state_hash = state::write(state, &shard).unwrap();
 	// load top pool
@@ -538,7 +538,8 @@ fn test_create_state_diff() {
 	let new_balance_acc_wo_money =
 		AccountInfo::decode(&mut acc_info_vec.as_slice()).unwrap().data.free;
 	// get block number
-	let block_number_key = substratee_stf::sgx::storage_value_key("System", "Number");
+	let block_number_key =
+		substratee_stf::stf_sgx_primitives::storage_value_key("System", "Number");
 	let new_block_number_encoded = state_diff.get(&block_number_key).unwrap().as_ref().unwrap();
 	let new_block_number =
 		substratee_worker_primitives::BlockNumber::decode(&mut new_block_number_encoded.as_slice())
@@ -549,7 +550,7 @@ fn test_create_state_diff() {
 	assert_eq!(new_block_number, 1);
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -576,9 +577,9 @@ fn test_executing_call_updates_account_nonce() {
 	let account_with_money = pair_with_money.public();
 	let account_without_money = signer_without_money.public();
 	let account_with_money_key_hash =
-		substratee_stf::sgx::account_key_hash(&account_with_money.into());
+		substratee_stf::stf_sgx_primitives::account_key_hash(&account_with_money.into());
 	let account_without_money_key_hash =
-		substratee_stf::sgx::account_key_hash(&account_without_money.into());
+		substratee_stf::stf_sgx_primitives::account_key_hash(&account_without_money.into());
 
 	let _prev_state_hash = state::write(state, &shard).unwrap();
 	// load top pool
@@ -628,7 +629,7 @@ fn test_executing_call_updates_account_nonce() {
 	assert_eq!(nonce, 1);
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -655,9 +656,9 @@ fn test_invalid_nonce_call_is_not_executed() {
 	let account_with_money = pair_with_money.public();
 	let account_without_money = signer_without_money.public();
 	let account_with_money_key_hash =
-		substratee_stf::sgx::account_key_hash(&account_with_money.into());
+		substratee_stf::stf_sgx_primitives::account_key_hash(&account_with_money.into());
 	let account_without_money_key_hash =
-		substratee_stf::sgx::account_key_hash(&account_without_money.into());
+		substratee_stf::stf_sgx_primitives::account_key_hash(&account_without_money.into());
 
 	let _prev_state_hash = state::write(state, &shard).unwrap();
 	// load top pool
@@ -711,7 +712,7 @@ fn test_invalid_nonce_call_is_not_executed() {
 	assert_eq!(acc_data_with_money.free, 2000);
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 #[allow(unused)]
@@ -780,7 +781,7 @@ fn test_non_root_shielding_call_is_not_executed() {
 	assert_eq!(new_acc_money, prev_acc_money);
 
 	// clean up
-	state::remove_shard_dir(&shard);
+	state::tests::remove_shard_dir(&shard);
 }
 
 fn get_current_shard_index(shard: &ShardIdentifier) -> usize {

--- a/enclave/src/top_pool/base_pool.rs
+++ b/enclave/src/top_pool/base_pool.rs
@@ -570,198 +570,459 @@ impl Limit {
 }
 
 /// Tests
-use alloc::borrow::ToOwned;
+#[cfg(feature = "test")]
+pub mod tests {
 
-type Hash = u64;
+	use super::*;
+	use alloc::borrow::ToOwned;
 
-fn test_pool() -> BasePool<Hash, Vec<u8>> {
-	BasePool::default()
-}
+	type Hash = u64;
 
-pub fn test_should_import_transaction_to_ready() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
+	fn test_pool() -> BasePool<Hash, Vec<u8>> {
+		BasePool::default()
+	}
 
-	// when
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1u64,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
+	pub fn test_should_import_transaction_to_ready() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
 
-	// then
-	assert_eq!(pool.ready(shard).count(), 1);
-	assert_eq!(pool.ready.len(shard), 1);
-}
+		// when
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1u64,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
 
-pub fn test_should_not_import_same_transaction_twice() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
+		// then
+		assert_eq!(pool.ready(shard).count(), 1);
+		assert_eq!(pool.ready.len(shard), 1);
+	}
 
-	// when
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap_err();
+	pub fn test_should_not_import_same_transaction_twice() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
 
-	// then
-	assert_eq!(pool.ready(shard).count(), 1);
-	assert_eq!(pool.ready.len(shard), 1);
-}
+		// when
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap_err();
 
-pub fn test_should_import_transaction_to_future_and_promote_it_later() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
+		// then
+		assert_eq!(pool.ready(shard).count(), 1);
+		assert_eq!(pool.ready.len(shard), 1);
+	}
 
-	// when
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	assert_eq!(pool.ready(shard).count(), 0);
-	assert_eq!(pool.ready.len(shard), 0);
-	pool.import(
-		TrustedOperation {
-			data: vec![2u8],
-			bytes: 1,
-			hash: 2,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![0]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
+	pub fn test_should_import_transaction_to_future_and_promote_it_later() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
 
-	// then
-	assert_eq!(pool.ready(shard).count(), 2);
-	assert_eq!(pool.ready.len(shard), 2);
-}
+		// when
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![0]],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		assert_eq!(pool.ready(shard).count(), 0);
+		assert_eq!(pool.ready.len(shard), 0);
+		pool.import(
+			TrustedOperation {
+				data: vec![2u8],
+				bytes: 1,
+				hash: 2,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![],
+				provides: vec![vec![0]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
 
-pub fn test_should_promote_a_subgraph() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
+		// then
+		assert_eq!(pool.ready(shard).count(), 2);
+		assert_eq!(pool.ready.len(shard), 2);
+	}
 
-	// when
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![3u8],
-			bytes: 1,
-			hash: 3,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![2]],
-			provides: vec![],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![2u8],
-			bytes: 1,
-			hash: 2,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![1]],
-			provides: vec![vec![3], vec![2]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![4u8],
-			bytes: 1,
-			hash: 4,
-			priority: 1_000u64,
-			valid_till: 64u64,
-			requires: vec![vec![3], vec![4]],
-			provides: vec![],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	assert_eq!(pool.ready(shard).count(), 0);
-	assert_eq!(pool.ready.len(shard), 0);
+	pub fn test_should_promote_a_subgraph() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
 
-	let res = pool
-		.import(
+		// when
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![0]],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![3u8],
+				bytes: 1,
+				hash: 3,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![2]],
+				provides: vec![],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![2u8],
+				bytes: 1,
+				hash: 2,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![1]],
+				provides: vec![vec![3], vec![2]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![4u8],
+				bytes: 1,
+				hash: 4,
+				priority: 1_000u64,
+				valid_till: 64u64,
+				requires: vec![vec![3], vec![4]],
+				provides: vec![],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		assert_eq!(pool.ready(shard).count(), 0);
+		assert_eq!(pool.ready.len(shard), 0);
+
+		let res = pool
+			.import(
+				TrustedOperation {
+					data: vec![5u8],
+					bytes: 1,
+					hash: 5,
+					priority: 5u64,
+					valid_till: 64u64,
+					requires: vec![],
+					provides: vec![vec![0], vec![4]],
+					propagate: true,
+					source: Source::External,
+				},
+				shard,
+			)
+			.unwrap();
+
+		// then
+		let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
+
+		assert_eq!(it.next(), Some(5));
+		assert_eq!(it.next(), Some(1));
+		assert_eq!(it.next(), Some(2));
+		assert_eq!(it.next(), Some(4));
+		assert_eq!(it.next(), Some(3));
+		assert_eq!(it.next(), None);
+		assert_eq!(
+			res,
+			Imported::Ready {
+				hash: 5,
+				promoted: vec![1, 2, 3, 4],
+				failed: vec![],
+				removed: vec![]
+			}
+		);
+	}
+
+	pub fn test_should_handle_a_cycle() {
+		// given
+		let shard = ShardIdentifier::default();
+		let mut pool = test_pool();
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![0]],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![3u8],
+				bytes: 1,
+				hash: 3,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![1]],
+				provides: vec![vec![2]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		assert_eq!(pool.ready(shard).count(), 0);
+		assert_eq!(pool.ready.len(shard), 0);
+
+		// when
+		pool.import(
+			TrustedOperation {
+				data: vec![2u8],
+				bytes: 1,
+				hash: 2,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![2]],
+				provides: vec![vec![0]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+
+		// then
+		{
+			let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
+			assert_eq!(it.next(), None);
+		}
+		// all operations occupy the Future queue - it's fine
+		assert_eq!(pool.future.len(shard), 3);
+
+		// let's close the cycle with one additional operation
+		let res = pool
+			.import(
+				TrustedOperation {
+					data: vec![4u8],
+					bytes: 1,
+					hash: 4,
+					priority: 50u64,
+					valid_till: 64u64,
+					requires: vec![],
+					provides: vec![vec![0]],
+					propagate: true,
+					source: Source::External,
+				},
+				shard,
+			)
+			.unwrap();
+		let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
+		assert_eq!(it.next(), Some(4));
+		assert_eq!(it.next(), Some(1));
+		assert_eq!(it.next(), Some(3));
+		assert_eq!(it.next(), None);
+		assert_eq!(
+			res,
+			Imported::Ready { hash: 4, promoted: vec![1, 3], failed: vec![2], removed: vec![] }
+		);
+		assert_eq!(pool.future.len(shard), 0);
+	}
+
+	pub fn test_should_handle_a_cycle_with_low_priority() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![0]],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![3u8],
+				bytes: 1,
+				hash: 3,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![1]],
+				provides: vec![vec![2]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		assert_eq!(pool.ready(shard).count(), 0);
+		assert_eq!(pool.ready.len(shard), 0);
+
+		// when
+		pool.import(
+			TrustedOperation {
+				data: vec![2u8],
+				bytes: 1,
+				hash: 2,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![2]],
+				provides: vec![vec![0]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+
+		// then
+		{
+			let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
+			assert_eq!(it.next(), None);
+		}
+		// all operations occupy the Future queue - it's fine
+		assert_eq!(pool.future.len(shard), 3);
+
+		// let's close the cycle with one additional operation
+		let err = pool
+			.import(
+				TrustedOperation {
+					data: vec![4u8],
+					bytes: 1,
+					hash: 4,
+					priority: 1u64, // lower priority than Tx(2)
+					valid_till: 64u64,
+					requires: vec![],
+					provides: vec![vec![0]],
+					propagate: true,
+					source: Source::External,
+				},
+				shard,
+			)
+			.unwrap_err();
+		let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
+		assert_eq!(it.next(), None);
+		assert_eq!(pool.ready.len(shard), 0);
+		assert_eq!(pool.future.len(shard), 0);
+		if let error::Error::CycleDetected = err {
+		} else {
+			assert!(false, "Invalid error kind: {:?}", err);
+		}
+	}
+
+	pub fn test_can_track_heap_size() {
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
+		pool.import(
+			TrustedOperation {
+				data: vec![5u8; 1024],
+				bytes: 1,
+				hash: 5,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![],
+				provides: vec![vec![0], vec![4]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.expect("import 1 should be ok");
+		pool.import(
+			TrustedOperation {
+				data: vec![3u8; 1024],
+				bytes: 1,
+				hash: 7,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![],
+				provides: vec![vec![2], vec![7]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.expect("import 2 should be ok");
+
+		//assert!(parity_util_mem::malloc_size(&pool) > 5000);
+	}
+
+	pub fn test_should_remove_invalid_transactions() {
+		// given
+		let shard = ShardIdentifier::default();
+		let mut pool = test_pool();
+		pool.import(
 			TrustedOperation {
 				data: vec![5u8],
 				bytes: 1,
@@ -776,450 +1037,160 @@ pub fn test_should_promote_a_subgraph() {
 			shard,
 		)
 		.unwrap();
-
-	// then
-	let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
-
-	assert_eq!(it.next(), Some(5));
-	assert_eq!(it.next(), Some(1));
-	assert_eq!(it.next(), Some(2));
-	assert_eq!(it.next(), Some(4));
-	assert_eq!(it.next(), Some(3));
-	assert_eq!(it.next(), None);
-	assert_eq!(
-		res,
-		Imported::Ready { hash: 5, promoted: vec![1, 2, 3, 4], failed: vec![], removed: vec![] }
-	);
-}
-
-pub fn test_should_handle_a_cycle() {
-	// given
-	let shard = ShardIdentifier::default();
-	let mut pool = test_pool();
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![3u8],
-			bytes: 1,
-			hash: 3,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![1]],
-			provides: vec![vec![2]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	assert_eq!(pool.ready(shard).count(), 0);
-	assert_eq!(pool.ready.len(shard), 0);
-
-	// when
-	pool.import(
-		TrustedOperation {
-			data: vec![2u8],
-			bytes: 1,
-			hash: 2,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![2]],
-			provides: vec![vec![0]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-
-	// then
-	{
-		let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
-		assert_eq!(it.next(), None);
-	}
-	// all operations occupy the Future queue - it's fine
-	assert_eq!(pool.future.len(shard), 3);
-
-	// let's close the cycle with one additional operation
-	let res = pool
-		.import(
+		pool.import(
 			TrustedOperation {
-				data: vec![4u8],
+				data: vec![1u8],
 				bytes: 1,
-				hash: 4,
-				priority: 50u64,
+				hash: 1,
+				priority: 5u64,
 				valid_till: 64u64,
-				requires: vec![],
-				provides: vec![vec![0]],
+				requires: vec![vec![0]],
+				provides: vec![vec![1]],
 				propagate: true,
 				source: Source::External,
 			},
 			shard,
 		)
 		.unwrap();
-	let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
-	assert_eq!(it.next(), Some(4));
-	assert_eq!(it.next(), Some(1));
-	assert_eq!(it.next(), Some(3));
-	assert_eq!(it.next(), None);
-	assert_eq!(
-		res,
-		Imported::Ready { hash: 4, promoted: vec![1, 3], failed: vec![2], removed: vec![] }
-	);
-	assert_eq!(pool.future.len(shard), 0);
-}
-
-pub fn test_should_handle_a_cycle_with_low_priority() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![3u8],
-			bytes: 1,
-			hash: 3,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![1]],
-			provides: vec![vec![2]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	assert_eq!(pool.ready(shard).count(), 0);
-	assert_eq!(pool.ready.len(shard), 0);
-
-	// when
-	pool.import(
-		TrustedOperation {
-			data: vec![2u8],
-			bytes: 1,
-			hash: 2,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![2]],
-			provides: vec![vec![0]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-
-	// then
-	{
-		let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
-		assert_eq!(it.next(), None);
-	}
-	// all operations occupy the Future queue - it's fine
-	assert_eq!(pool.future.len(shard), 3);
-
-	// let's close the cycle with one additional operation
-	let err = pool
-		.import(
+		pool.import(
 			TrustedOperation {
-				data: vec![4u8],
+				data: vec![3u8],
 				bytes: 1,
-				hash: 4,
-				priority: 1u64, // lower priority than Tx(2)
+				hash: 3,
+				priority: 5u64,
 				valid_till: 64u64,
-				requires: vec![],
-				provides: vec![vec![0]],
+				requires: vec![vec![2]],
+				provides: vec![],
 				propagate: true,
 				source: Source::External,
 			},
 			shard,
 		)
-		.unwrap_err();
-	let mut it = pool.ready(shard).into_iter().map(|tx| tx.data[0]);
-	assert_eq!(it.next(), None);
-	assert_eq!(pool.ready.len(shard), 0);
-	assert_eq!(pool.future.len(shard), 0);
-	if let error::Error::CycleDetected = err {
-	} else {
-		assert!(false, "Invalid error kind: {:?}", err);
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![2u8],
+				bytes: 1,
+				hash: 2,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![1]],
+				provides: vec![vec![3], vec![2]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![4u8],
+				bytes: 1,
+				hash: 4,
+				priority: 1_000u64,
+				valid_till: 64u64,
+				requires: vec![vec![3], vec![4]],
+				provides: vec![],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		// future
+		pool.import(
+			TrustedOperation {
+				data: vec![6u8],
+				bytes: 1,
+				hash: 6,
+				priority: 1_000u64,
+				valid_till: 64u64,
+				requires: vec![vec![11]],
+				provides: vec![],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		assert_eq!(pool.ready(shard).count(), 5);
+		assert_eq!(pool.future.len(shard), 1);
+
+		// when
+		pool.remove_subtree(&[6, 1], shard);
+
+		// then
+		assert_eq!(pool.ready(shard).count(), 1);
+		assert_eq!(pool.future.len(shard), 0);
 	}
-}
 
-pub fn test_can_track_heap_size() {
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
-	pool.import(
-		TrustedOperation {
-			data: vec![5u8; 1024],
-			bytes: 1,
-			hash: 5,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![0], vec![4]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.expect("import 1 should be ok");
-	pool.import(
-		TrustedOperation {
-			data: vec![3u8; 1024],
-			bytes: 1,
-			hash: 7,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![2], vec![7]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.expect("import 2 should be ok");
-
-	//assert!(parity_util_mem::malloc_size(&pool) > 5000);
-}
-
-pub fn test_should_remove_invalid_transactions() {
-	// given
-	let shard = ShardIdentifier::default();
-	let mut pool = test_pool();
-	pool.import(
-		TrustedOperation {
-			data: vec![5u8],
-			bytes: 1,
-			hash: 5,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![0], vec![4]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![3u8],
-			bytes: 1,
-			hash: 3,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![2]],
-			provides: vec![],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![2u8],
-			bytes: 1,
-			hash: 2,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![1]],
-			provides: vec![vec![3], vec![2]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![4u8],
-			bytes: 1,
-			hash: 4,
-			priority: 1_000u64,
-			valid_till: 64u64,
-			requires: vec![vec![3], vec![4]],
-			provides: vec![],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	// future
-	pool.import(
-		TrustedOperation {
-			data: vec![6u8],
-			bytes: 1,
-			hash: 6,
-			priority: 1_000u64,
-			valid_till: 64u64,
-			requires: vec![vec![11]],
-			provides: vec![],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	assert_eq!(pool.ready(shard).count(), 5);
-	assert_eq!(pool.future.len(shard), 1);
-
-	// when
-	pool.remove_subtree(&[6, 1], shard);
-
-	// then
-	assert_eq!(pool.ready(shard).count(), 1);
-	assert_eq!(pool.future.len(shard), 0);
-}
-
-pub fn test_should_prune_ready_transactions() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
-	// future (waiting for 0)
-	pool.import(
-		TrustedOperation {
-			data: vec![5u8],
-			bytes: 1,
-			hash: 5,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![vec![100]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	// ready
-	pool.import(
-		TrustedOperation {
-			data: vec![1u8],
-			bytes: 1,
-			hash: 1,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![],
-			provides: vec![vec![1]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![2u8],
-			bytes: 1,
-			hash: 2,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![2]],
-			provides: vec![vec![3]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![3u8],
-			bytes: 1,
-			hash: 3,
-			priority: 5u64,
-			valid_till: 64u64,
-			requires: vec![vec![1]],
-			provides: vec![vec![2]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-	pool.import(
-		TrustedOperation {
-			data: vec![4u8],
-			bytes: 1,
-			hash: 4,
-			priority: 1_000u64,
-			valid_till: 64u64,
-			requires: vec![vec![3], vec![2]],
-			provides: vec![vec![4]],
-			propagate: true,
-			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
-
-	assert_eq!(pool.ready(shard).count(), 4);
-	assert_eq!(pool.future.len(shard), 1);
-
-	// when
-	let result = pool.prune_tags(vec![vec![0], vec![2]], shard);
-
-	// then
-	assert_eq!(result.pruned.len(), 2);
-	assert_eq!(result.failed.len(), 0);
-	assert_eq!(
-		result.promoted[0],
-		Imported::Ready { hash: 5, promoted: vec![], failed: vec![], removed: vec![] }
-	);
-	assert_eq!(result.promoted.len(), 1);
-	assert_eq!(pool.future.len(shard), 0);
-	assert_eq!(pool.ready.len(shard), 3);
-	assert_eq!(pool.ready(shard).count(), 3);
-}
-
-pub fn test_transaction_debug() {
-	assert_eq!(
-		format!(
-			"{:?}",
+	pub fn test_should_prune_ready_transactions() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
+		// future (waiting for 0)
+		pool.import(
+			TrustedOperation {
+				data: vec![5u8],
+				bytes: 1,
+				hash: 5,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![0]],
+				provides: vec![vec![100]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		// ready
+		pool.import(
+			TrustedOperation {
+				data: vec![1u8],
+				bytes: 1,
+				hash: 1,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![],
+				provides: vec![vec![1]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![2u8],
+				bytes: 1,
+				hash: 2,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![2]],
+				provides: vec![vec![3]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
+			TrustedOperation {
+				data: vec![3u8],
+				bytes: 1,
+				hash: 3,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![1]],
+				provides: vec![vec![2]],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		)
+		.unwrap();
+		pool.import(
 			TrustedOperation {
 				data: vec![4u8],
 				bytes: 1,
@@ -1230,113 +1201,117 @@ pub fn test_transaction_debug() {
 				provides: vec![vec![4]],
 				propagate: true,
 				source: Source::External,
-			}
-		),
-		"TrustedOperation { \
+			},
+			shard,
+		)
+		.unwrap();
+
+		assert_eq!(pool.ready(shard).count(), 4);
+		assert_eq!(pool.future.len(shard), 1);
+
+		// when
+		let result = pool.prune_tags(vec![vec![0], vec![2]], shard);
+
+		// then
+		assert_eq!(result.pruned.len(), 2);
+		assert_eq!(result.failed.len(), 0);
+		assert_eq!(
+			result.promoted[0],
+			Imported::Ready { hash: 5, promoted: vec![], failed: vec![], removed: vec![] }
+		);
+		assert_eq!(result.promoted.len(), 1);
+		assert_eq!(pool.future.len(shard), 0);
+		assert_eq!(pool.ready.len(shard), 3);
+		assert_eq!(pool.ready(shard).count(), 3);
+	}
+
+	pub fn test_transaction_debug() {
+		assert_eq!(
+			format!(
+				"{:?}",
+				TrustedOperation {
+					data: vec![4u8],
+					bytes: 1,
+					hash: 4,
+					priority: 1_000u64,
+					valid_till: 64u64,
+					requires: vec![vec![3], vec![2]],
+					provides: vec![vec![4]],
+					propagate: true,
+					source: Source::External,
+				}
+			),
+			"TrustedOperation { \
 hash: 4, priority: 1000, valid_till: 64, bytes: 1, propagate: true, \
 source: External, requires: [03,02], provides: [04], data: [4]}"
-			.to_owned()
-	);
-}
-
-pub fn test_transaction_propagation() {
-	assert!(TrustedOperation {
-		data: vec![4u8],
-		bytes: 1,
-		hash: 4,
-		priority: 1_000u64,
-		valid_till: 64u64,
-		requires: vec![vec![3], vec![2]],
-		provides: vec![vec![4]],
-		propagate: true,
-		source: Source::External,
+				.to_owned()
+		);
 	}
-	.is_propagable());
 
-	assert!(!TrustedOperation {
-		data: vec![4u8],
-		bytes: 1,
-		hash: 4,
-		priority: 1_000u64,
-		valid_till: 64u64,
-		requires: vec![vec![3], vec![2]],
-		provides: vec![vec![4]],
-		propagate: false,
-		source: Source::External,
-	}
-	.is_propagable());
-}
-
-pub fn test_should_reject_future_transactions() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
-
-	// when
-	pool.reject_future_operations = true;
-
-	// then
-	let err = pool.import(
-		TrustedOperation {
-			data: vec![5u8],
+	pub fn test_transaction_propagation() {
+		assert!(TrustedOperation {
+			data: vec![4u8],
 			bytes: 1,
-			hash: 5,
-			priority: 5u64,
+			hash: 4,
+			priority: 1_000u64,
 			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![],
+			requires: vec![vec![3], vec![2]],
+			provides: vec![vec![4]],
 			propagate: true,
 			source: Source::External,
-		},
-		shard,
-	);
+		}
+		.is_propagable());
 
-	if let Err(error::Error::RejectedFutureTrustedOperation) = err {
-	} else {
-		assert!(false, "Invalid error kind: {:?}", err);
-	}
-}
-
-pub fn test_should_clear_future_queue() {
-	// given
-	let mut pool = test_pool();
-	let shard = ShardIdentifier::default();
-
-	// when
-	pool.import(
-		TrustedOperation {
-			data: vec![5u8],
+		assert!(!TrustedOperation {
+			data: vec![4u8],
 			bytes: 1,
-			hash: 5,
-			priority: 5u64,
+			hash: 4,
+			priority: 1_000u64,
 			valid_till: 64u64,
-			requires: vec![vec![0]],
-			provides: vec![],
-			propagate: true,
+			requires: vec![vec![3], vec![2]],
+			provides: vec![vec![4]],
+			propagate: false,
 			source: Source::External,
-		},
-		shard,
-	)
-	.unwrap();
+		}
+		.is_propagable());
+	}
 
-	// then
-	assert_eq!(pool.future.len(shard), 1);
+	pub fn test_should_reject_future_transactions() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
 
-	// and then when
-	assert_eq!(pool.clear_future(shard).len(), 1);
+		// when
+		pool.reject_future_operations = true;
 
-	// then
-	assert_eq!(pool.future.len(shard), 0);
-}
+		// then
+		let err = pool.import(
+			TrustedOperation {
+				data: vec![5u8],
+				bytes: 1,
+				hash: 5,
+				priority: 5u64,
+				valid_till: 64u64,
+				requires: vec![vec![0]],
+				provides: vec![],
+				propagate: true,
+				source: Source::External,
+			},
+			shard,
+		);
 
-pub fn test_should_accept_future_transactions_when_explicitly_asked_to() {
-	// given
-	let mut pool = test_pool();
-	pool.reject_future_operations = true;
-	let shard = ShardIdentifier::default();
+		if let Err(error::Error::RejectedFutureTrustedOperation) = err {
+		} else {
+			assert!(false, "Invalid error kind: {:?}", err);
+		}
+	}
 
-	// when
-	let flag_value = pool.with_futures_enabled(|pool, flag| {
+	pub fn test_should_clear_future_queue() {
+		// given
+		let mut pool = test_pool();
+		let shard = ShardIdentifier::default();
+
+		// when
 		pool.import(
 			TrustedOperation {
 				data: vec![5u8],
@@ -1353,11 +1328,46 @@ pub fn test_should_accept_future_transactions_when_explicitly_asked_to() {
 		)
 		.unwrap();
 
-		flag
-	});
+		// then
+		assert_eq!(pool.future.len(shard), 1);
 
-	// then
-	assert!(flag_value);
-	assert!(pool.reject_future_operations);
-	assert_eq!(pool.future.len(shard), 1);
+		// and then when
+		assert_eq!(pool.clear_future(shard).len(), 1);
+
+		// then
+		assert_eq!(pool.future.len(shard), 0);
+	}
+
+	pub fn test_should_accept_future_transactions_when_explicitly_asked_to() {
+		// given
+		let mut pool = test_pool();
+		pool.reject_future_operations = true;
+		let shard = ShardIdentifier::default();
+
+		// when
+		let flag_value = pool.with_futures_enabled(|pool, flag| {
+			pool.import(
+				TrustedOperation {
+					data: vec![5u8],
+					bytes: 1,
+					hash: 5,
+					priority: 5u64,
+					valid_till: 64u64,
+					requires: vec![vec![0]],
+					provides: vec![],
+					propagate: true,
+					source: Source::External,
+				},
+				shard,
+			)
+			.unwrap();
+
+			flag
+		});
+
+		// then
+		assert!(flag_value);
+		assert!(pool.reject_future_operations);
+		assert_eq!(pool.future.len(shard), 1);
+	}
 }

--- a/enclave/src/top_pool/pool.rs
+++ b/enclave/src/top_pool/pool.rs
@@ -16,54 +16,24 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use core::matches;
-
-use codec::{Decode, Encode};
-use jsonrpc_core::{
-	futures,
-	futures::{channel::mpsc::Receiver, executor::block_on, future, Future},
-};
-use sp_application_crypto::ed25519;
-use sp_core::hash::H256;
-use sp_runtime::{
-	generic::BlockId,
-	traits::{self, Block as BlockT, Extrinsic as ExtrinsicT, Hash, SaturatedConversion, Verify},
-	transaction_validity::{
-		InvalidTransaction as InvalidTrustedOperation, TransactionTag as Tag, TransactionValidity,
-		TransactionValidityError, ValidTransaction,
-	},
-};
-/// test
-///
-/// Extrinsic for test-runtime.
-use std::collections::HashSet;
-use std::{
-	collections::HashMap,
-	sync::{Arc, SgxMutex as Mutex},
-	time::Instant,
-	untrusted::time::InstantEx,
-	vec::Vec,
-};
-
-use substratee_stf::{
-	Index, ShardIdentifier, TrustedCall, TrustedCallSigned,
-	TrustedOperation as StfTrustedOperation, TrustedOperation,
-};
-use substratee_worker_primitives::BlockHash as SidechainBlockHash;
-
 use crate::{
 	ocall::ocall_api::EnclaveRpcOCallApi,
-	test::mocks::enclave_rpc_ocall_mock::EnclaveRpcOCallMock,
 	top_pool::{
-		base_pool as base,
-		base_pool::Limit,
-		error,
+		base_pool as base, error,
 		primitives::TrustedOperationSource,
 		validated_pool::{ValidatedOperation, ValidatedPool},
 	},
 };
-
-use super::primitives::from_low_u64_to_be_h256;
+use core::matches;
+use jsonrpc_core::futures::{channel::mpsc::Receiver, future, Future};
+use sp_runtime::{
+	generic::BlockId,
+	traits::{self, Block as BlockT, SaturatedConversion},
+	transaction_validity::{TransactionTag as Tag, TransactionValidity, TransactionValidityError},
+};
+use std::{collections::HashMap, sync::Arc, time::Instant, untrusted::time::InstantEx, vec::Vec};
+use substratee_stf::{ShardIdentifier, TrustedOperation as StfTrustedOperation};
+use substratee_worker_primitives::BlockHash as SidechainBlockHash;
 
 /// Modification notification event stream type;
 pub type EventStream<H> = Receiver<H>;
@@ -494,10 +464,23 @@ impl<B: ChainApi, R: EnclaveRpcOCallApi> Clone for Pool<B, R> {
 	}
 }
 
-pub mod test {
-	use sp_runtime::traits::BlakeTwo256;
-
+#[cfg(feature = "test")]
+pub mod tests {
 	use super::*;
+	use crate::{
+		test::mocks::enclave_rpc_ocall_mock::EnclaveRpcOCallMock,
+		top_pool::{base_pool::Limit, primitives::from_low_u64_to_be_h256},
+	};
+	use codec::{Decode, Encode};
+	use jsonrpc_core::{futures, futures::executor::block_on};
+	use sp_application_crypto::ed25519;
+	use sp_core::hash::H256;
+	use sp_runtime::{
+		traits::{BlakeTwo256, Extrinsic as ExtrinsicT, Hash, Verify},
+		transaction_validity::{InvalidTransaction as InvalidTrustedOperation, ValidTransaction},
+	};
+	use std::{collections::HashSet, sync::SgxMutex as Mutex};
+	use substratee_stf::{Index, TrustedCall, TrustedCallSigned, TrustedOperation};
 
 	#[derive(Clone, PartialEq, Eq, Encode, Decode, core::fmt::Debug)]
 	pub enum Extrinsic {
@@ -536,7 +519,7 @@ pub mod test {
 	/// The block number type used in this runtime.
 	pub type BlockNumber = u64;
 	/// Index of a transaction.
-	pub type Index = u64;
+	//pub type Index = u64;
 	/// The item of a block digest.
 	pub type DigestItem = sp_runtime::generic::DigestItem<H256>;
 	/// The digest of a block.
@@ -545,180 +528,129 @@ pub mod test {
 	pub type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	/// A test block.
 	pub type Block = sp_runtime::generic::Block<Header, Extrinsic>;
-}
 
-const INVALID_NONCE: Index = 254;
-const SOURCE: TrustedOperationSource = TrustedOperationSource::External;
+	const INVALID_NONCE: Index = 254;
+	const SOURCE: TrustedOperationSource = TrustedOperationSource::External;
 
-#[derive(Clone, Debug, Default)]
-struct TestApi {
-	delay: Arc<Mutex<Option<std::sync::mpsc::Receiver<()>>>>,
-	invalidate: Arc<Mutex<HashSet<H256>>>,
-	clear_requirements: Arc<Mutex<HashSet<H256>>>,
-	add_requirements: Arc<Mutex<HashSet<H256>>>,
-}
+	#[derive(Clone, Debug, Default)]
+	struct TestApi {
+		delay: Arc<Mutex<Option<std::sync::mpsc::Receiver<()>>>>,
+		invalidate: Arc<Mutex<HashSet<H256>>>,
+		clear_requirements: Arc<Mutex<HashSet<H256>>>,
+		add_requirements: Arc<Mutex<HashSet<H256>>>,
+	}
 
-impl ChainApi for TestApi {
-	type Block = test::Block;
-	type Error = error::Error;
-	type ValidationFuture = futures::future::Ready<error::Result<TransactionValidity>>;
-	type BodyFuture = futures::future::Ready<error::Result<Option<Vec<StfTrustedOperation>>>>;
+	impl ChainApi for TestApi {
+		type Block = tests::Block;
+		type Error = error::Error;
+		type ValidationFuture = futures::future::Ready<error::Result<TransactionValidity>>;
+		type BodyFuture = futures::future::Ready<error::Result<Option<Vec<StfTrustedOperation>>>>;
 
-	/// Verify extrinsic at given block.
-	fn validate_transaction(
-		&self,
-		_source: TrustedOperationSource,
-		uxt: StfTrustedOperation,
-		_shard: ShardIdentifier,
-	) -> Self::ValidationFuture {
-		let hash = self.hash_and_length(&uxt).0;
-		let nonce: Index = match uxt {
-			StfTrustedOperation::direct_call(signed_call) => signed_call.nonce,
-			_ => 0,
-		};
-
-		// This is used to control the test flow.
-		if nonce > 0 {
-			let opt = self.delay.lock().unwrap().take();
-			if let Some(delay) = opt {
-				if delay.recv().is_err() {
-					println!("Error waiting for delay!");
-				}
-			}
-		}
-
-		if self.invalidate.lock().unwrap().contains(&hash) {
-			return futures::future::ready(Ok(InvalidTrustedOperation::Custom(0).into()))
-		}
-
-		futures::future::ready(if nonce > 254 {
-			Ok(InvalidTrustedOperation::Stale.into())
-		} else {
-			let mut operation = ValidTransaction {
-				priority: 4,
-				requires: if nonce > 0 { vec![vec![nonce as u8 - 1]] } else { vec![] },
-				provides: if nonce == INVALID_NONCE { vec![] } else { vec![vec![nonce as u8]] },
-				longevity: 3,
-				propagate: true,
+		/// Verify extrinsic at given block.
+		fn validate_transaction(
+			&self,
+			_source: TrustedOperationSource,
+			uxt: StfTrustedOperation,
+			_shard: ShardIdentifier,
+		) -> Self::ValidationFuture {
+			let hash = self.hash_and_length(&uxt).0;
+			let nonce: Index = match uxt {
+				StfTrustedOperation::direct_call(signed_call) => signed_call.nonce,
+				_ => 0,
 			};
 
-			if self.clear_requirements.lock().unwrap().contains(&hash) {
-				operation.requires.clear();
+			// This is used to control the test flow.
+			if nonce > 0 {
+				let opt = self.delay.lock().unwrap().take();
+				if let Some(delay) = opt {
+					if delay.recv().is_err() {
+						println!("Error waiting for delay!");
+					}
+				}
 			}
 
-			if self.add_requirements.lock().unwrap().contains(&hash) {
-				operation.requires.push(vec![128]);
+			if self.invalidate.lock().unwrap().contains(&hash) {
+				return futures::future::ready(Ok(InvalidTrustedOperation::Custom(0).into()))
 			}
 
-			Ok(Ok(operation))
-		})
+			futures::future::ready(if nonce > 254 {
+				Ok(InvalidTrustedOperation::Stale.into())
+			} else {
+				let mut operation = ValidTransaction {
+					priority: 4,
+					requires: if nonce > 0 { vec![vec![nonce as u8 - 1]] } else { vec![] },
+					provides: if nonce == INVALID_NONCE { vec![] } else { vec![vec![nonce as u8]] },
+					longevity: 3,
+					propagate: true,
+				};
+
+				if self.clear_requirements.lock().unwrap().contains(&hash) {
+					operation.requires.clear();
+				}
+
+				if self.add_requirements.lock().unwrap().contains(&hash) {
+					operation.requires.push(vec![128]);
+				}
+
+				Ok(Ok(operation))
+			})
+		}
+
+		/// Returns a block number given the block id.
+		fn block_id_to_number(
+			&self,
+			at: &BlockId<Self::Block>,
+		) -> Result<Option<NumberFor<Self>>, Self::Error> {
+			Ok(match at {
+				BlockId::Number(num) => Some(*num),
+				BlockId::Hash(_) => None,
+			})
+		}
+
+		/// Returns a block hash given the block id.
+		fn block_id_to_hash(
+			&self,
+			at: &BlockId<Self::Block>,
+		) -> Result<Option<SidechainBlockHash>, Self::Error> {
+			Ok(match at {
+				BlockId::Number(num) => Some(from_low_u64_to_be_h256(*num)),
+				BlockId::Hash(_) => None,
+			})
+		}
+
+		/// Hash the extrinsic.
+		fn hash_and_length(&self, uxt: &StfTrustedOperation) -> (BlockHash<Self>, usize) {
+			let encoded = uxt.encode();
+			let len = encoded.len();
+			(tests::Hashing::hash_of(&encoded), len)
+		}
+
+		fn block_body(&self, _id: &BlockId<Self::Block>) -> Self::BodyFuture {
+			futures::future::ready(Ok(None))
+		}
 	}
 
-	/// Returns a block number given the block id.
-	fn block_id_to_number(
-		&self,
-		at: &BlockId<Self::Block>,
-	) -> Result<Option<NumberFor<Self>>, Self::Error> {
-		Ok(match at {
-			BlockId::Number(num) => Some(*num),
-			BlockId::Hash(_) => None,
-		})
+	fn to_top(call: TrustedCall, nonce: Index) -> TrustedOperation {
+		TrustedCallSigned::new(call, nonce, Default::default()).into_trusted_operation(true)
 	}
 
-	/// Returns a block hash given the block id.
-	fn block_id_to_hash(
-		&self,
-		at: &BlockId<Self::Block>,
-	) -> Result<Option<SidechainBlockHash>, Self::Error> {
-		Ok(match at {
-			BlockId::Number(num) => Some(from_low_u64_to_be_h256(*num)),
-			BlockId::Hash(_) => None,
-		})
+	fn test_pool() -> Pool<TestApi, EnclaveRpcOCallMock> {
+		Pool::new(Default::default(), TestApi::default().into())
 	}
 
-	/// Hash the extrinsic.
-	fn hash_and_length(&self, uxt: &StfTrustedOperation) -> (BlockHash<Self>, usize) {
-		let encoded = uxt.encode();
-		let len = encoded.len();
-		(test::Hashing::hash_of(&encoded), len)
-	}
-
-	fn block_body(&self, _id: &BlockId<Self::Block>) -> Self::BodyFuture {
-		futures::future::ready(Ok(None))
-	}
-}
-
-fn to_top(call: TrustedCall, nonce: Index) -> TrustedOperation {
-	TrustedCallSigned::new(call, nonce, Default::default()).into_trusted_operation(true)
-}
-
-fn test_pool() -> Pool<TestApi, EnclaveRpcOCallMock> {
-	Pool::new(Default::default(), TestApi::default().into())
-}
-
-pub fn test_should_validate_and_import_transaction() {
-	// given
-	let pool = test_pool();
-	let shard = ShardIdentifier::default();
-
-	// when
-	let hash = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
-			),
-			0,
-		),
-		shard,
-	))
-	.unwrap();
-
-	// then
-	assert_eq!(pool.validated_pool().ready(shard).map(|v| v.hash).collect::<Vec<_>>(), vec![hash]);
-}
-
-pub fn test_should_reject_if_temporarily_banned() {
-	// given
-	let pool = test_pool();
-	let shard = ShardIdentifier::default();
-	let top = to_top(
-		TrustedCall::balance_transfer(
-			test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-			test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-			5,
-		),
-		0,
-	);
-
-	// when
-	pool.validated_pool.rotator().ban(&Instant::now(), vec![pool.hash_of(&top)]);
-	let res = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, top, shard));
-	assert_eq!(pool.validated_pool().status(shard).ready, 0);
-	assert_eq!(pool.validated_pool().status(shard).future, 0);
-
-	// then
-	assert!(matches!(res.unwrap_err(), error::Error::TemporarilyBanned));
-}
-
-pub fn test_should_notify_about_pool_events() {
-	let (stream, hash0, hash1) = {
+	pub fn test_should_validate_and_import_transaction() {
 		// given
 		let pool = test_pool();
 		let shard = ShardIdentifier::default();
-		let stream = pool.validated_pool().import_notification_stream();
 
 		// when
-		let hash0 = block_on(pool.submit_one(
+		let hash = block_on(pool.submit_one(
 			&BlockId::Number(0),
 			SOURCE,
 			to_top(
 				TrustedCall::balance_transfer(
-					test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-					test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
 					5,
 				),
 				0,
@@ -726,13 +658,127 @@ pub fn test_should_notify_about_pool_events() {
 			shard,
 		))
 		.unwrap();
+
+		// then
+		assert_eq!(
+			pool.validated_pool().ready(shard).map(|v| v.hash).collect::<Vec<_>>(),
+			vec![hash]
+		);
+	}
+
+	pub fn test_should_reject_if_temporarily_banned() {
+		// given
+		let pool = test_pool();
+		let shard = ShardIdentifier::default();
+		let top = to_top(
+			TrustedCall::balance_transfer(
+				tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+				tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+				5,
+			),
+			0,
+		);
+
+		// when
+		pool.validated_pool.rotator().ban(&Instant::now(), vec![pool.hash_of(&top)]);
+		let res = block_on(pool.submit_one(&BlockId::Number(0), SOURCE, top, shard));
+		assert_eq!(pool.validated_pool().status(shard).ready, 0);
+		assert_eq!(pool.validated_pool().status(shard).future, 0);
+
+		// then
+		assert!(matches!(res.unwrap_err(), error::Error::TemporarilyBanned));
+	}
+
+	pub fn test_should_notify_about_pool_events() {
+		let (stream, hash0, hash1) = {
+			// given
+			let pool = test_pool();
+			let shard = ShardIdentifier::default();
+			let stream = pool.validated_pool().import_notification_stream();
+
+			// when
+			let hash0 = block_on(pool.submit_one(
+				&BlockId::Number(0),
+				SOURCE,
+				to_top(
+					TrustedCall::balance_transfer(
+						tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+						tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+						5,
+					),
+					0,
+				),
+				shard,
+			))
+			.unwrap();
+			let hash1 = block_on(pool.submit_one(
+				&BlockId::Number(0),
+				SOURCE,
+				to_top(
+					TrustedCall::balance_transfer(
+						tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+						tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+						5,
+					),
+					1,
+				),
+				shard,
+			))
+			.unwrap();
+			// future doesn't count
+			let _hash = block_on(pool.submit_one(
+				&BlockId::Number(0),
+				SOURCE,
+				to_top(
+					TrustedCall::balance_transfer(
+						tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+						tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+						5,
+					),
+					3,
+				),
+				shard,
+			))
+			.unwrap();
+
+			assert_eq!(pool.validated_pool().status(shard).ready, 2);
+			assert_eq!(pool.validated_pool().status(shard).future, 1);
+
+			(stream, hash0, hash1)
+		};
+
+		// then
+		let mut it = futures::executor::block_on_stream(stream);
+		assert_eq!(it.next(), Some(hash0));
+		assert_eq!(it.next(), Some(hash1));
+		assert_eq!(it.next(), None);
+	}
+
+	pub fn test_should_clear_stale_transactions() {
+		// given
+		let pool = test_pool();
+		let shard = ShardIdentifier::default();
 		let hash1 = block_on(pool.submit_one(
 			&BlockId::Number(0),
 			SOURCE,
 			to_top(
 				TrustedCall::balance_transfer(
-					test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-					test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					5,
+				),
+				0,
+			),
+			shard,
+		))
+		.unwrap();
+		let hash2 = block_on(pool.submit_one(
+			&BlockId::Number(0),
+			SOURCE,
+			to_top(
+				TrustedCall::balance_transfer(
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
 					5,
 				),
 				1,
@@ -740,14 +786,13 @@ pub fn test_should_notify_about_pool_events() {
 			shard,
 		))
 		.unwrap();
-		// future doesn't count
-		let _hash = block_on(pool.submit_one(
+		let hash3 = block_on(pool.submit_one(
 			&BlockId::Number(0),
 			SOURCE,
 			to_top(
 				TrustedCall::balance_transfer(
-					test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-					test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
 					5,
 				),
 				3,
@@ -755,205 +800,146 @@ pub fn test_should_notify_about_pool_events() {
 			shard,
 		))
 		.unwrap();
+		// when
+		pool.validated_pool.clear_stale(&BlockId::Number(5), shard).unwrap();
 
-		assert_eq!(pool.validated_pool().status(shard).ready, 2);
+		// then
+		assert_eq!(pool.validated_pool().ready(shard).count(), 0);
+		assert_eq!(pool.validated_pool().status(shard).future, 0);
+		assert_eq!(pool.validated_pool().status(shard).ready, 0);
+		// make sure they are temporarily banned as well
+		assert!(pool.validated_pool.rotator().is_banned(&hash1));
+		assert!(pool.validated_pool.rotator().is_banned(&hash2));
+		assert!(pool.validated_pool.rotator().is_banned(&hash3));
+	}
+
+	pub fn test_should_ban_mined_transactions() {
+		// given
+		let pool = test_pool();
+		let shard = ShardIdentifier::default();
+		let hash1 = block_on(pool.submit_one(
+			&BlockId::Number(0),
+			SOURCE,
+			to_top(
+				TrustedCall::balance_transfer(
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					5,
+				),
+				0,
+			),
+			shard,
+		))
+		.unwrap();
+
+		// when
+		block_on(pool.prune_tags(&BlockId::Number(1), vec![vec![0]], vec![hash1], shard)).unwrap();
+
+		// then
+		assert!(pool.validated_pool.rotator().is_banned(&hash1));
+	}
+
+	pub fn test_should_limit_futures() {
+		// given
+		let shard = ShardIdentifier::default();
+		let limit = Limit { count: 100, total_bytes: 300 };
+		let pool: Pool<TestApi, EnclaveRpcOCallMock> = Pool::new(
+			Options { ready: limit.clone(), future: limit, ..Default::default() },
+			TestApi::default().into(),
+		);
+
+		let hash1 = block_on(pool.submit_one(
+			&BlockId::Number(0),
+			SOURCE,
+			to_top(
+				TrustedCall::balance_transfer(
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					5,
+				),
+				1,
+			),
+			shard,
+		))
+		.unwrap();
 		assert_eq!(pool.validated_pool().status(shard).future, 1);
 
-		(stream, hash0, hash1)
-	};
-
-	// then
-	let mut it = futures::executor::block_on_stream(stream);
-	assert_eq!(it.next(), Some(hash0));
-	assert_eq!(it.next(), Some(hash1));
-	assert_eq!(it.next(), None);
-}
-
-pub fn test_should_clear_stale_transactions() {
-	// given
-	let pool = test_pool();
-	let shard = ShardIdentifier::default();
-	let hash1 = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
+		// when
+		let hash2 = block_on(pool.submit_one(
+			&BlockId::Number(0),
+			SOURCE,
+			to_top(
+				TrustedCall::balance_transfer(
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					5,
+				),
+				10,
 			),
-			0,
-		),
-		shard,
-	))
-	.unwrap();
-	let hash2 = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
+			shard,
+		))
+		.unwrap();
+
+		// then
+		assert_eq!(pool.validated_pool().status(shard).future, 1);
+		assert!(pool.validated_pool.rotator().is_banned(&hash1));
+		assert!(!pool.validated_pool.rotator().is_banned(&hash2));
+	}
+
+	pub fn test_should_error_if_reject_immediately() {
+		// given
+		let shard = ShardIdentifier::default();
+		let limit = Limit { count: 100, total_bytes: 10 };
+		let pool: Pool<TestApi, EnclaveRpcOCallMock> = Pool::new(
+			Options { ready: limit.clone(), future: limit, ..Default::default() },
+			TestApi::default().into(),
+		);
+
+		// when
+		block_on(pool.submit_one(
+			&BlockId::Number(0),
+			SOURCE,
+			to_top(
+				TrustedCall::balance_transfer(
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					5,
+				),
+				1,
 			),
-			1,
-		),
-		shard,
-	))
-	.unwrap();
-	let hash3 = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
+			shard,
+		))
+		.unwrap_err();
+
+		// then
+		assert_eq!(pool.validated_pool().status(shard).ready, 0);
+		assert_eq!(pool.validated_pool().status(shard).future, 0);
+	}
+
+	pub fn test_should_reject_transactions_with_no_provides() {
+		// given
+		let pool = test_pool();
+		let shard = ShardIdentifier::default();
+
+		// when
+		let err = block_on(pool.submit_one(
+			&BlockId::Number(0),
+			SOURCE,
+			to_top(
+				TrustedCall::balance_transfer(
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
+					tests::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
+					5,
+				),
+				INVALID_NONCE,
 			),
-			3,
-		),
-		shard,
-	))
-	.unwrap();
-	// when
-	pool.validated_pool.clear_stale(&BlockId::Number(5), shard).unwrap();
+			shard,
+		))
+		.unwrap_err();
 
-	// then
-	assert_eq!(pool.validated_pool().ready(shard).count(), 0);
-	assert_eq!(pool.validated_pool().status(shard).future, 0);
-	assert_eq!(pool.validated_pool().status(shard).ready, 0);
-	// make sure they are temporarily banned as well
-	assert!(pool.validated_pool.rotator().is_banned(&hash1));
-	assert!(pool.validated_pool.rotator().is_banned(&hash2));
-	assert!(pool.validated_pool.rotator().is_banned(&hash3));
-}
-
-pub fn test_should_ban_mined_transactions() {
-	// given
-	let pool = test_pool();
-	let shard = ShardIdentifier::default();
-	let hash1 = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
-			),
-			0,
-		),
-		shard,
-	))
-	.unwrap();
-
-	// when
-	block_on(pool.prune_tags(&BlockId::Number(1), vec![vec![0]], vec![hash1], shard)).unwrap();
-
-	// then
-	assert!(pool.validated_pool.rotator().is_banned(&hash1));
-}
-
-pub fn test_should_limit_futures() {
-	// given
-	let shard = ShardIdentifier::default();
-	let limit = Limit { count: 100, total_bytes: 300 };
-	let pool: Pool<TestApi, EnclaveRpcOCallMock> = Pool::new(
-		Options { ready: limit.clone(), future: limit, ..Default::default() },
-		TestApi::default().into(),
-	);
-
-	let hash1 = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
-			),
-			1,
-		),
-		shard,
-	))
-	.unwrap();
-	assert_eq!(pool.validated_pool().status(shard).future, 1);
-
-	// when
-	let hash2 = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
-			),
-			10,
-		),
-		shard,
-	))
-	.unwrap();
-
-	// then
-	assert_eq!(pool.validated_pool().status(shard).future, 1);
-	assert!(pool.validated_pool.rotator().is_banned(&hash1));
-	assert!(!pool.validated_pool.rotator().is_banned(&hash2));
-}
-
-pub fn test_should_error_if_reject_immediately() {
-	// given
-	let shard = ShardIdentifier::default();
-	let limit = Limit { count: 100, total_bytes: 10 };
-	let pool: Pool<TestApi, EnclaveRpcOCallMock> = Pool::new(
-		Options { ready: limit.clone(), future: limit, ..Default::default() },
-		TestApi::default().into(),
-	);
-
-	// when
-	block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
-			),
-			1,
-		),
-		shard,
-	))
-	.unwrap_err();
-
-	// then
-	assert_eq!(pool.validated_pool().status(shard).ready, 0);
-	assert_eq!(pool.validated_pool().status(shard).future, 0);
-}
-
-pub fn test_should_reject_transactions_with_no_provides() {
-	// given
-	let pool = test_pool();
-	let shard = ShardIdentifier::default();
-
-	// when
-	let err = block_on(pool.submit_one(
-		&BlockId::Number(0),
-		SOURCE,
-		to_top(
-			TrustedCall::balance_transfer(
-				test::AccountId::from_h256(from_low_u64_to_be_h256(1)).into(),
-				test::AccountId::from_h256(from_low_u64_to_be_h256(2)).into(),
-				5,
-			),
-			INVALID_NONCE,
-		),
-		shard,
-	))
-	.unwrap_err();
-
-	// then
-	assert_eq!(pool.validated_pool().status(shard).ready, 0);
-	assert_eq!(pool.validated_pool().status(shard).future, 0);
-	assert!(matches!(err, error::Error::NoTagsProvided));
+		// then
+		assert_eq!(pool.validated_pool().status(shard).ready, 0);
+		assert_eq!(pool.validated_pool().status(shard).future, 0);
+		assert!(matches!(err, error::Error::NoTagsProvided));
+	}
 }

--- a/enclave/src/top_pool/primitives.rs
+++ b/enclave/src/top_pool/primitives.rs
@@ -1,12 +1,7 @@
 // File replacing substrate crate sp_transaction_pool::{error, PoolStatus};
 
 extern crate alloc;
-use alloc::{
-	boxed::Box,
-	string::{String, ToString},
-	sync::Arc,
-	vec::Vec,
-};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::{hash::Hash, pin::Pin};
 use std::collections::HashMap;
 
@@ -303,40 +298,47 @@ pub fn from_low_u64_to_be_h256(val: u64) -> H256 {
 }
 
 /// test
-pub fn test_h256() {
-	let tests = vec![
-		(
-			from_low_u64_to_be_h256(0),
-			"0x0000000000000000000000000000000000000000000000000000000000000000",
-		),
-		(
-			from_low_u64_to_be_h256(2),
-			"0x0000000000000000000000000000000000000000000000000000000000000002",
-		),
-		(
-			from_low_u64_to_be_h256(15),
-			"0x000000000000000000000000000000000000000000000000000000000000000f",
-		),
-		(
-			from_low_u64_to_be_h256(16),
-			"0x0000000000000000000000000000000000000000000000000000000000000010",
-		),
-		(
-			from_low_u64_to_be_h256(1_000),
-			"0x00000000000000000000000000000000000000000000000000000000000003e8",
-		),
-		(
-			from_low_u64_to_be_h256(100_000),
-			"0x00000000000000000000000000000000000000000000000000000000000186a0",
-		),
-		(
-			from_low_u64_to_be_h256(u64::max_value()),
-			"0x000000000000000000000000000000000000000000000000ffffffffffffffff",
-		),
-	];
+#[cfg(feature = "test")]
+pub mod tests {
 
-	for (number, expected) in tests {
-		// workaround, as H256 in no_std does not implement (de)serialize
-		assert_eq!(expected.to_string(), format!("{:?}", number));
+	use super::*;
+	use alloc::string::ToString;
+
+	pub fn test_h256() {
+		let tests = vec![
+			(
+				from_low_u64_to_be_h256(0),
+				"0x0000000000000000000000000000000000000000000000000000000000000000",
+			),
+			(
+				from_low_u64_to_be_h256(2),
+				"0x0000000000000000000000000000000000000000000000000000000000000002",
+			),
+			(
+				from_low_u64_to_be_h256(15),
+				"0x000000000000000000000000000000000000000000000000000000000000000f",
+			),
+			(
+				from_low_u64_to_be_h256(16),
+				"0x0000000000000000000000000000000000000000000000000000000000000010",
+			),
+			(
+				from_low_u64_to_be_h256(1_000),
+				"0x00000000000000000000000000000000000000000000000000000000000003e8",
+			),
+			(
+				from_low_u64_to_be_h256(100_000),
+				"0x00000000000000000000000000000000000000000000000000000000000186a0",
+			),
+			(
+				from_low_u64_to_be_h256(u64::max_value()),
+				"0x000000000000000000000000000000000000000000000000ffffffffffffffff",
+			),
+		];
+
+		for (number, expected) in tests {
+			// workaround, as H256 in no_std does not implement (de)serialize
+			assert_eq!(expected.to_string(), format!("{:?}", number));
+		}
 	}
 }

--- a/stf/Cargo.toml
+++ b/stf/Cargo.toml
@@ -30,6 +30,7 @@ std = [
     "substrate-client-keystore",
     "my-node-runtime",
 ]
+test = []
 
 [dependencies]
 log-sgx             = { package = "log", git = "https://github.com/mesalock-linux/log-sgx", optional = true }

--- a/stf/src/lib.rs
+++ b/stf/src/lib.rs
@@ -89,13 +89,19 @@ impl From<sr25519::Pair> for KeyPair {
 }
 
 #[cfg(feature = "sgx")]
-pub mod sgx;
+pub mod stf_sgx;
 
 #[cfg(feature = "sgx")]
-pub use sgx::types::*;
+pub mod stf_sgx_primitives;
+
+#[cfg(feature = "sgx")]
+pub use stf_sgx::types::*;
 
 #[cfg(feature = "std")]
 pub mod cli;
+
+#[cfg(all(feature = "test", feature = "sgx"))]
+pub mod test_genesis;
 
 #[derive(Encode, Decode, Clone, core::fmt::Debug)]
 #[allow(non_camel_case_types)]

--- a/stf/src/sgx.rs
+++ b/stf/src/sgx.rs
@@ -80,7 +80,7 @@ impl Stf {
 				&1u128.encode(),
 			);
 			sp_io::storage::set(
-				&storage_value_key("Balances", "TransfactionByteFee"),
+				&storage_value_key("Balances", "TransactionByteFee"),
 				&1u128.encode(),
 			);
 			sp_io::storage::set(

--- a/stf/src/stf_sgx.rs
+++ b/stf/src/stf_sgx.rs
@@ -1,21 +1,25 @@
-use sgx_tstd as std;
-use std::{collections::HashMap, prelude::v1::*, vec};
-
+use crate::{
+	stf_sgx_primitives::{
+		get_account_info, increment_nonce, shards_key_hash, storage_value_key, validate_nonce,
+		StfError, StfResult,
+	},
+	AccountId, Getter, Index, PublicGetter, StatePayload, TrustedCall, TrustedCallSigned,
+	TrustedGetter, SUBSRATEE_REGISTRY_MODULE, UNSHIELD,
+};
 use codec::{Decode, Encode};
-use derive_more::Display;
 use log_sgx::*;
 use sgx_externalities::SgxExternalitiesTypeTrait;
-use sgx_runtime::{Balance, BlockNumber as L1BlockNumer, Runtime};
-use sp_core::{crypto::AccountId32, Pair, H256 as Hash};
+use sgx_runtime::{BlockNumber as L1BlockNumer, Runtime};
+use sgx_tstd as std;
+use sp_core::H256 as Hash;
 use sp_io::{hashing::blake2_256, SgxExternalitiesTrait};
 use sp_runtime::MultiAddress;
+use std::{collections::HashMap, prelude::v1::*};
 use substratee_worker_primitives::BlockNumber;
-use support::{ensure, metadata::StorageHasher, traits::UnfilteredDispatchable};
+use support::{ensure, traits::UnfilteredDispatchable};
 
-use crate::{
-	AccountId, Getter, Index, PublicGetter, ShardIdentifier, StatePayload, TrustedCall,
-	TrustedCallSigned, TrustedGetter, SUBSRATEE_REGISTRY_MODULE, UNSHIELD,
-};
+#[cfg(feature = "test")]
+use crate::test_genesis::test_genesis_setup;
 
 /// Simple blob that holds a call in encoded format
 #[derive(Clone, Debug)]
@@ -46,31 +50,16 @@ pub mod types {
 
 use types::*;
 
-const ALICE_ENCODED: [u8; 32] = [
-	212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133,
-	76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-];
-const ALICE_FUNDS: Balance = 1000000000000000;
-
 impl Stf {
 	pub fn init_state() -> State {
 		debug!("initializing stf state");
 		let mut ext = State::new();
 		// set initial state hash
 		let state_hash: Hash = blake2_256(&ext.clone().encode()).into();
+
 		ext.execute_with(|| {
 			// do not set genesis for pallets that are meant to be on-chain
 			// use get_storage_hashes_to_update instead
-			sp_io::storage::set(&storage_value_key("Sudo", "Key"), &ALICE_ENCODED);
-			// fund root account
-			sgx_runtime::BalancesCall::<Runtime>::set_balance(
-				MultiAddress::Id(AccountId32::from(ALICE_ENCODED)),
-				ALICE_FUNDS,
-				ALICE_FUNDS,
-			)
-			.dispatch_bypass_filter(sgx_runtime::Origin::root())
-			.map_err(|_| StfError::Dispatch("balance_set_balance".to_string()))
-			.unwrap();
 
 			sp_io::storage::set(&storage_value_key("Balances", "TotalIssuance"), &11u128.encode());
 			sp_io::storage::set(&storage_value_key("Balances", "CreationFee"), &1u128.encode());
@@ -95,27 +84,11 @@ impl Stf {
 			);
 			// Set first parent hash to initial state hash
 			sp_io::storage::set(&storage_value_key("System", "LastHash"), &state_hash.encode());
-			//FIXME: for testing purpose only - maybe add feature?
-			// for example: feature = endowtestaccounts
-			let public = AccountId32::from(
-				sp_core::ed25519::Pair::from_seed(b"12345678901234567890123456789012").public(),
-			);
-			sgx_runtime::BalancesCall::<Runtime>::set_balance(
-				MultiAddress::Id(public.clone()),
-				2000,
-				2000,
-			)
-			.dispatch_bypass_filter(sgx_runtime::Origin::root())
-			.map_err(|_| StfError::Dispatch("balance_set_balance".to_string()))
-			.unwrap();
-
-			let print_public: [u8; 32] = public.clone().into();
-			if let Some(info) = get_account_info(&public) {
-				debug!("{:?} balance is {}", print_public, info.data.free);
-			} else {
-				debug!("{:?} balance is zero", print_public);
-			}
 		});
+
+		#[cfg(feature = "test")]
+		test_genesis_setup(&mut ext);
+
 		ext
 	}
 
@@ -290,7 +263,7 @@ impl Stf {
 		})
 	}
 
-	//FIXME: Add Test feature as this function is only used for unit testing currently
+	#[cfg(feature = "test")]
 	pub fn account_data(ext: &mut State, account: &AccountId) -> Option<AccountData> {
 		ext.execute_with(|| {
 			if let Some(info) = get_account_info(account) {
@@ -438,139 +411,12 @@ impl Stf {
 	}
 }
 
-pub fn storage_hashes_to_update_per_shard(_shard: &ShardIdentifier) -> Vec<Vec<u8>> {
-	Vec::new()
-}
-
-pub fn shards_key_hash() -> Vec<u8> {
-	// here you have to point to a storage value containing a Vec of ShardIdentifiers
-	// the enclave uses this to autosubscribe to no shards
-	vec![]
-}
-
-// get the AccountInfo key where the account is stored
-pub fn account_key_hash(account: &AccountId) -> Vec<u8> {
-	storage_map_key("System", "Account", account, &StorageHasher::Blake2_128Concat)
-}
-
-fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
-	if let Some(infovec) = sp_io::storage::get(&storage_map_key(
-		"System",
-		"Account",
-		who,
-		&StorageHasher::Blake2_128Concat,
-	)) {
-		if let Ok(info) = AccountInfo::decode(&mut infovec.as_slice()) {
-			Some(info)
-		} else {
-			None
-		}
-	} else {
-		None
-	}
-}
-
-fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
-	// validate
-	let expected_nonce = get_account_info(who).map_or_else(|| 0, |acc| acc.nonce);
-	if expected_nonce == nonce {
-		return Ok(())
-	}
-	Err(StfError::InvalidNonce(nonce))
-}
-
-/// increment nonce after a successful call execution
-fn increment_nonce(account: &AccountId) {
-	//FIXME: Proper error handling - should be taken into
-	// consideration after implementing pay fee check
-	if let Some(mut acc_info) = get_account_info(account) {
-		debug!("incrementing account nonce");
-		acc_info.nonce += 1;
-		sp_io::storage::set(&account_key_hash(account), &acc_info.encode());
-		debug!(
-			"updated account {:?} nonce: {:?}",
-			account.encode(),
-			get_account_info(account).unwrap().nonce
-		);
-	} else {
-		error!("tried to increment nonce of a non-existent account")
-	}
-}
-
-pub fn storage_value_key(module_prefix: &str, storage_prefix: &str) -> Vec<u8> {
-	let mut bytes = sp_core::twox_128(module_prefix.as_bytes()).to_vec();
-	bytes.extend(&sp_core::twox_128(storage_prefix.as_bytes())[..]);
-	bytes
-}
-
-pub fn storage_map_key<K: Encode>(
-	module_prefix: &str,
-	storage_prefix: &str,
-	mapkey1: &K,
-	hasher1: &StorageHasher,
-) -> Vec<u8> {
-	let mut bytes = sp_core::twox_128(module_prefix.as_bytes()).to_vec();
-	bytes.extend(&sp_core::twox_128(storage_prefix.as_bytes())[..]);
-	bytes.extend(key_hash(mapkey1, hasher1));
-	bytes
-}
-
-pub fn storage_double_map_key<K: Encode, Q: Encode>(
-	module_prefix: &str,
-	storage_prefix: &str,
-	mapkey1: &K,
-	hasher1: &StorageHasher,
-	mapkey2: &Q,
-	hasher2: &StorageHasher,
-) -> Vec<u8> {
-	let mut bytes = sp_core::twox_128(module_prefix.as_bytes()).to_vec();
-	bytes.extend(&sp_core::twox_128(storage_prefix.as_bytes())[..]);
-	bytes.extend(key_hash(mapkey1, hasher1));
-	bytes.extend(key_hash(mapkey2, hasher2));
-	bytes
-}
-
-/// generates the key's hash depending on the StorageHasher selected
-fn key_hash<K: Encode>(key: &K, hasher: &StorageHasher) -> Vec<u8> {
-	let encoded_key = key.encode();
-	match hasher {
-		StorageHasher::Identity => encoded_key.to_vec(),
-		StorageHasher::Blake2_128 => sp_core::blake2_128(&encoded_key).to_vec(),
-		StorageHasher::Blake2_128Concat => {
-			// copied from substrate Blake2_128Concat::hash since StorageHasher is not public
-			let x: &[u8] = encoded_key.as_slice();
-			sp_core::blake2_128(x).iter().chain(x.iter()).cloned().collect::<Vec<_>>()
-		},
-		StorageHasher::Blake2_256 => sp_core::blake2_256(&encoded_key).to_vec(),
-		StorageHasher::Twox128 => sp_core::twox_128(&encoded_key).to_vec(),
-		StorageHasher::Twox256 => sp_core::twox_256(&encoded_key).to_vec(),
-		StorageHasher::Twox64Concat => sp_core::twox_64(&encoded_key).to_vec(),
-	}
-}
-
-pub type StfResult<T> = Result<T, StfError>;
-
-#[derive(Debug, Display, PartialEq, Eq)]
-pub enum StfError {
-	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
-	MissingPrivileges(AccountId),
-	#[display(fmt = "Error dispatching runtime call. {:?}", _0)]
-	Dispatch(String),
-	#[display(fmt = "Not enough funds to perform operation")]
-	MissingFunds,
-	#[display(fmt = "Account does not exist {:?}", _0)]
-	InexistentAccount(AccountId),
-	#[display(fmt = "Invalid Nonce {:?}", _0)]
-	InvalidNonce(Index),
-	StorageHashMismatch,
-	InvalidStorageDiff,
-}
-
 // this must be pub to be able to test it in the enclave. In the future this should be testable
 // with cargo test. See: https://github.com/scs/substraTEE-worker/issues/272.
+#[cfg(feature = "test")]
 pub mod tests {
-	use super::{State, StateHash, StatePayload, Stf, StfTrait};
-	use crate::sgx::StfError;
+	use super::*;
+	use crate::stf_sgx::StfError;
 	use sgx_externalities::SgxExternalitiesTypeTrait;
 	use sp_core::H256;
 	use sp_runtime::traits::{BlakeTwo256, Hash};

--- a/stf/src/stf_sgx_primitives.rs
+++ b/stf/src/stf_sgx_primitives.rs
@@ -1,0 +1,152 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{AccountId, AccountInfo, Index, ShardIdentifier};
+use codec::{Decode, Encode};
+use derive_more::Display;
+use log_sgx::*;
+use sgx_tstd as std;
+use std::{prelude::v1::*, vec};
+use support::metadata::StorageHasher;
+
+pub type StfResult<T> = Result<T, StfError>;
+
+#[derive(Debug, Display, PartialEq, Eq)]
+pub enum StfError {
+	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
+	MissingPrivileges(AccountId),
+	#[display(fmt = "Error dispatching runtime call. {:?}", _0)]
+	Dispatch(String),
+	#[display(fmt = "Not enough funds to perform operation")]
+	MissingFunds,
+	#[display(fmt = "Account does not exist {:?}", _0)]
+	InexistentAccount(AccountId),
+	#[display(fmt = "Invalid Nonce {:?}", _0)]
+	InvalidNonce(Index),
+	StorageHashMismatch,
+	InvalidStorageDiff,
+}
+
+pub fn storage_hashes_to_update_per_shard(_shard: &ShardIdentifier) -> Vec<Vec<u8>> {
+	Vec::new()
+}
+
+pub fn shards_key_hash() -> Vec<u8> {
+	// here you have to point to a storage value containing a Vec of ShardIdentifiers
+	// the enclave uses this to autosubscribe to no shards
+	vec![]
+}
+
+// get the AccountInfo key where the account is stored
+pub fn account_key_hash(account: &AccountId) -> Vec<u8> {
+	storage_map_key("System", "Account", account, &StorageHasher::Blake2_128Concat)
+}
+
+pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
+	if let Some(infovec) = sp_io::storage::get(&storage_map_key(
+		"System",
+		"Account",
+		who,
+		&StorageHasher::Blake2_128Concat,
+	)) {
+		if let Ok(info) = AccountInfo::decode(&mut infovec.as_slice()) {
+			Some(info)
+		} else {
+			None
+		}
+	} else {
+		None
+	}
+}
+
+pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
+	// validate
+	let expected_nonce = get_account_info(who).map_or_else(|| 0, |acc| acc.nonce);
+	if expected_nonce == nonce {
+		return Ok(())
+	}
+	Err(StfError::InvalidNonce(nonce))
+}
+
+/// increment nonce after a successful call execution
+pub fn increment_nonce(account: &AccountId) {
+	//FIXME: Proper error handling - should be taken into
+	// consideration after implementing pay fee check
+	if let Some(mut acc_info) = get_account_info(account) {
+		debug!("incrementing account nonce");
+		acc_info.nonce += 1;
+		sp_io::storage::set(&account_key_hash(account), &acc_info.encode());
+		debug!(
+			"updated account {:?} nonce: {:?}",
+			account.encode(),
+			get_account_info(account).unwrap().nonce
+		);
+	} else {
+		error!("tried to increment nonce of a non-existent account")
+	}
+}
+
+pub fn storage_value_key(module_prefix: &str, storage_prefix: &str) -> Vec<u8> {
+	let mut bytes = sp_core::twox_128(module_prefix.as_bytes()).to_vec();
+	bytes.extend(&sp_core::twox_128(storage_prefix.as_bytes())[..]);
+	bytes
+}
+
+pub fn storage_map_key<K: Encode>(
+	module_prefix: &str,
+	storage_prefix: &str,
+	mapkey1: &K,
+	hasher1: &StorageHasher,
+) -> Vec<u8> {
+	let mut bytes = sp_core::twox_128(module_prefix.as_bytes()).to_vec();
+	bytes.extend(&sp_core::twox_128(storage_prefix.as_bytes())[..]);
+	bytes.extend(key_hash(mapkey1, hasher1));
+	bytes
+}
+
+pub fn storage_double_map_key<K: Encode, Q: Encode>(
+	module_prefix: &str,
+	storage_prefix: &str,
+	mapkey1: &K,
+	hasher1: &StorageHasher,
+	mapkey2: &Q,
+	hasher2: &StorageHasher,
+) -> Vec<u8> {
+	let mut bytes = sp_core::twox_128(module_prefix.as_bytes()).to_vec();
+	bytes.extend(&sp_core::twox_128(storage_prefix.as_bytes())[..]);
+	bytes.extend(key_hash(mapkey1, hasher1));
+	bytes.extend(key_hash(mapkey2, hasher2));
+	bytes
+}
+
+/// generates the key's hash depending on the StorageHasher selected
+fn key_hash<K: Encode>(key: &K, hasher: &StorageHasher) -> Vec<u8> {
+	let encoded_key = key.encode();
+	match hasher {
+		StorageHasher::Identity => encoded_key.to_vec(),
+		StorageHasher::Blake2_128 => sp_core::blake2_128(&encoded_key).to_vec(),
+		StorageHasher::Blake2_128Concat => {
+			// copied from substrate Blake2_128Concat::hash since StorageHasher is not public
+			let x: &[u8] = encoded_key.as_slice();
+			sp_core::blake2_128(x).iter().chain(x.iter()).cloned().collect::<Vec<_>>()
+		},
+		StorageHasher::Blake2_256 => sp_core::blake2_256(&encoded_key).to_vec(),
+		StorageHasher::Twox128 => sp_core::twox_128(&encoded_key).to_vec(),
+		StorageHasher::Twox256 => sp_core::twox_256(&encoded_key).to_vec(),
+		StorageHasher::Twox64Concat => sp_core::twox_64(&encoded_key).to_vec(),
+	}
+}

--- a/stf/src/test_genesis.rs
+++ b/stf/src/test_genesis.rs
@@ -1,0 +1,83 @@
+/*
+	Copyright 2019 Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::stf_sgx_primitives::{get_account_info, storage_value_key, StfError};
+use log_sgx::*;
+use sgx_externalities::SgxExternalitiesTrait;
+use sgx_runtime::{Balance, Runtime};
+use sgx_tstd as std;
+use sp_core::{crypto::AccountId32, Pair};
+use sp_io::SgxExternalities;
+use sp_runtime::MultiAddress;
+use std::{string::ToString, vec, vec::Vec};
+use support::traits::UnfilteredDispatchable;
+
+const ALICE_ENCODED: [u8; 32] = [
+	212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133,
+	76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
+];
+
+const ALICE_FUNDS: Balance = 1000000000000000;
+
+pub fn test_genesis_setup(state: &mut SgxExternalities) {
+	// set alice sudo account
+	set_sudo_account(state, &ALICE_ENCODED);
+
+	let generic_test_account = AccountId32::from(
+		sp_core::ed25519::Pair::from_seed(b"12345678901234567890123456789012").public(),
+	);
+
+	let endowees: Vec<(AccountId32, Balance, Balance)> = vec![
+		(generic_test_account, 2000, 2000),
+		(AccountId32::from(ALICE_ENCODED), ALICE_FUNDS, ALICE_FUNDS),
+	];
+
+	endow(state, endowees);
+}
+
+fn set_sudo_account(state: &mut SgxExternalities, account_encoded: &[u8]) {
+	state.execute_with(|| {
+		sp_io::storage::set(&storage_value_key("Sudo", "Key"), account_encoded);
+	})
+}
+
+fn endow(
+	state: &mut SgxExternalities,
+	endowees: impl IntoIterator<Item = (AccountId32, Balance, Balance)>,
+) {
+	state.execute_with(|| {
+		for e in endowees.into_iter() {
+			let account = e.0;
+
+			sgx_runtime::BalancesCall::<Runtime>::set_balance(
+				MultiAddress::Id(account.clone()),
+				e.1,
+				e.2,
+			)
+			.dispatch_bypass_filter(sgx_runtime::Origin::root())
+			.map_err(|_| StfError::Dispatch("balance_set_balance".to_string()))
+			.unwrap();
+
+			let print_public: [u8; 32] = account.clone().into();
+			if let Some(info) = get_account_info(&print_public.into()) {
+				debug!("{:?} balance is {}", print_public, info.data.free);
+			} else {
+				debug!("{:?} balance is zero", print_public);
+			}
+		}
+	});
+}


### PR DESCRIPTION
* STF crate has a new `test_accounts` feature - this will endow the `Alice` and another test account upon initialization
* The enclave has a new `test` feature that activates the `test_accounts` feature in the STF create in case of development mode, and disabled in production mode
* In production mode, the enclave has a dummy implementation for the e-call `test_main_entrance()`
* Also moved the tests to a separate sub-module `tests` in some module in the enclave

Closes #215