### PR TITLE
Minor refactorings after sifting through the 'produce_blocks' code

### DIFF
--- a/enclave/chain_relay/src/lib.rs
+++ b/enclave/chain_relay/src/lib.rs
@@ -100,8 +100,8 @@ pub trait Validator: Encode + Decode + Clone + Default {
 
 #[derive(Encode, Decode, Clone, Default)]
 pub struct LightValidation {
-	pub num_relays: RelayId,
-	pub tracked_relays: BTreeMap<RelayId, RelayState<Block>>,
+	num_relays: RelayId,
+	tracked_relays: BTreeMap<RelayId, RelayState<Block>>,
 }
 
 impl LightValidation {

--- a/enclave/chain_relay/src/lib.rs
+++ b/enclave/chain_relay/src/lib.rs
@@ -214,7 +214,7 @@ impl LightValidation {
 			found_xts.into_iter().map(|i| relay.verify_tx_inclusion.remove(i)).collect();
 
 		if !rm.is_empty() {
-			info!("Verfified inclusion proof of {} extrinsics.", rm.len());
+			info!("Verified inclusion proof of {} extrinsics.", rm.len());
 		}
 
 		Ok(())

--- a/enclave/src/io.rs
+++ b/enclave/src/io.rs
@@ -76,7 +76,7 @@ fn _write<F: Write>(bytes: &[u8], mut file: F) -> SgxResult<sgx_status_t> {
 
 pub mod light_validation {
 	use crate::utils::UnwrapOrSgxErrorUnexpected;
-	use chain_relay::{storage_proof::StorageProof, Header, LightValidation};
+	use chain_relay::{storage_proof::StorageProof, Header, LightValidation, Validator};
 	use codec::{Decode, Encode};
 	use log::*;
 	use sgx_types::{sgx_status_t, SgxResult};

--- a/enclave/src/io.rs
+++ b/enclave/src/io.rs
@@ -14,6 +14,8 @@
 	limitations under the License.
 
 */
+use crate::utils::UnwrapOrSgxErrorUnexpected;
+use sgx_types::*;
 use std::{
 	fs,
 	io::{Read, Write},
@@ -21,10 +23,6 @@ use std::{
 	string::String,
 	vec::Vec,
 };
-
-use sgx_types::*;
-
-use crate::utils::UnwrapOrSgxErrorUnexpected;
 
 pub fn unseal(filepath: &str) -> SgxResult<Vec<u8>> {
 	SgxFile::open(filepath)
@@ -110,11 +108,11 @@ pub mod light_validation {
 
 		let validator = unseal().sgx_error_with_log("Error reading validator")?;
 
-		let genesis = validator.genesis_hash(validator.num_relays).unwrap();
+		let genesis = validator.genesis_hash(validator.num_relays()).unwrap();
 		if genesis == header.hash() {
 			info!("Found already initialized chain relay with Genesis Hash: {:?}", genesis);
 			info!("Chain Relay state: {:?}", validator);
-			Ok(validator.latest_finalized_header(validator.num_relays).unwrap())
+			Ok(validator.latest_finalized_header(validator.num_relays()).unwrap())
 		} else {
 			init_validator(header, auth, proof)
 		}
@@ -130,6 +128,6 @@ pub mod light_validation {
 		validator.initialize_relay(header, auth.into(), proof).sgx_error()?;
 		super::seal(validator.encode().as_slice(), CHAIN_RELAY_DB)?;
 
-		Ok(validator.latest_finalized_header(validator.num_relays).unwrap())
+		Ok(validator.latest_finalized_header(validator.num_relays()).unwrap())
 	}
 }

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -40,7 +40,7 @@ use crate::{
 use base58::ToBase58;
 use chain_relay::{
 	storage_proof::{StorageProof, StorageProofChecker},
-	Block, Header, LightValidation,
+	Block, Header, LightValidation, Validator,
 };
 use codec::{alloc::string::String, Decode, Encode};
 use core::ops::Deref;


### PR DESCRIPTION
I've done a couple of refactorings in the worker code concerning the `produce_blocks` workflow. Mostly extracted methods to shorten and clarify long existing methods. In some places also shared duplicated code.