### PR TITLE
Worker primitives are made SGX compatible, with all modules (including rpc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "approx"
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "bitvec"
@@ -5381,9 +5381,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde",
- "serde_derive",
  "serde_json",
- "sgx_tstd",
  "sp-core",
  "sp-keyring",
  "sp-runtime",

--- a/enclave/Cargo.lock
+++ b/enclave/Cargo.lock
@@ -140,9 +140,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "bitvec"
@@ -997,9 +997,9 @@ source = "git+https://github.com/scs/jsonrpc?branch=no_std#694656d8153005de90c84
 dependencies = [
  "futures 0.3.8",
  "log",
- "serde 1.0.118",
- "serde_derive",
- "serde_json 1.0.60",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde_derive 1.0.118",
+ "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
  "sp-std",
 ]
 
@@ -1899,9 +1899,17 @@ dependencies = [
 [[package]]
 name = "serde"
 version = "1.0.118"
+source = "git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
+dependencies = [
+ "sgx_tstd",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.118"
 source = "git+https://github.com/mesalock-linux/serde-sgx#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
- "serde_derive",
+ "serde_derive 1.0.118",
  "sgx_tstd",
 ]
 
@@ -1910,14 +1918,17 @@ name = "serde"
 version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
+dependencies = [
+ "serde_derive 1.0.127",
+]
 
 [[package]]
 name = "serde-big-array"
 version = "0.3.0"
 source = "git+https://github.com/mesalock-linux/serde-big-array-sgx#94122c5167aee38b39b09a620a60db2c28cf7428"
 dependencies = [
- "serde 1.0.118",
- "serde_derive",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde_derive 1.0.118",
 ]
 
 [[package]]
@@ -1931,13 +1942,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive"
+version = "1.0.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.9",
+ "syn 1.0.74",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.60"
+source = "git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3#380893814ad2a057758d825bab798aa117f7362a"
+dependencies = [
+ "itoa 0.4.5",
+ "ryu",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "sgx_tstd",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.60"
 source = "git+https://github.com/mesalock-linux/serde-json-sgx#380893814ad2a057758d825bab798aa117f7362a"
 dependencies = [
  "itoa 0.4.5",
  "ryu",
- "serde 1.0.118",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
  "sgx_tstd",
 ]
 
@@ -2022,9 +2055,9 @@ version = "1.1.3"
 source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#7c07ce0bfbacd3f4f2af53a2cdef9539018be73c"
 dependencies = [
  "itertools",
- "serde 1.0.118",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
  "serde-big-array",
- "serde_derive",
+ "serde_derive 1.0.118",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
@@ -2779,9 +2812,9 @@ dependencies = [
  "retain_mut",
  "rust-base58",
  "rustls",
- "serde 1.0.118",
- "serde_derive",
- "serde_json 1.0.60",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
+ "serde_derive 1.0.118",
+ "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx-externalities",
  "sgx_rand",
  "sgx_serialize",
@@ -2825,6 +2858,7 @@ dependencies = [
  "chrono 0.4.19",
  "parity-scale-codec",
  "primitive-types",
+ "serde 1.0.127",
  "serde_json 1.0.66",
  "sp-core",
  "sp-runtime",

--- a/enclave/Cargo.toml
+++ b/enclave/Cargo.toml
@@ -57,8 +57,8 @@ webpki = { git = "https://github.com/mesalock-linux/webpki", branch = "mesalock_
 webpki-roots = { git = "https://github.com/mesalock-linux/webpki-roots", branch = "mesalock_sgx" }
 log = { git = "https://github.com/mesalock-linux/log-sgx" }
 env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx" }
-serde = { git = "https://github.com/mesalock-linux/serde-sgx" }
-serde_json = { git = "https://github.com/mesalock-linux/serde-json-sgx" }
+serde = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx" }
+serde_json = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx" }
 yasna = { rev = "sgx_1.1.3", default-features = false, features = ["bit-vec", "num-bigint", "chrono", "mesalock_sgx"], git = "https://github.com/mesalock-linux/yasna.rs-sgx" }
 rustls = { rev = "sgx_1.1.3", features = ["dangerous_configuration"], git = "https://github.com/mesalock-linux/rustls" }
 
@@ -86,8 +86,8 @@ test-utils = { path = "../primitives/test-utils", default-features = false, feat
 chain-relay = { path = "chain_relay" }
 substratee-stf = { path = "../stf", default-features = false, features = ["sgx"] }
 substratee-storage = { path = "../primitives/storage", default-features = false }
-substratee-worker-primitives= {path = "../primitives/worker", default-features = false }
-substratee-node-primitives = {path = "../primitives/node", default-features = false, features = ["sgx"] }
+substratee-worker-primitives= { path = "../primitives/worker", default-features = false }
+substratee-node-primitives = { path = "../primitives/node", default-features = false, features = ["sgx"] }
 
 # substrate deps
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/enclave/src/rpc/worker_api_direct.rs
+++ b/enclave/src/rpc/worker_api_direct.rs
@@ -45,8 +45,8 @@ use crate::rpc::{
 
 use crate::top_pool::pool::Options as PoolOptions;
 
+use self::serde_json::*;
 use jsonrpc_core::{futures::executor, Error as RpcError, *};
-use serde_json::*;
 
 use substratee_stf::ShardIdentifier;
 

--- a/primitives/worker/Cargo.toml
+++ b/primitives/worker/Cargo.toml
@@ -7,10 +7,9 @@ edition = "2018"
 [dependencies]
 codec           = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "full"] }
 primitive-types = { version = "0.10.1", default-features = false, features = ["codec"] }
-serde           = { version = "1.0", optional = true}
-serde_derive    = { version = "1.0", optional = true}
-serde_json      = { version = "1.0", default-features = false, features = ["alloc"] }
 chrono          = { version = "0.4.19", default-features = false, features = ["alloc"]}
+serde           = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
+serde_json      = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # local deps
 substratee-storage = { path = "../storage", default-features = false }
@@ -21,18 +20,11 @@ sp-std = { version = "4.0.0-dev", default-features = false, git = "https://githu
 sp-core = { version = "4.0.0-dev", default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "master"}
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 
-# sgx deps
-sgx_tstd = { rev = "v1.1.3", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-
-
-
-
 [features]
 default = ["std"]
 std = [ 'codec/std',
         'chrono/std',
-        'serde',
-        'serde_derive',
+        'serde/std',
         'serde_json/std',
         'primitive-types/std',
         'substratee-sidechain-primitives/std',

--- a/primitives/worker/src/lib.rs
+++ b/primitives/worker/src/lib.rs
@@ -12,9 +12,7 @@ pub use substratee_sidechain_primitives::{
 	},
 };
 
-#[cfg(feature = "std")]
 pub mod rpc;
-#[cfg(feature = "std")]
 pub use rpc::*;
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
@@ -53,24 +51,6 @@ pub enum TrustedOperationStatus {
 	Dropped,
 	/// TrustedOperation is no longer valid in the current state.
 	Invalid,
-}
-
-#[derive(Encode, Decode)]
-pub struct RpcReturnValue {
-	pub value: Vec<u8>,
-	pub do_watch: bool,
-	pub status: DirectRequestStatus,
-	//pub signature: Signature,
-}
-impl RpcReturnValue {
-	pub fn new(val: Vec<u8>, watch: bool, status: DirectRequestStatus) -> Self {
-		Self {
-			value: val,
-			do_watch: watch,
-			status,
-			//signature: sign,
-		}
-	}
 }
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq)]

--- a/primitives/worker/src/rpc.rs
+++ b/primitives/worker/src/rpc.rs
@@ -1,6 +1,27 @@
+extern crate alloc;
+
+use crate::DirectRequestStatus;
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
 use codec::{Decode, Encode};
 use serde::{Deserialize, Serialize};
-use std::string::String;
+
+#[derive(Encode, Decode)]
+pub struct RpcReturnValue {
+	pub value: Vec<u8>,
+	pub do_watch: bool,
+	pub status: DirectRequestStatus,
+	//pub signature: Signature,
+}
+impl RpcReturnValue {
+	pub fn new(val: Vec<u8>, watch: bool, status: DirectRequestStatus) -> Self {
+		Self {
+			value: val,
+			do_watch: watch,
+			status,
+			//signature: sign,
+		}
+	}
+}
 
 #[derive(Clone, Encode, Decode, Serialize, Deserialize)]
 // Todo: result should not be Vec<u8>, but `T: Serialize`


### PR DESCRIPTION
The worker primitives crate has now all its module available in the SGX environment (specifically the RPC structs that use serde)