### PR TITLE
[chain relay] update justifications

### DIFF
--- a/enclave/chain_relay/Cargo.toml
+++ b/enclave/chain_relay/Cargo.toml
@@ -16,7 +16,7 @@ hash-db = { version = "0.15.2", default-features = false }
 log = { git = "https://github.com/mesalock-linux/log-sgx" }
 num = { package = "num-traits", version = "0.2", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-grandpa = { package = "finality-grandpa", version = "0.14.1", default-features = false, features = ["derive-codec"] }
+finality-grandpa = { version = "0.14.3", default-features = false, features = ["derive-codec"] }
 
 # local deps
 substratee-storage = { path = "../../primitives/storage", default-features = false }

--- a/enclave/chain_relay/Cargo.toml
+++ b/enclave/chain_relay/Cargo.toml
@@ -16,7 +16,7 @@ hash-db = { version = "0.15.2", default-features = false }
 log = { git = "https://github.com/mesalock-linux/log-sgx" }
 num = { package = "num-traits", version = "0.2", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
-finality-grandpa = { version = "0.14.3", default-features = false }
+grandpa = { package = "finality-grandpa", version = "0.14.1", default-features = false, features = ["derive-codec"] }
 
 # local deps
 substratee-storage = { path = "../../primitives/storage", default-features = false }

--- a/enclave/chain_relay/src/error.rs
+++ b/enclave/chain_relay/src/error.rs
@@ -1,6 +1,5 @@
 use crate::std::string::String;
 use derive_more::{Display, From};
-use std::convert::From;
 
 /// Substrate Client error
 #[derive(Debug, Display, From)]
@@ -12,6 +11,8 @@ pub enum JustificationError {
 	#[display(fmt = "bad justification for header: {}", _0)]
 	#[from(ignore)]
 	BadJustification(String),
+	/// Invalid authorities set received from the runtime.
+	InvalidAuthoritiesSet
 }
 
 #[derive(Debug, From)]
@@ -22,16 +23,7 @@ pub enum Error {
 	ValidatorSetMismatch,
 	InvalidAncestryProof,
 	NoSuchRelayExists,
-	InvalidFinalityProof,
+	InvalidFinalityProof(JustificationError),
 	// UnknownClientError,
 	HeaderAncestryMismatch,
-}
-
-impl From<JustificationError> for Error {
-	fn from(e: JustificationError) -> Self {
-		match e {
-			JustificationError::BadJustification(_) | JustificationError::JustificationDecode =>
-				Error::InvalidFinalityProof,
-		}
-	}
 }

--- a/enclave/chain_relay/src/error.rs
+++ b/enclave/chain_relay/src/error.rs
@@ -12,7 +12,7 @@ pub enum JustificationError {
 	#[from(ignore)]
 	BadJustification(String),
 	/// Invalid authorities set received from the runtime.
-	InvalidAuthoritiesSet
+	InvalidAuthoritiesSet,
 }
 
 #[derive(Debug, From)]

--- a/enclave/chain_relay/src/justification.rs
+++ b/enclave/chain_relay/src/justification.rs
@@ -22,15 +22,12 @@ use crate::std::{
 
 use super::error::JustificationError as ClientError;
 use finality_grandpa::{voter_set::VoterSet, Error as GrandpaError};
-use sp_finality_grandpa::{AuthorityId, AuthorityPair, AuthoritySignature, RoundNumber, SetId, AuthorityList};
+use sp_finality_grandpa::{AuthorityId, AuthoritySignature, AuthorityList};
 use sp_runtime::{
-	generic::BlockId,
 	traits::{Block as BlockT, Header as HeaderT, NumberFor},
 };
 use codec::{Encode, Decode};
 use log::*;
-use sp_core::Pair;
-
 
 /// A commit message for this chain's block type.
 pub type Commit<Block> = finality_grandpa::Commit<
@@ -48,7 +45,7 @@ pub type Commit<Block> = finality_grandpa::Commit<
 ///
 /// This is meant to be stored in the db and passed around the network to other
 /// nodes, and are used by syncing nodes to prove authority set handoffs.
-#[derive(Clone, Encode, Decode, PartialEq, Eq, Debug)]
+#[derive(Clone, Encode, Decode, PartialEq, Eq)]
 pub struct GrandpaJustification<Block: BlockT> {
 	round: u64,
 	pub(crate) commit: Commit<Block>,
@@ -81,12 +78,12 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 	}
 
 	/// Validate the commit and the votes' ancestry proofs.
-	pub fn verify(&self, set_id: u64, authorities: &AuthorityList) -> Result<(), ClientError>
+	pub fn verify(&self, set_id: u64, authorities: AuthorityList) -> Result<(), ClientError>
 	where
 		NumberFor<Block>: finality_grandpa::BlockNumberOps,
 	{
 		let voters = VoterSet::new(authorities.iter().cloned())
-			.ok_or(ClientError::Consensus(sp_consensus::Error::InvalidAuthoritiesSet))?;
+			.ok_or(ClientError::InvalidAuthoritiesSet)?;
 
 		self.verify_with_voter_set(set_id, &voters)
 	}

--- a/enclave/chain_relay/src/justification.rs
+++ b/enclave/chain_relay/src/justification.rs
@@ -81,7 +81,7 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 		NumberFor<Block>: finality_grandpa::BlockNumberOps,
 	{
 		let voters =
-			VoterSet::new(authorities.iter().cloned()).ok_or(ClientError::InvalidAuthoritiesSet)?;
+			VoterSet::new(authorities.into_iter()).ok_or(ClientError::InvalidAuthoritiesSet)?;
 
 		self.verify_with_voter_set(set_id, &voters)
 	}

--- a/enclave/chain_relay/src/justification.rs
+++ b/enclave/chain_relay/src/justification.rs
@@ -21,13 +21,11 @@ use crate::std::{
 };
 
 use super::error::JustificationError as ClientError;
+use codec::{Decode, Encode};
 use finality_grandpa::{voter_set::VoterSet, Error as GrandpaError};
-use sp_finality_grandpa::{AuthorityId, AuthoritySignature, AuthorityList};
-use sp_runtime::{
-	traits::{Block as BlockT, Header as HeaderT, NumberFor},
-};
-use codec::{Encode, Decode};
 use log::*;
+use sp_finality_grandpa::{AuthorityId, AuthorityList, AuthoritySignature};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT, NumberFor};
 
 /// A commit message for this chain's block type.
 pub type Commit<Block> = finality_grandpa::Commit<
@@ -82,8 +80,8 @@ impl<Block: BlockT> GrandpaJustification<Block> {
 	where
 		NumberFor<Block>: finality_grandpa::BlockNumberOps,
 	{
-		let voters = VoterSet::new(authorities.iter().cloned())
-			.ok_or(ClientError::InvalidAuthoritiesSet)?;
+		let voters =
+			VoterSet::new(authorities.iter().cloned()).ok_or(ClientError::InvalidAuthoritiesSet)?;
 
 		self.verify_with_voter_set(set_id, &voters)
 	}

--- a/enclave/chain_relay/src/lib.rs
+++ b/enclave/chain_relay/src/lib.rs
@@ -170,14 +170,6 @@ impl LightValidation {
 		Block: BlockT,
 		NumberFor<Block>: finality_grandpa::BlockNumberOps,
 	{
-		if justification.0 != GRANDPA_ENGINE_ID {
-			// TODO: the import queue needs to be refactored to be able dispatch to the correct
-			// `JustificationImport` instance based on `ConsensusEngineId`, or we need to build a
-			// justification import pipeline similar to what we do for `BlockImport`. In the
-			// meantime we'll just drop the justification, since this is only used for BEEFY which
-			// is still WIP.
-			return Ok(())
-		}
 		// We don't really care about the justification, as long as it's valid
 		let _ = GrandpaJustification::<Block>::decode_and_verify_finalizes(
 			&justification.1,


### PR DESCRIPTION
- removal of communication block (speficially functions `localized_payload_with_buffer` and `check_message_sig_with_buffer`) because they are now implemented in the [sp_finality_grandpa crate](https://github.com/paritytech/substrate/tree/master/primitives/finality-grandpa) which implements no_std.
- adaptions (mostly copy paste) according to substrate [sc-finality-grandpa justifications.rs](https://github.com/paritytech/substrate/blob/master/client/finality-grandpa/src/justification.rs)
- chain relay will not panic upon faulty justification but print an error message