### PR TITLE
move `OpaqueCall` to itp_types and use `OpaqueExtrinsic` consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,6 +2291,7 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "sgx_types",
+ "sp-runtime",
  "sp-std",
 ]
 

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -220,9 +220,13 @@ impl Stf {
 					);
 
 					Self::unshield_funds(account_incognito, value)?;
-					calls.push(OpaqueCall(
-						([TEEREX_MODULE, UNSHIELD], beneficiary, value, shard, call_hash).encode(),
-					));
+					calls.push(OpaqueCall::from_tuple(&(
+						[TEEREX_MODULE, UNSHIELD],
+						beneficiary,
+						value,
+						shard,
+						call_hash,
+					)));
 					Ok(())
 				},
 				TrustedCall::balance_shield(root, who, value) => {

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use itp_storage::storage_value_key;
-use itp_types::SidechainBlockNumber;
+use itp_types::{OpaqueCall, SidechainBlockNumber};
 use log_sgx::*;
 use sgx_externalities::SgxExternalitiesTypeTrait;
 use sgx_runtime::{BlockNumber as L1BlockNumer, Runtime};
@@ -20,16 +20,6 @@ use support::{ensure, traits::UnfilteredDispatchable};
 
 #[cfg(feature = "test")]
 use crate::test_genesis::test_genesis_setup;
-
-/// Simple blob that holds a call in encoded format
-#[derive(Clone, Debug)]
-pub struct OpaqueCall(pub Vec<u8>);
-
-impl Encode for OpaqueCall {
-	fn encode(&self) -> Vec<u8> {
-		self.0.clone()
-	}
-}
 
 pub trait StfTrait = SgxExternalitiesTrait + StateHash + Clone + Send + Sync;
 

--- a/core-primitives/ocall-api/Cargo.toml
+++ b/core-primitives/ocall-api/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 
 # substrate deps
+sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
 
 # sgx-deps
@@ -21,5 +22,7 @@ itp-types = { path = "../types", default-features = false }
 default = ["std"]
 std = [
     "codec/std",
+    "sp-runtime/std",
+    "sp-std/std",
     "itp-types/std",
 ]

--- a/core-primitives/ocall-api/src/lib.rs
+++ b/core-primitives/ocall-api/src/lib.rs
@@ -24,6 +24,7 @@ use itp_types::{
 	WorkerResponse,
 };
 use sgx_types::*;
+use sp_runtime::OpaqueExtrinsic;
 use sp_std::prelude::Vec;
 
 /// Trait for the enclave to make o-calls related to remote attestation
@@ -65,7 +66,7 @@ pub trait EnclaveRpcOCallApi: Clone + Debug + Send + Sync + Default {
 pub trait EnclaveOnChainOCallApi: Clone + Debug + Send + Sync {
 	fn send_block_and_confirmation(
 		&self,
-		confirmations: Vec<Vec<u8>>,
+		confirmations: Vec<OpaqueExtrinsic>,
 		signed_blocks: Vec<SignedSidechainBlock>,
 	) -> SgxResult<()>;
 

--- a/core-primitives/types/src/lib.rs
+++ b/core-primitives/types/src/lib.rs
@@ -42,13 +42,21 @@ pub type Header = HeaderG<BlockNumber, BlakeTwo256>;
 pub type Block = BlockG<Header, OpaqueExtrinsic>;
 pub type SignedBlock = SignedBlockG<Block>;
 
-/// Simple blob that holds a call in encoded format
-#[derive(Clone, Debug)]
-pub struct OpaqueCall(pub Vec<u8>);
+/// Simple blob to hold an call without committing to its format and ensure it is serialized
+/// correctly.
+#[derive(Debug, PartialEq, Eq, Clone, Default, Encode, Decode)]
+pub struct OpaqueCall(Vec<u8>);
 
-impl Encode for OpaqueCall {
-	fn encode(&self) -> Vec<u8> {
-		self.0.clone()
+impl OpaqueCall {
+	/// Convert an encoded call to an `OpaqueCall`.
+	pub fn from_bytes(mut bytes: &[u8]) -> Result<Self, codec::Error> {
+		Self::decode(&mut bytes)
+	}
+
+	pub fn from_tuple<C: Encode>(call: &C) -> Self {
+		call.using_encoded(|mut c| {
+			Self::decode(&mut c).expect("A previously encoded call has valid codec; qed.")
+		})
 	}
 }
 

--- a/core-primitives/types/src/lib.rs
+++ b/core-primitives/types/src/lib.rs
@@ -42,21 +42,20 @@ pub type Header = HeaderG<BlockNumber, BlakeTwo256>;
 pub type Block = BlockG<Header, OpaqueExtrinsic>;
 pub type SignedBlock = SignedBlockG<Block>;
 
-/// Simple blob to hold an call without committing to its format and ensure it is serialized
-/// correctly.
-#[derive(Debug, PartialEq, Eq, Clone, Default, Encode, Decode)]
-pub struct OpaqueCall(Vec<u8>);
+/// Simple blob to hold an encoded call
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct OpaqueCall(pub Vec<u8>);
 
 impl OpaqueCall {
 	/// Convert an encoded call to an `OpaqueCall`.
-	pub fn from_bytes(mut bytes: &[u8]) -> Result<Self, codec::Error> {
-		Self::decode(&mut bytes)
-	}
-
 	pub fn from_tuple<C: Encode>(call: &C) -> Self {
-		call.using_encoded(|mut c| {
-			Self::decode(&mut c).expect("A previously encoded call has valid codec; qed.")
-		})
+		OpaqueCall(call.encode())
+	}
+}
+
+impl Encode for OpaqueCall {
+	fn encode(&self) -> Vec<u8> {
+		self.0.clone()
 	}
 }
 

--- a/core-primitives/types/src/lib.rs
+++ b/core-primitives/types/src/lib.rs
@@ -42,6 +42,16 @@ pub type Header = HeaderG<BlockNumber, BlakeTwo256>;
 pub type Block = BlockG<Header, OpaqueExtrinsic>;
 pub type SignedBlock = SignedBlockG<Block>;
 
+/// Simple blob that holds a call in encoded format
+#[derive(Clone, Debug)]
+pub struct OpaqueCall(pub Vec<u8>);
+
+impl Encode for OpaqueCall {
+	fn encode(&self) -> Vec<u8> {
+		self.0.clone()
+	}
+}
+
 // Note in the pallet teerex this is a struct. But for the codec this does not matter.
 #[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
 pub struct Request {

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "sgx_types",
+ "sp-runtime",
  "sp-std",
 ]
 

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -484,9 +484,12 @@ where
 		let genesis_hash = validator.genesis_hash(validator.num_relays()).unwrap();
 		let block_hash = signed_block.block.header.hash();
 		let prev_state_hash = signed_block.block.header.parent_hash();
-		calls.push(OpaqueCall(
-			(xt_block, genesis_hash, block_hash, prev_state_hash.encode()).encode(),
-		));
+		calls.push(OpaqueCall::from_tuple(&(
+			xt_block,
+			genesis_hash,
+			block_hash,
+			prev_state_hash.encode(),
+		)));
 	}
 
 	Ok(calls)
@@ -777,7 +780,7 @@ pub fn compose_block_and_confirmation(
 
 	let xt_block = [TEEREX_MODULE, BLOCK_CONFIRMED];
 	let opaque_call =
-		OpaqueCall((xt_block, shard, block_hash, state_hash_aposteriori.encode()).encode());
+		OpaqueCall::from_tuple(&(xt_block, shard, block_hash, state_hash_aposteriori.encode()));
 	Ok((opaque_call, signed_block))
 }
 
@@ -923,7 +926,7 @@ fn handle_shield_funds_xt(
 	let call_hash = blake2_256(&xt.encode());
 	debug!("Call hash 0x{}", hex::encode_hex(&call_hash));
 
-	calls.push(OpaqueCall((xt_call, shard, call_hash, state_hash.encode()).encode()));
+	calls.push(OpaqueCall::from_tuple(&(xt_call, shard, call_hash, state_hash.encode())));
 
 	Ok(())
 }

--- a/enclave-runtime/src/ocall/on_chain_ocall.rs
+++ b/enclave-runtime/src/ocall/on_chain_ocall.rs
@@ -23,12 +23,13 @@ use itp_ocall_api::EnclaveOnChainOCallApi;
 use itp_types::{block::SignedBlock as SignedSidechainBlock, WorkerRequest, WorkerResponse};
 use log::*;
 use sgx_types::*;
+use sp_runtime::OpaqueExtrinsic;
 use std::vec::Vec;
 
 impl EnclaveOnChainOCallApi for OcallApi {
 	fn send_block_and_confirmation(
 		&self,
-		confirmations: Vec<Vec<u8>>,
+		confirmations: Vec<OpaqueExtrinsic>,
 		signed_blocks: Vec<SignedSidechainBlock>,
 	) -> SgxResult<()> {
 		let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;

--- a/enclave-runtime/src/tests.rs
+++ b/enclave-runtime/src/tests.rs
@@ -189,7 +189,7 @@ fn test_compose_block_and_confirmation() {
 	.unwrap();
 	let xt_block_encoded = [TEEREX_MODULE, BLOCK_CONFIRMED].encode();
 	let block_hash_encoded = blake2_256(&signed_block.block().encode()).encode();
-	let mut opaque_call_vec = opaque_call.0;
+	let mut opaque_call_vec = opaque_call.encode();
 
 	// then
 	assert!(signed_block.verify_signature());
@@ -429,7 +429,7 @@ fn test_create_block_and_confirmation_works() {
 	debug!("got {} signed block(s)", signed_blocks.len());
 
 	let signed_block = signed_blocks[index].clone();
-	let mut opaque_call_vec = confirm_calls[index].0.clone();
+	let mut opaque_call_vec = confirm_calls[index].encode();
 	let xt_block_encoded = [TEEREX_MODULE, BLOCK_CONFIRMED].encode();
 	let block_hash_encoded = blake2_256(&signed_block.block().encode()).encode();
 


### PR DESCRIPTION
Minor adjustment I did while preparing aura.