### PR TITLE
Fix interval block production

### DIFF
--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -37,7 +37,7 @@ extern "C" {
 		latest_header_size: usize,
 	) -> sgx_status_t;
 
-	pub fn produce_blocks(
+	pub fn sync_parentchain_and_execute_tops(
 		eid: sgx_enclave_id_t,
 		retval: *mut sgx_status_t,
 		blocks: *const u8,

--- a/core-primitives/enclave-api/src/side_chain.rs
+++ b/core-primitives/enclave-api/src/side_chain.rs
@@ -17,21 +17,38 @@
 */
 
 use crate::{error::Error, Enclave, EnclaveResult};
+use codec::Encode;
 use frame_support::ensure;
 use itp_enclave_api_ffi as ffi;
 use sgx_types::sgx_status_t;
+use sp_runtime::{generic::SignedBlock, traits::Block};
 
 /// trait for handling blocks on the side chain
 pub trait SideChain: Send + Sync + 'static {
-	fn produce_blocks(&self, blocks: Vec<u8>, nonce: u32) -> EnclaveResult<()>;
+	fn produce_blocks<PB: Block>(
+		&self,
+		blocks: &[SignedBlock<PB>],
+		nonce: u32,
+	) -> EnclaveResult<()>;
 }
 
 impl SideChain for Enclave {
-	fn produce_blocks(&self, blocks: Vec<u8>, nonce: u32) -> EnclaveResult<()> {
+	fn produce_blocks<PB: Block>(
+		&self,
+		blocks: &[SignedBlock<PB>],
+		nonce: u32,
+	) -> EnclaveResult<()> {
 		let mut retval = sgx_status_t::SGX_SUCCESS;
+		let blocks_enc = blocks.encode();
 
 		let result = unsafe {
-			ffi::produce_blocks(self.eid, &mut retval, blocks.as_ptr(), blocks.len(), &nonce)
+			ffi::produce_blocks(
+				self.eid,
+				&mut retval,
+				blocks_enc.as_ptr(),
+				blocks_enc.len(),
+				&nonce,
+			)
 		};
 
 		ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));

--- a/core-primitives/enclave-api/src/side_chain.rs
+++ b/core-primitives/enclave-api/src/side_chain.rs
@@ -25,7 +25,8 @@ use sp_runtime::{generic::SignedBlock, traits::Block};
 
 /// trait for handling blocks on the side chain
 pub trait SideChain: Send + Sync + 'static {
-	fn produce_blocks<PB: Block>(
+	/// Sync parentchain blocks and execute pending tops in the enclave
+	fn sync_parentchain_and_execute_tops<PB: Block>(
 		&self,
 		blocks: &[SignedBlock<PB>],
 		nonce: u32,
@@ -33,7 +34,7 @@ pub trait SideChain: Send + Sync + 'static {
 }
 
 impl SideChain for Enclave {
-	fn produce_blocks<PB: Block>(
+	fn sync_parentchain_and_execute_tops<PB: Block>(
 		&self,
 		blocks: &[SignedBlock<PB>],
 		nonce: u32,
@@ -42,7 +43,7 @@ impl SideChain for Enclave {
 		let blocks_enc = blocks.encode();
 
 		let result = unsafe {
-			ffi::produce_blocks(
+			ffi::sync_parentchain_and_execute_tops(
 				self.eid,
 				&mut retval,
 				blocks_enc.as_ptr(),

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -51,7 +51,7 @@ enclave {
             [out, size=latest_header_size] uint8_t* latest_header, size_t latest_header_size
         );
 
-        public sgx_status_t produce_blocks(
+        public sgx_status_t sync_parentchain_and_execute_tops(
             [in, size=blocks_size] uint8_t* blocks, size_t blocks_size,
             [in] uint32_t* nonce
         );

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -447,7 +447,7 @@ pub unsafe extern "C" fn sync_parentchain_and_execute_tops(
 ///
 /// Sync parentchain blocks to the light-client and execute pending trusted operations.
 ///
-/// This function x	 an ecall that does the following:
+/// This function makes an ecall that does the following:
 ///
 /// *   send `confirm_call` xt's of the `Stf` functions executed due to in-/direct invocation to the
 ///     to the parentchain

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -550,10 +550,7 @@ pub fn produce_blocks<E: EnclaveBase + SideChain>(
 		let tee_nonce = api.get_nonce_of(&tee_accountid).unwrap();
 
 		// Produce blocks
-		if let Err(e) = chunk
-			.to_vec()
-			.using_encoded(|b| enclave_api.produce_blocks(b.to_vec(), tee_nonce))
-		{
+		if let Err(e) = enclave_api.produce_blocks(chunk, tee_nonce) {
 			error!("{:?}", e);
 			// enclave might not have synced
 			return last_synced_head

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -537,21 +537,15 @@ pub fn produce_blocks<E: EnclaveBase + SideChain>(
 	api: &Api<sr25519::Pair, WsRpcClient>,
 	last_synced_head: Header,
 ) -> Header {
-	// obtain latest finalized block from layer one
-	debug!("Getting current head");
+	let tee_accountid = enclave_account(enclave_api);
+
+	trace!("Getting current head");
 	let curr_head: SignedBlock = api.last_finalized_block().unwrap().unwrap();
+	let head_block_number = curr_head.block.header.number;
 
 	let blocks_to_sync = get_blocks_to_sync(api, &last_synced_head, &curr_head);
 
-	let tee_accountid = enclave_account(enclave_api);
-
 	// only feed BLOCK_SYNC_BATCH_SIZE blocks at a time into the enclave to save enclave state regularly
-	let mut current_block_number = if curr_head.block.header.hash() == last_synced_head.hash() {
-		curr_head.block.header.number as usize
-	} else {
-		blocks_to_sync.first().map(|h| h.block.header.number as usize).unwrap_or(0)
-	};
-
 	for chunk in blocks_to_sync.chunks(BLOCK_SYNC_BATCH_SIZE as usize) {
 		let tee_nonce = api.get_nonce_of(&tee_accountid).unwrap();
 
@@ -565,11 +559,10 @@ pub fn produce_blocks<E: EnclaveBase + SideChain>(
 			return last_synced_head
 		};
 
-		current_block_number += chunk.len();
 		println!(
 			"Synced {} blocks out of {} finalized blocks",
-			current_block_number,
-			blocks_to_sync[0].block.header.number as usize + blocks_to_sync.len()
+			chunk.last().map(|b| b.block.header.number).expect("Chunk can't be empty; qed"),
+			head_block_number,
 		)
 	}
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -560,7 +560,6 @@ pub fn produce_blocks<E: EnclaveBase + SideChain>(
 	for chunk in blocks_to_sync.chunks(BLOCK_SYNC_BATCH_SIZE as usize) {
 		let tee_nonce = api.get_nonce_of(&tee_accountid).unwrap();
 
-		// Produce blocks
 		if let Err(e) = enclave_api.produce_blocks(chunk, tee_nonce) {
 			error!("{:?}", e);
 			// enclave might not have synced
@@ -572,8 +571,7 @@ pub fn produce_blocks<E: EnclaveBase + SideChain>(
 
 		println!(
 			"Synced {} blocks out of {} finalized blocks",
-			chunk.last().map(|b| b.block.header.number).expect("Chunk can't be empty; qed"),
-			head_block_number,
+			last_synced_head.number, head_block_number,
 		)
 	}
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -575,7 +575,7 @@ pub fn produce_blocks<E: EnclaveBase + SideChain>(
 		)
 	}
 
-	curr_head.block.header
+	last_synced_head
 }
 
 /// gets a list of blocks that need to be synced, ordered from oldest to most recent header

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -535,7 +535,7 @@ pub fn init_light_client<E: EnclaveBase + SideChain>(
 pub fn produce_blocks<E: EnclaveBase + SideChain>(
 	enclave_api: &E,
 	api: &Api<sr25519::Pair, WsRpcClient>,
-	last_synced_head: Header,
+	mut last_synced_head: Header,
 ) -> Header {
 	let tee_accountid = enclave_account(enclave_api);
 
@@ -555,6 +555,9 @@ pub fn produce_blocks<E: EnclaveBase + SideChain>(
 			// enclave might not have synced
 			return last_synced_head
 		};
+
+		last_synced_head =
+			chunk.last().map(|b| b.block.header.clone()).expect("Chunk can't be empty; qed");
 
 		println!(
 			"Synced {} blocks out of {} finalized blocks",

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -529,9 +529,15 @@ pub fn init_light_client<E: EnclaveBase + SideChain>(
 	produce_blocks(enclave_api, api, latest)
 }
 
-/// Starts block production
+/// Gets the amount of blocks to sync from the parentchain and feeds them to the enclave.
 ///
-/// Returns the last synced header of layer one
+/// It also calls into the enclave if there are no blocks to sync because the enclave does
+/// currently two things in `produce_blocks`:
+///
+/// * sync blocks
+/// * execute pending trusted operations
+///
+/// Todo: the two tasks above should be independent: #404
 pub fn produce_blocks<E: EnclaveBase + SideChain>(
 	enclave_api: &E,
 	api: &Api<sr25519::Pair, WsRpcClient>,

--- a/service/src/tests/integration_tests.rs
+++ b/service/src/tests/integration_tests.rs
@@ -71,7 +71,7 @@ pub fn call_worker_encrypted_set_balance_works<E: EnclaveBase + SideChain>(
 	println!("Sleeping until block with shield funds is finalized...");
 	sleep(Duration::new(10, 0));
 	println!("Syncing light client to look for shield_funds extrinsic");
-	crate::produce_blocks(enclave_api, &api, last_synced_head)
+	crate::sync_parentchain_and_execute_tops(enclave_api, &api, last_synced_head)
 }
 
 pub fn forward_encrypted_unshield_works<E: EnclaveBase + SideChain>(
@@ -93,7 +93,7 @@ pub fn forward_encrypted_unshield_works<E: EnclaveBase + SideChain>(
 	println!("Sleeping until block with shield funds is finalized...");
 	sleep(Duration::new(10, 0));
 	println!("Syncing light client to look for CallWorker with TrustedCall::unshield extrinsic");
-	crate::produce_blocks(enclave_api, &api, last_synced_head)
+	crate::sync_parentchain_and_execute_tops(enclave_api, &api, last_synced_head)
 }
 
 pub fn init_light_client<E: EnclaveBase + SideChain>(port: &str, enclave_api: &E) -> Header {
@@ -122,5 +122,5 @@ pub fn shield_funds_workds<E: EnclaveBase + SideChain>(
 	println!("Sleeping until block with shield funds is finalized...");
 	sleep(Duration::new(10, 0));
 	println!("Syncing light client to look for shield_funds extrinsic");
-	crate::produce_blocks(enclave_api, &api, last_synced_head)
+	crate::sync_parentchain_and_execute_tops(enclave_api, &api, last_synced_head)
 }


### PR DESCRIPTION
In was intended that we produce sidechain blocks at a certain interval. However, this did actually not work as it should before.

The implementation before failed to call in the enclave if there were no `blocks_to_sync`. Hence, the sidechain's block production time was limited to the parentchain's block production time.

This is fixed here, we call into the enclave regardless of `blocks_to_sync` being empty or not.

Closes #405 