### PR TITLE
[enclave/sidechain] move ocall_api to its own crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5699,6 +5699,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "substratee-ocall-api"
+version = "0.8.0"
+dependencies = [
+ "parity-scale-codec 2.1.3",
+ "sgx_types",
+ "sp-std",
+ "substratee-worker-primitives",
+]
+
+[[package]]
 name = "substratee-settings"
 version = "0.8.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "primitives/enclave-api",
     "primitives/enclave-api/ffi",
     "primitives/node",
+    "primitives/ocall-api",
     "primitives/pallet-teerex-storage",
     "primitives/settings",
     "primitives/storage",

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -2611,6 +2611,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "substratee-ocall-api"
+version = "0.8.0"
+dependencies = [
+ "parity-scale-codec",
+ "sgx_types",
+ "sp-std",
+ "substratee-worker-primitives",
+]
+
+[[package]]
 name = "substratee-settings"
 version = "0.8.0"
 
@@ -2708,6 +2718,7 @@ dependencies = [
  "sp-version",
  "substrate-api-client",
  "substratee-node-primitives",
+ "substratee-ocall-api",
  "substratee-settings",
  "substratee-stf",
  "substratee-storage",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -62,6 +62,7 @@ multibase = { git = "https://github.com/whalelephant/rust-multibase", branch = "
 
 # local deps
 substratee-settings = { path = "../primitives/settings" }
+substratee-ocall-api = { path = "../primitives/ocall-api", default-features = false }
 pallet-teerex-storage = { path = "../primitives/pallet-teerex-storage", default-features = false }
 
 [dependencies.linked-hash-map]

--- a/enclave/src/attestation.rs
+++ b/enclave/src/attestation.rs
@@ -58,12 +58,10 @@ use substratee_settings::{
 
 use crate::{
 	cert, ed25519, hex, io,
-	ocall::{
-		ocall_api::EnclaveAttestationOCallApi,
-		ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
-	},
+	ocall::ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
 	utils::{hash_from_slice, write_slice_and_whitespace_pad, UnwrapOrSgxErrorUnexpected},
 };
+use substratee_ocall_api::EnclaveAttestationOCallApi;
 
 pub const DEV_HOSTNAME: &str = "api.trustedservices.intel.com";
 

--- a/enclave/src/cert.rs
+++ b/enclave/src/cert.rs
@@ -1,5 +1,5 @@
 use super::CERTEXPIRYDAYS;
-use crate::{ocall::ocall_api::EnclaveAttestationOCallApi, utils::UnwrapOrSgxErrorUnexpected};
+use crate::utils::UnwrapOrSgxErrorUnexpected;
 use arrayvec::ArrayVec;
 use bit_vec::BitVec;
 use chrono::{prelude::*, Duration, TimeZone, Utc as TzUtc};
@@ -10,6 +10,7 @@ use serde_json::Value;
 use sgx_tcrypto::*;
 use sgx_types::*;
 use std::{io::BufReader, prelude::v1::*, ptr, str, time::*, untrusted::time::SystemTimeEx};
+use substratee_ocall_api::EnclaveAttestationOCallApi;
 use yasna::models::ObjectIdentifier;
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];

--- a/enclave/src/lib.rs
+++ b/enclave/src/lib.rs
@@ -31,7 +31,6 @@ extern crate sgx_tstd as std;
 use crate::{
 	error::{Error, Result},
 	ocall::{
-		ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi, EnclaveRpcOCallApi},
 		ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
 		rpc_ocall::EnclaveRpcOCall,
 	},
@@ -66,6 +65,9 @@ use substrate_api_client::{
 	compose_extrinsic_offline, extrinsic::xt_primitives::UncheckedExtrinsicV4,
 };
 use substratee_node_primitives::{CallWorkerFn, ShieldFundsFn};
+use substratee_ocall_api::{
+	EnclaveAttestationOCallApi, EnclaveOnChainOCallApi, EnclaveRpcOCallApi,
+};
 use substratee_settings::{
 	enclave::{CALL_TIMEOUT, GETTER_TIMEOUT},
 	node::{

--- a/enclave/src/ocall/attestation_ocall.rs
+++ b/enclave/src/ocall/attestation_ocall.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::ocall::{ffi, ocall_api::EnclaveAttestationOCallApi};
+use crate::ocall::ffi;
 use frame_support::ensure;
 use log::*;
 use sgx_tse::rsgx_create_report;
@@ -25,6 +25,7 @@ use sgx_types::{
 	sgx_status_t, sgx_target_info_t, sgx_update_info_bit_t, SgxResult,
 };
 use std::{ptr, vec::Vec};
+use substratee_ocall_api::EnclaveAttestationOCallApi;
 
 #[derive(Clone, Debug)]
 pub struct EnclaveAttestationOCall {}

--- a/enclave/src/ocall/ipfs_ocall.rs
+++ b/enclave/src/ocall/ipfs_ocall.rs
@@ -16,12 +16,10 @@
 
 */
 
-use crate::ocall::{
-	ffi,
-	ocall_api::{EnclaveIpfsOCallApi, IpfsCid},
-};
+use crate::ocall::ffi;
 use frame_support::ensure;
 use sgx_types::{sgx_status_t, SgxResult};
+use substratee_ocall_api::{EnclaveIpfsOCallApi, IpfsCid};
 
 #[derive(Clone, Debug)]
 pub struct EnclaveIpfsOcall;

--- a/enclave/src/ocall/mod.rs
+++ b/enclave/src/ocall/mod.rs
@@ -15,7 +15,6 @@
 
 */
 
-pub mod ocall_api;
 pub mod ocall_component_factory;
 pub mod rpc_ocall;
 

--- a/enclave/src/ocall/ocall_component_factory.rs
+++ b/enclave/src/ocall/ocall_component_factory.rs
@@ -16,15 +16,13 @@
 */
 
 use crate::ocall::{
-	attestation_ocall::EnclaveAttestationOCall,
-	ipfs_ocall::EnclaveIpfsOcall,
-	ocall_api::{
-		EnclaveAttestationOCallApi, EnclaveIpfsOCallApi, EnclaveOnChainOCallApi, EnclaveRpcOCallApi,
-	},
-	on_chain_ocall::EnclaveOnChainOCall,
-	rpc_ocall::EnclaveRpcOCall,
+	attestation_ocall::EnclaveAttestationOCall, ipfs_ocall::EnclaveIpfsOcall,
+	on_chain_ocall::EnclaveOnChainOCall, rpc_ocall::EnclaveRpcOCall,
 };
 use std::sync::Arc;
+use substratee_ocall_api::{
+	EnclaveAttestationOCallApi, EnclaveIpfsOCallApi, EnclaveOnChainOCallApi, EnclaveRpcOCallApi,
+};
 
 /// Abstract factory trait for OCall components
 pub trait OCallComponentFactoryTrait<A, R, O, I>

--- a/enclave/src/ocall/on_chain_ocall.rs
+++ b/enclave/src/ocall/on_chain_ocall.rs
@@ -16,14 +16,12 @@
 
 */
 
-use crate::{
-	ocall::{ffi, ocall_api::EnclaveOnChainOCallApi},
-	rpc::author::alloc::prelude::v1::Vec,
-};
+use crate::{ocall::ffi, rpc::author::alloc::prelude::v1::Vec};
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use log::*;
 use sgx_types::*;
+use substratee_ocall_api::EnclaveOnChainOCallApi;
 use substratee_worker_primitives::{
 	block::SignedBlock as SignedSidechainBlock, WorkerRequest, WorkerResponse,
 };

--- a/enclave/src/ocall/rpc_ocall.rs
+++ b/enclave/src/ocall/rpc_ocall.rs
@@ -16,11 +16,12 @@
 
 */
 
-use crate::ocall::{ffi, ocall_api::EnclaveRpcOCallApi};
+use crate::ocall::ffi;
 use codec::Encode;
 use frame_support::ensure;
 use sgx_types::{sgx_status_t, SgxResult};
 use std::vec::Vec;
+use substratee_ocall_api::EnclaveRpcOCallApi;
 use substratee_worker_primitives::TrustedOperationStatus;
 
 #[derive(Clone, Debug, Default)]

--- a/enclave/src/onchain/storage.rs
+++ b/enclave/src/onchain/storage.rs
@@ -1,8 +1,9 @@
-use crate::{ocall::ocall_api::EnclaveOnChainOCallApi, Result};
+use crate::Result;
 use codec::Decode;
 use sp_core::H256;
 use sp_runtime::traits::Header;
 use sp_std::prelude::Vec;
+use substratee_ocall_api::EnclaveOnChainOCallApi;
 use substratee_storage::{verify_storage_entries, Error as StorageError, StorageEntryVerified};
 use substratee_worker_primitives::WorkerRequest;
 

--- a/enclave/src/rpc/basic_pool.rs
+++ b/enclave/src/rpc/basic_pool.rs
@@ -1,15 +1,12 @@
 pub extern crate alloc;
 
-use crate::{
-	ocall::ocall_api::EnclaveRpcOCallApi,
-	top_pool::{
-		base_pool::TrustedOperation,
-		error::IntoPoolError,
-		pool::{ChainApi, ExtrinsicHash, Options as PoolOptions, Pool},
-		primitives::{
-			ImportNotificationStream, PoolFuture, PoolStatus, TrustedOperationPool,
-			TrustedOperationSource, TxHash,
-		},
+use crate::top_pool::{
+	base_pool::TrustedOperation,
+	error::IntoPoolError,
+	pool::{ChainApi, ExtrinsicHash, Options as PoolOptions, Pool},
+	primitives::{
+		ImportNotificationStream, PoolFuture, PoolStatus, TrustedOperationPool,
+		TrustedOperationSource, TxHash,
 	},
 };
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
@@ -23,6 +20,7 @@ use sp_runtime::{
 	traits::{Block as BlockT, NumberFor, Zero},
 };
 use std::{collections::HashMap, sync::SgxMutex as Mutex};
+use substratee_ocall_api::EnclaveRpcOCallApi;
 use substratee_stf::{ShardIdentifier, TrustedOperation as StfTrustedOperation};
 
 type BoxedReadyIterator<Hash, Data> =

--- a/enclave/src/test/ipfs_tests.rs
+++ b/enclave/src/test/ipfs_tests.rs
@@ -18,13 +18,11 @@
 
 use crate::{
 	ipfs::IpfsContent,
-	ocall::{
-		ocall_api::EnclaveIpfsOCallApi,
-		ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
-	},
+	ocall::ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
 };
 use log::*;
 use std::{fs::File, io::Read, vec::Vec};
+use substratee_ocall_api::EnclaveIpfsOCallApi;
 
 #[allow(unused)]
 fn test_ocall_read_write_ipfs() {

--- a/enclave/src/test/mocks/attestation_ocall_mock.rs
+++ b/enclave/src/test/mocks/attestation_ocall_mock.rs
@@ -16,9 +16,10 @@
 
 */
 
-use crate::{ocall::ocall_api::EnclaveAttestationOCallApi, rpc::author::alloc::prelude::v1::Vec};
+use crate::rpc::author::alloc::prelude::v1::Vec;
 use sgx_types::*;
 use std::fmt::{Debug, Formatter, Result as FormatResult};
+use substratee_ocall_api::EnclaveAttestationOCallApi;
 
 #[derive(Clone)]
 pub struct AttestationOCallMock {

--- a/enclave/src/test/mocks/enclave_rpc_ocall_mock.rs
+++ b/enclave/src/test/mocks/enclave_rpc_ocall_mock.rs
@@ -16,9 +16,10 @@
 
 */
 
-use crate::{ocall::ocall_api::EnclaveRpcOCallApi, rpc::author::alloc::prelude::v1::Vec};
+use crate::rpc::author::alloc::prelude::v1::Vec;
 use codec::Encode;
 use sgx_types::SgxResult;
+use substratee_ocall_api::EnclaveRpcOCallApi;
 use substratee_worker_primitives::TrustedOperationStatus;
 
 #[derive(Clone, Debug, Default)]

--- a/enclave/src/test/on_chain_ocall_tests.rs
+++ b/enclave/src/test/on_chain_ocall_tests.rs
@@ -16,13 +16,11 @@
 
 */
 
-use crate::ocall::{
-	ocall_api::EnclaveOnChainOCallApi,
-	ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
-};
+use crate::ocall::ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait};
 use log::*;
 use std::vec::Vec;
 use substrate_api_client::utils::storage_key;
+use substratee_ocall_api::EnclaveOnChainOCallApi;
 use substratee_worker_primitives::{WorkerRequest, WorkerResponse};
 
 #[allow(unused)]

--- a/enclave/src/tests.rs
+++ b/enclave/src/tests.rs
@@ -16,10 +16,7 @@
 
 use crate::{
 	aes, ed25519,
-	ocall::{
-		ocall_api::EnclaveAttestationOCallApi,
-		ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
-	},
+	ocall::ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
 	rpc, rsa3072, sidechain, state,
 	test::{cert_tests::*, mocks::enclave_rpc_ocall_mock::EnclaveRpcOCallMock},
 	top_pool, Timeout,
@@ -46,6 +43,7 @@ use std::{
 	untrusted::time::SystemTimeEx,
 	vec::Vec,
 };
+use substratee_ocall_api::EnclaveAttestationOCallApi;
 use substratee_settings::{
 	enclave::GETTER_TIMEOUT,
 	node::{BLOCK_CONFIRMED, SUBSTRATEE_REGISTRY_MODULE},

--- a/enclave/src/tls_ra.rs
+++ b/enclave/src/tls_ra.rs
@@ -17,13 +17,11 @@ use crate::{
 	aes,
 	attestation::{create_ra_report_and_signature, DEV_HOSTNAME},
 	cert,
-	ocall::{
-		ocall_api::EnclaveAttestationOCallApi,
-		ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
-	},
+	ocall::ocall_component_factory::{OCallComponentFactory, OCallComponentFactoryTrait},
 	rsa3072,
 	utils::UnwrapOrSgxErrorUnexpected,
 };
+use substratee_ocall_api::EnclaveAttestationOCallApi;
 
 struct ClientAuth<A> {
 	outdated_ok: bool,

--- a/enclave/src/top_pool/listener.rs
+++ b/enclave/src/top_pool/listener.rs
@@ -16,12 +16,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ocall::ocall_api::EnclaveRpcOCallApi, top_pool::watcher::Watcher};
+use crate::top_pool::watcher::Watcher;
 use codec::Encode;
 use linked_hash_map::LinkedHashMap;
 use log::{debug, trace};
 use sp_runtime::traits;
 use std::{collections::HashMap, hash, string::String, sync::Arc, vec::Vec};
+use substratee_ocall_api::EnclaveRpcOCallApi;
 use substratee_worker_primitives::BlockHash as SidechainBlockHash;
 
 /// Extrinsic pool default listener.

--- a/enclave/src/top_pool/pool.rs
+++ b/enclave/src/top_pool/pool.rs
@@ -16,13 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-	ocall::ocall_api::EnclaveRpcOCallApi,
-	top_pool::{
-		base_pool as base, error,
-		primitives::TrustedOperationSource,
-		validated_pool::{ValidatedOperation, ValidatedPool},
-	},
+use crate::top_pool::{
+	base_pool as base, error,
+	primitives::TrustedOperationSource,
+	validated_pool::{ValidatedOperation, ValidatedPool},
 };
 use core::matches;
 use jsonrpc_core::futures::{channel::mpsc::Receiver, future, Future};
@@ -32,6 +29,7 @@ use sp_runtime::{
 	transaction_validity::{TransactionTag as Tag, TransactionValidity, TransactionValidityError},
 };
 use std::{collections::HashMap, sync::Arc, time::Instant, untrusted::time::InstantEx, vec::Vec};
+use substratee_ocall_api::EnclaveRpcOCallApi;
 use substratee_stf::{ShardIdentifier, TrustedOperation as StfTrustedOperation};
 use substratee_worker_primitives::BlockHash as SidechainBlockHash;
 

--- a/enclave/src/top_pool/validated_pool.rs
+++ b/enclave/src/top_pool/validated_pool.rs
@@ -48,9 +48,9 @@ use sp_runtime::{
 
 use jsonrpc_core::futures::channel::mpsc::{channel, Sender};
 
-use crate::ocall::ocall_api::EnclaveRpcOCallApi;
 use codec::Encode;
 use retain_mut::RetainMut;
+use substratee_ocall_api::EnclaveRpcOCallApi;
 
 /// Pre-validated operation. Validated pool only accepts operations wrapped in this enum.
 #[derive(Debug)]

--- a/enclave/src/top_pool/watcher.rs
+++ b/enclave/src/top_pool/watcher.rs
@@ -19,11 +19,11 @@
 //! Extrinsics status updates.
 
 extern crate alloc;
-use crate::ocall::ocall_api::EnclaveRpcOCallApi;
 use alloc::{string::String, sync::Arc, vec::Vec};
 use codec::Encode;
 use sp_runtime::traits;
 use std::hash;
+use substratee_ocall_api::EnclaveRpcOCallApi;
 use substratee_worker_primitives::{BlockHash as SidechainBlockHash, TrustedOperationStatus};
 
 /// Extrinsic watcher.

--- a/primitives/ocall-api/Cargo.toml
+++ b/primitives/ocall-api/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "substratee-ocall-api"
+version = "0.8.0"
+authors = ["Supercomputing Systems AG <info@scs.ch>"]
+edition = "2018"
+resolver = "2"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+
+# substrate deps
+sp-std = { version = "3.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
+
+# sgx-deps
+sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+
+# local deps
+substratee-worker-primitives = { path = "../worker", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "substratee-worker-primitives/std",
+]

--- a/primitives/ocall-api/src/lib.rs
+++ b/primitives/ocall-api/src/lib.rs
@@ -15,10 +15,12 @@
 
 */
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use codec::{Decode, Encode};
 use core::fmt::Debug;
 use sgx_types::*;
-use std::vec::Vec;
+use sp_std::prelude::Vec;
 use substratee_worker_primitives::{
 	block::SignedBlock as SignedSidechainBlock, TrustedOperationStatus, WorkerRequest,
 	WorkerResponse,


### PR DESCRIPTION
I just realized, that with `ocall_api` abstractions, it is only the innermost implementation of the ocalls that need the sgx stuff. If we make the `ocall_api` available as separate crate, we can independently use it and start using cargo test in dependants.

- [x] first merge #338 
- [x] rebase and retarget this to master