### PR TITLE
[GA] bump node artifact.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -172,7 +172,7 @@ jobs:
           name: integritee-node-skip-ias-check
           # in fact this action should download the latest artifact, but sometimes fails. Then we need to
           # set the `run_id` to force a download of an updated binary.
-          run_id: 1116673694
+          run_id: 1184880114
           path: node
           repo: integritee-network/integritee-node
 


### PR DESCRIPTION
The current enclave prefunding amount requires a reasonable ED configuration. Otherwise, the funds will be below what is needed to pay tx fees

Hence, a node update is required.