### PR TITLE
New REST client crate, based on http_req and rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,14 @@ dependencies = [
 
 [[package]]
 name = "bytes"
+version = "0.5.4"
+source = "git+https://github.com/mesalock-linux/bytes-sgx#63d1951a35f2e888696aba3796aac45214e727ec"
+dependencies = [
+ "sgx_tstd",
+]
+
+[[package]]
+name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
@@ -1879,6 +1887,17 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.2.1"
+source = "git+https://github.com/mesalock-linux/http-sgx?tag=sgx_1.1.3#62544a1833f98f1810a44877c5f1efe45f5327c0"
+dependencies = [
+ "bytes 0.5.4",
+ "fnv 1.0.6",
+ "itoa 0.4.5",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "http"
+version = "0.2.1"
 source = "git+https://github.com/integritee-network/http-sgx?branch=sgx-experimental#307b5421fb7a489a114bede0dc05c8d32b804f49"
 dependencies = [
  "bytes 1.0.1",
@@ -1917,6 +1936,30 @@ dependencies = [
  "bytes 1.1.0",
  "http 0.2.4",
  "pin-project-lite 0.2.7",
+]
+
+[[package]]
+name = "http_req"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dab1fb99f5163b9b25805e4c191ea9425ae311442688bfe03c97e8a2ba66e9d"
+dependencies = [
+ "rustls 0.19.1",
+ "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki-roots 0.21.1",
+]
+
+[[package]]
+name = "http_req"
+version = "0.7.2"
+source = "git+https://github.com/mesalock-linux/http_req-sgx?tag=sgx_1.1.3#5d0f7474c73b70d2dbdda69c1db2a2e31aee6eb8"
+dependencies = [
+ "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
+ "sgx_tstd",
+ "unicase 2.6.0 (git+https://github.com/mesalock-linux/unicase-sgx)",
+ "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
+ "webpki-roots 0.21.0 (git+https://github.com/mesalock-linux/webpki-roots?branch=mesalock_sgx)",
 ]
 
 [[package]]
@@ -2407,6 +2450,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "itc-rest-client"
+version = "0.8.0"
+dependencies = [
+ "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.2.1 (git+https://github.com/mesalock-linux/http-sgx?tag=sgx_1.1.3)",
+ "http 0.2.4",
+ "http_req 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http_req 0.7.2 (git+https://github.com/mesalock-linux/http_req-sgx?tag=sgx_1.1.3)",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.130",
+ "serde_json 1.0.67",
+ "sgx_tstd",
+ "sgx_types",
+ "thiserror 1.0.28",
+ "thiserror 1.0.9",
+ "url 2.1.1",
+ "url 2.2.2",
+]
+
+[[package]]
 name = "itc-rpc-client"
 version = "0.8.0"
 dependencies = [
@@ -2774,7 +2837,7 @@ dependencies = [
  "socket2",
  "thiserror 1.0.28",
  "tokio 1.11.0",
- "unicase",
+ "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3120,7 +3183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
- "unicase",
+ "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -6633,7 +6696,7 @@ dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?tag=sgx_1.1.3)",
  "byteorder 1.3.4",
  "bytes 1.0.1",
- "http 0.2.1",
+ "http 0.2.1 (git+https://github.com/integritee-network/http-sgx?branch=sgx-experimental)",
  "httparse 1.4.1",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx?tag=sgx_1.1.3)",
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",
@@ -6644,7 +6707,7 @@ dependencies = [
  "url 2.1.1",
  "utf-8 0.7.4",
  "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
- "webpki-roots",
+ "webpki-roots 0.21.0 (git+https://github.com/mesalock-linux/webpki-roots?tag=sgx_1.1.3)",
 ]
 
 [[package]]
@@ -6699,6 +6762,15 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "git+https://github.com/mesalock-linux/unicase-sgx#0b0519348572927118af47af3da4da9ffdca8ec6"
+dependencies = [
+ "sgx_tstd",
  "version_check",
 ]
 
@@ -7043,6 +7115,24 @@ source = "git+https://github.com/mesalock-linux/webpki-roots?tag=sgx_1.1.3#6ff3b
 dependencies = [
  "sgx_tstd",
  "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.0"
+source = "git+https://github.com/mesalock-linux/webpki-roots?branch=mesalock_sgx#6ff3be547ac13ccd46ae55605ad6506ce30688ef"
+dependencies = [
+ "sgx_tstd",
+ "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "core/light-client",
     "core/direct-rpc-server",
     "core/tls-websocket-server",
+    "core/rest-client",
     "core-primitives/api-client-extensions",
     "core-primitives/enclave-api",
     "core-primitives/enclave-api/ffi",

--- a/core/rest-client/Cargo.toml
+++ b/core/rest-client/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "itc-rest-client"
+version = "0.8.0"
+authors = ["Integritee AG <hello@integritee.network>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["std"]
+std = [
+    "http",
+    "http_req",
+    "thiserror",
+    "url",
+]
+sgx = [
+    "http-sgx",
+    "http_req-sgx",
+    "sgx_types",
+    "sgx_tstd",
+    "thiserror_sgx",
+    "url_sgx",
+]
+
+[dependencies]
+
+# std dependencies
+http_req = { version = "0.7", optional = true, default-features = false, features = ["rust-tls"] }
+http = { version = "0.2", optional = true }
+thiserror = { version = "1.0.26", optional = true }
+url = { version = "2.0.0", optional = true }
+
+# sgx dependencies
+http_req-sgx = { package = "http_req", git = "https://github.com/mesalock-linux/http_req-sgx", tag = "sgx_1.1.3", optional = true }
+http-sgx = { package = "http", git = "https://github.com/mesalock-linux/http-sgx", tag = "sgx_1.1.3", optional = true }
+sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
+url_sgx = { package = "url", git = "https://github.com/mesalock-linux/rust-url-sgx", tag = "sgx_1.1.3", optional = true }
+
+# no_std dependencies
+base64 = { version = "0.13", default-features = false, features = ["alloc"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+log = { version = "0.4", default-features = false }

--- a/core/rest-client/src/error.rs
+++ b/core/rest-client/src/error.rs
@@ -1,0 +1,58 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use std::string::String;
+
+/// REST client error
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("HTTP client creation failed")]
+	HttpClientError,
+
+	#[error("Failed to parse final URL.")]
+	UrlError,
+
+	#[error("Failed to serialize struct to JSON (in POST): {0}")]
+	SerializeParseError(serde_json::Error),
+
+	#[error("Failed to deserialize data to struct (in GET or POST response: {0} {1}")]
+	DeserializeParseError(serde_json::Error, String),
+
+	#[error("Failed to make the outgoing request")]
+	RequestError,
+
+	#[error("HTTP header error: {0}")]
+	HttpHeaderError(http::header::ToStrError),
+
+	#[error(transparent)]
+	HttpReqError(#[from] http_req::error::Error),
+
+	#[error("Failed to perform IO operation: {0}")]
+	IoError(std::io::Error),
+
+	#[error("Server returned non-success status: {0}, details: {1}")]
+	HttpError(u16, String),
+
+	#[error("Request has timed out")]
+	TimeoutError,
+
+	#[error("Invalid parameter value")]
+	InvalidValue,
+}

--- a/core/rest-client/src/http_client.rs
+++ b/core/rest-client/src/http_client.rs
@@ -1,0 +1,435 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use crate::{error::Error, Query, RestPath};
+use http::{
+	header::{HeaderName, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT},
+	HeaderValue,
+};
+use http_req::{
+	request::{Method, Request},
+	response::{Headers, Response},
+	uri::Uri,
+};
+use log::*;
+use std::{
+	collections::HashMap,
+	str::FromStr,
+	string::{String, ToString},
+	time::Duration,
+	vec::Vec,
+};
+use url::Url;
+
+pub type EncodedBody = Vec<u8>;
+
+/// Simple trait to send HTTP request, based on `http_req`.
+///
+/// Automatically upgrades to TLS in case the base URL contains 'https'
+pub trait SendHttpRequest {
+	fn send_request<U, T>(
+		&self,
+		base_url: Url,
+		method: Method,
+		params: U,
+		query: Option<&Query<'_>>,
+		maybe_body: Option<String>,
+	) -> Result<(Response, EncodedBody), Error>
+	where
+		T: RestPath<U>;
+}
+
+/// HTTP client implementation
+///
+/// wrapper for the `http_req` library that adds the necessary headers and body to a request
+pub struct HttpClient {
+	send_null_body: bool,
+	timeout: Option<Duration>,
+	headers: Headers,
+	authorization: Option<String>,
+}
+
+impl Default for HttpClient {
+	fn default() -> Self {
+		HttpClient {
+			send_null_body: true,
+			timeout: None,
+			headers: Headers::new(),
+			authorization: None,
+		}
+	}
+}
+
+impl HttpClient {
+	pub fn new(
+		send_null_body: bool,
+		timeout: Option<Duration>,
+		headers: Option<Headers>,
+		authorization: Option<String>,
+	) -> Self {
+		HttpClient {
+			send_null_body,
+			timeout,
+			headers: headers.unwrap_or_else(Headers::new),
+			authorization,
+		}
+	}
+
+	/// Set credentials for HTTP Basic authentication.
+	pub fn set_auth(&mut self, user: &str, pass: &str) {
+		let mut s: String = user.to_string();
+		s.push(':');
+		s.push_str(pass);
+		self.authorization = Some(format!("Basic {}", base64::encode(&s)));
+	}
+
+	/// Set HTTP header from string name and value.
+	///
+	/// The header is added to all subsequent GET and POST requests
+	/// unless the headers are cleared with `clear_headers()` call.
+	pub fn set_header(&mut self, name: &'static str, value: &str) -> Result<(), Error> {
+		let header_name = HeaderName::from_str(name).map_err(|_| Error::InvalidValue)?;
+		let value = HeaderValue::from_str(value).map_err(|_| Error::InvalidValue)?;
+
+		add_to_headers(&mut self.headers, header_name, value);
+		Ok(())
+	}
+
+	/// Clear all previously set headers
+	pub fn clear_headers(&mut self) {
+		self.headers = Headers::new();
+	}
+}
+
+impl SendHttpRequest for HttpClient {
+	fn send_request<U, T>(
+		&self,
+		base_url: Url,
+		method: Method,
+		params: U,
+		query: Option<&Query<'_>>,
+		maybe_body: Option<String>,
+	) -> Result<(Response, EncodedBody), Error>
+	where
+		T: RestPath<U>,
+	{
+		let url = join_url(base_url, T::get_path(params)?.as_str(), query)?;
+		let uri = Uri::from_str(url.as_str()).map_err(Error::HttpReqError)?;
+
+		trace!("uri: {:?}", uri);
+
+		let mut request = Request::new(&uri);
+		request.method(method);
+
+		let mut request_headers = Headers::default_http(&uri);
+
+		if let Some(body) = maybe_body.as_ref() {
+			if self.send_null_body || body != "null" {
+				let len = HeaderValue::from_str(&body.len().to_string())
+					.map_err(|_| Error::RequestError)?;
+
+				add_to_headers(&mut request_headers, CONTENT_LENGTH, len);
+				add_to_headers(
+					&mut request_headers,
+					CONTENT_TYPE,
+					HeaderValue::from_str("application/json").unwrap(),
+				);
+
+				trace!("set request body: {}", body);
+				request.body(body.as_bytes()); // takes body non-owned (!)
+			}
+		} else {
+			debug!("no body to send");
+		}
+
+		if let Some(ref auth) = self.authorization {
+			add_to_headers(
+				&mut request_headers,
+				AUTHORIZATION,
+				HeaderValue::from_str(auth).map_err(|_| Error::RequestError)?,
+			);
+		}
+
+		// add pre-set headers
+		for (key, value) in self.headers.iter() {
+			request_headers.insert(key, &value.clone());
+		}
+
+		// add user agent header
+		let pkg_version = env!("CARGO_PKG_VERSION");
+		add_to_headers(
+			&mut request_headers,
+			USER_AGENT,
+			HeaderValue::from_str(format!("integritee/{}", pkg_version).as_str())
+				.map_err(|_| Error::RequestError)?,
+		);
+
+		request.headers(HashMap::from(request_headers));
+
+		request
+			.timeout(self.timeout)
+			.connect_timeout(self.timeout)
+			.read_timeout(self.timeout)
+			.write_timeout(self.timeout);
+
+		trace!("{:?}", request);
+
+		let mut writer = Vec::new();
+
+		let response = request.send(&mut writer).map_err(Error::HttpReqError)?;
+
+		Ok((response, writer))
+	}
+}
+
+fn join_url(base_url: Url, path: &str, params: Option<&Query>) -> Result<Url, Error> {
+	let mut url = base_url.join(path).map_err(|_| Error::UrlError)?;
+
+	if let Some(params) = params {
+		for &(key, item) in params.iter() {
+			url.query_pairs_mut().append_pair(key, item);
+		}
+	}
+
+	Ok(url)
+}
+
+fn add_to_headers(headers: &mut Headers, key: HeaderName, value: HeaderValue) {
+	let header_value_str = value.to_str();
+
+	match header_value_str {
+		Ok(v) => {
+			headers.insert(key.as_str(), v);
+		},
+		Err(e) => {
+			error!("Failed to add header to request: {:?}", e);
+		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+	use http::header::CONNECTION;
+	use serde::{Deserialize, Serialize};
+	use std::vec::Vec;
+
+	#[test]
+	fn join_url_adds_query_parameters() {
+		let base_url = Url::parse("https://example.com").unwrap();
+		let path = "api/v2/example_list";
+		let query = [("filter", "all"), ("order", ("desc"))];
+
+		let complete_url = join_url(base_url, path, Some(&query)).unwrap();
+
+		assert_eq!(
+			complete_url.as_str(),
+			"https://example.com/api/v2/example_list?filter=all&order=desc"
+		);
+	}
+
+	#[test]
+	fn join_url_has_no_query_parameters() {
+		let base_url = Url::parse("https://example.com").unwrap();
+		let path = "api/v2/endpoint";
+		let complete_url = join_url(base_url, path, None).unwrap();
+		assert_eq!(complete_url.as_str(), "https://example.com/api/v2/endpoint");
+	}
+
+	#[test]
+	fn join_url_with_too_many_slashes() {
+		let base_url = Url::parse("https://api.mydomain.com").unwrap();
+		let path = "/api/v1/post";
+		let complete_url = join_url(base_url, path, None).unwrap();
+		assert_eq!(complete_url.as_str(), "https://api.mydomain.com/api/v1/post");
+	}
+
+	#[test]
+	fn get_with_parameters() {
+		#[derive(Serialize, Deserialize, Debug)]
+		struct RequestArgs {
+			pub order: String,
+			pub filter: String,
+		}
+
+		// Data structure that matches with REST API JSON
+		#[derive(Serialize, Deserialize, Debug)]
+		struct HttpBinAnything {
+			pub args: RequestArgs,
+			pub origin: String,
+			pub url: String,
+		}
+
+		impl RestPath<()> for HttpBinAnything {
+			fn get_path(_: ()) -> Result<String, Error> {
+				Ok(format!("anything"))
+			}
+		}
+
+		let http_client = HttpClient::new(
+			true,
+			Some(Duration::from_secs(3u64)),
+			Some(headers_connection_close()),
+			None,
+		);
+		let base_url = Url::parse("https://httpbin.org").unwrap();
+		let query_parameters = [("order", "desc"), ("filter", "all")];
+
+		let (response, encoded_body) = http_client
+			.send_request::<(), HttpBinAnything>(
+				base_url,
+				Method::GET,
+				(),
+				Some(&query_parameters),
+				None,
+			)
+			.unwrap();
+
+		let response_body: HttpBinAnything =
+			deserialize_response_body(encoded_body.as_slice()).unwrap();
+
+		assert!(response.status_code().is_success());
+		assert_eq!(response_body.args.order.as_str(), "desc");
+		assert_eq!(response_body.args.filter.as_str(), "all");
+	}
+
+	#[test]
+	fn get_without_parameters() {
+		// Data structure that matches with REST API JSON
+		#[derive(Serialize, Deserialize, Debug)]
+		struct HttpBinAnything {
+			pub method: String,
+			pub url: String,
+		}
+
+		impl RestPath<()> for HttpBinAnything {
+			fn get_path(_: ()) -> Result<String, Error> {
+				Ok(format!("anything"))
+			}
+		}
+
+		let http_client = HttpClient::new(
+			true,
+			Some(Duration::from_secs(3u64)),
+			Some(headers_connection_close()),
+			None,
+		);
+		let base_url = Url::parse("https://httpbin.org").unwrap();
+
+		let (response, encoded_body) = http_client
+			.send_request::<(), HttpBinAnything>(base_url, Method::GET, (), None, None)
+			.unwrap();
+
+		let response_body: HttpBinAnything =
+			deserialize_response_body(encoded_body.as_slice()).unwrap();
+
+		assert!(response.status_code().is_success());
+		assert!(!response_body.url.is_empty());
+		assert_eq!(response_body.method.as_str(), "GET");
+	}
+
+	#[test]
+	fn post_with_body() {
+		#[derive(Serialize, Deserialize, Debug)]
+		struct HttpBinAnything {
+			pub data: String,
+			pub method: String,
+		}
+
+		impl RestPath<()> for HttpBinAnything {
+			fn get_path(_: ()) -> Result<String, Error> {
+				Ok(format!("anything"))
+			}
+		}
+
+		let http_client = HttpClient::new(
+			false,
+			Some(Duration::from_secs(3u64)),
+			Some(headers_connection_close()),
+			None,
+		);
+
+		let body_test = "this is a test body with special characters {::}/-".to_string();
+		let base_url = Url::parse("https://httpbin.org").unwrap();
+
+		let (response, encoded_body) = http_client
+			.send_request::<(), HttpBinAnything>(
+				base_url,
+				Method::POST,
+				(),
+				None,
+				Some(body_test.clone()),
+			)
+			.unwrap();
+
+		let response_body: HttpBinAnything =
+			deserialize_response_body(encoded_body.as_slice()).unwrap();
+
+		assert!(response.status_code().is_success());
+		assert_eq!(response_body.method.as_str(), "POST");
+		assert_eq!(response_body.data, body_test);
+	}
+
+	#[test]
+	fn get_coins_list_from_coin_gecko_works() {
+		// Data structure that matches with REST API JSON
+		#[derive(Serialize, Deserialize, Debug)]
+		struct CoinGeckoCoinsList {
+			id: String,
+			symbol: String,
+			name: String,
+		}
+
+		impl RestPath<()> for Vec<CoinGeckoCoinsList> {
+			fn get_path(_: ()) -> Result<String, Error> {
+				Ok(format!("api/v3/coins/list"))
+			}
+		}
+
+		let http_client = HttpClient::new(true, Some(Duration::from_secs(3u64)), None, None);
+		let base_url = Url::parse("https://api.coingecko.com").unwrap();
+
+		let (response, encoded_body) = http_client
+			.send_request::<(), Vec<CoinGeckoCoinsList>>(base_url, Method::GET, (), None, None)
+			.unwrap();
+
+		let coins_list: Vec<CoinGeckoCoinsList> =
+			deserialize_response_body(encoded_body.as_slice()).unwrap();
+
+		assert!(response.status_code().is_success());
+		assert!(!coins_list.is_empty());
+	}
+
+	fn headers_connection_close() -> Headers {
+		let mut headers = Headers::new();
+		add_to_headers(&mut headers, CONNECTION, HeaderValue::from_str("close").unwrap());
+		headers
+	}
+
+	fn deserialize_response_body<'a, T>(encoded_body: &'a [u8]) -> Result<T, Error>
+	where
+		T: Deserialize<'a>,
+	{
+		serde_json::from_slice::<'a, T>(encoded_body).map_err(|err| {
+			Error::DeserializeParseError(err, String::from_utf8_lossy(encoded_body).to_string())
+		})
+	}
+}

--- a/core/rest-client/src/http_client_builder.rs
+++ b/core/rest-client/src/http_client_builder.rs
@@ -1,0 +1,88 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use crate::http_client::HttpClient;
+use http_req::response::Headers;
+use std::{string::String, time::Duration};
+
+/// Builder for `HttpClient`
+pub struct HttpClientBuilder {
+	/// Request timeout
+	timeout: Duration,
+
+	/// Send null body
+	send_null_body: bool,
+
+	/// pre-set headers
+	headers: Option<Headers>,
+
+	/// authorization
+	authorization: Option<String>,
+}
+
+impl Default for HttpClientBuilder {
+	fn default() -> Self {
+		Self {
+			timeout: Duration::from_secs(u64::MAX),
+			send_null_body: true,
+			headers: None,
+			authorization: None,
+		}
+	}
+}
+
+impl HttpClientBuilder {
+	/// Set request timeout
+	///
+	/// Default is no timeout
+	pub fn timeout(mut self, timeout: Duration) -> Self {
+		self.timeout = timeout;
+		self
+	}
+
+	/// Send null body in POST/PUT
+	///
+	/// Default is yes
+	pub fn send_null_body(mut self, value: bool) -> Self {
+		self.send_null_body = value;
+		self
+	}
+
+	/// Pre-set headers to attach to each request
+	///
+	/// default is none
+	pub fn headers(mut self, headers: Headers) -> Self {
+		self.headers = Some(headers);
+		self
+	}
+
+	/// Basic HTTP authorization (format: `username:password`)
+	///
+	/// default is none
+	pub fn authorization(mut self, authorization: String) -> Self {
+		self.authorization = Some(authorization);
+		self
+	}
+
+	/// Create `HttpClient` with the configuration in this builder
+	pub fn build(self) -> HttpClient {
+		HttpClient::new(self.send_null_body, Some(self.timeout), self.headers, self.authorization)
+	}
+}

--- a/core/rest-client/src/lib.rs
+++ b/core/rest-client/src/lib.rs
@@ -1,0 +1,181 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! REST API Client, supporting SSL/TLS
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+#[macro_use]
+extern crate sgx_tstd as std;
+
+// re-export module to properly feature gate sgx and regular std environment
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+pub mod sgx_reexport_prelude {
+	pub use http_req_sgx as http_req;
+	pub use http_sgx as http;
+	pub use thiserror_sgx as thiserror;
+	pub use url_sgx as url;
+}
+
+pub mod error;
+pub mod http_client;
+pub mod http_client_builder;
+pub mod rest_client;
+
+#[cfg(test)]
+pub mod mocks;
+
+use crate::error::Error;
+use std::string::String;
+
+/// Type for URL query parameters.
+///
+/// Slice of tuples in which the first field is parameter name and second is value.
+/// These parameters are used with `get_with` and `post_with` functions.
+///
+/// # Examples
+/// The vector
+/// ```ignore
+/// vec![("param1", "1234"), ("param2", "abcd")]
+/// ```
+/// would be parsed to **param1=1234&param2=abcd** in the request URL.
+pub type Query<'a> = [(&'a str, &'a str)];
+
+/// Rest path builder trait for type.
+///
+/// Provides implementation for `rest_path` function that builds
+/// type (and REST endpoint) specific API path from given parameter(s).
+/// The built REST path is appended to the base URL given to `RestClient`.
+/// If `Err` is returned, it is propagated directly to API caller.
+pub trait RestPath<T> {
+	/// Construct type specific REST API path from given parameters
+	/// (e.g. "api/devices/1234").
+	fn get_path(par: T) -> Result<String, Error>;
+}
+
+/// REST HTTP GET trait
+///
+/// Provides the GET verb for a REST API
+pub trait RestGet {
+	/// Plain GET request
+	fn get<U, T>(&mut self, params: U) -> Result<T, Error>
+	where
+		T: serde::de::DeserializeOwned + RestPath<U>;
+
+	/// GET request with query parameters.
+	fn get_with<U, T>(&mut self, params: U, query: &Query<'_>) -> Result<T, Error>
+	where
+		T: serde::de::DeserializeOwned + RestPath<U>;
+}
+
+/// REST HTTP POST trait
+///
+/// Provides the POST verb for a REST API
+pub trait RestPost {
+	/// Plain POST request.
+	fn post<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>;
+
+	/// Make POST request with query parameters.
+	fn post_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>;
+
+	/// Make a POST request and capture returned body.
+	fn post_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned;
+
+	/// Make a POST request with query parameters and capture returned body.
+	fn post_capture_with<U, T, K>(
+		&mut self,
+		params: U,
+		data: &T,
+		query: &Query<'_>,
+	) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned;
+}
+
+/// REST HTTP PUT trait
+///
+/// Provides the PUT verb for a REST API
+pub trait RestPut {
+	/// PUT request.
+	fn put<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>;
+
+	/// Make PUT request with query parameters.
+	fn put_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>;
+
+	/// Make a PUT request and capture returned body.
+	fn put_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned;
+
+	/// Make a PUT request with query parameters and capture returned body.
+	fn put_capture_with<U, T, K>(
+		&mut self,
+		params: U,
+		data: &T,
+		query: &Query<'_>,
+	) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned;
+}
+
+/// REST HTTP PATCH trait
+///
+/// Provides the PATCH verb for a REST API
+pub trait RestPatch {
+	/// Make a PATCH request.
+	fn patch<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>;
+
+	/// Make PATCH request with query parameters.
+	fn patch_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>;
+}
+
+/// REST HTTP DELETE trait
+///
+/// Provides the DELETE verb for a REST API
+pub trait RestDelete {
+	/// Make a DELETE request.
+	fn delete<U, T>(&mut self, params: U) -> Result<(), Error>
+	where
+		T: RestPath<U>;
+
+	/// Make a DELETE request with query and body.
+	fn delete_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>;
+}

--- a/core/rest-client/src/mocks/http_client_mock.rs
+++ b/core/rest-client/src/mocks/http_client_mock.rs
@@ -1,0 +1,144 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	error::Error,
+	http_client::{EncodedBody, SendHttpRequest},
+	Query, RestPath,
+};
+use http_req::{request::Method, response::Response};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+const DEFAULT_HEAD: &[u8; 102] = b"HTTP/1.1 200 OK\r\n\
+                         		Date: Sat, 11 Jan 2003 02:44:04 GMT\r\n\
+                        		Content-Type: text/html\r\n\
+                        		Content-Length: 100\r\n\r\n";
+
+/// Response body returned by the HTTP client mock, contains information passed in by caller
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct ResponseBodyMock {
+	pub base_url: String,
+	pub method: String,
+	pub path: String,
+	pub request_body: Option<String>,
+	pub query_parameters: Vec<(String, String)>,
+}
+
+impl RestPath<String> for ResponseBodyMock {
+	fn get_path(path: String) -> Result<String, Error> {
+		Ok(format!("{}", path))
+	}
+}
+
+/// HTTP client mock - to be used in unit tests
+pub struct HttpClientMock {
+	response: Option<Response>,
+}
+
+impl HttpClientMock {
+	pub fn new(response: Option<Response>) -> Self {
+		HttpClientMock { response }
+	}
+}
+
+impl SendHttpRequest for HttpClientMock {
+	fn send_request<U, T>(
+		&self,
+		base_url: Url,
+		method: Method,
+		params: U,
+		query: Option<&Query<'_>>,
+		maybe_body: Option<String>,
+	) -> Result<(Response, EncodedBody), Error>
+	where
+		T: RestPath<U>,
+	{
+		let path = T::get_path(params)?;
+		let response = self
+			.response
+			.clone()
+			.unwrap_or_else(|| Response::from_head(DEFAULT_HEAD).unwrap());
+		let base_url_str = String::from(base_url.as_str());
+
+		let query_parameters = query
+			.map(|q| q.iter().map(|(key, value)| (key.to_string(), value.to_string())).collect())
+			.unwrap_or_else(|| Vec::<(String, String)>::new());
+
+		let response_body = ResponseBodyMock {
+			base_url: base_url_str,
+			method: format!("{:?}", method),
+			path,
+			request_body: maybe_body,
+			query_parameters,
+		};
+
+		let encoded_response_body = serde_json::to_vec(&response_body).unwrap();
+
+		Ok((response, encoded_response_body))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+
+	#[test]
+	pub fn response_body_mock_serialization_works() {
+		let response_body_mock = ResponseBodyMock {
+			base_url: "https://mydomain.com".to_string(),
+			method: "GET".to_string(),
+			path: "/api/v1".to_string(),
+			request_body: None,
+			query_parameters: vec![("order".to_string(), "desc".to_string())],
+		};
+
+		let serialized_body = serde_json::to_string(&response_body_mock).unwrap();
+		let deserialized_body: ResponseBodyMock =
+			serde_json::from_str(serialized_body.as_str()).unwrap();
+
+		assert_eq!(deserialized_body, response_body_mock);
+	}
+
+	#[test]
+	pub fn default_head_is_valid() {
+		assert!(Response::from_head(DEFAULT_HEAD).is_ok());
+	}
+
+	#[test]
+	pub fn client_mock_returns_parameters_in_result() {
+		let client_mock = HttpClientMock::new(None);
+		let base_url = Url::parse("https://integritee.network").unwrap();
+
+		let (response, encoded_response_body) = client_mock
+			.send_request::<String, ResponseBodyMock>(
+				base_url,
+				Method::GET,
+				"/api/v1/get".to_string(),
+				None,
+				None,
+			)
+			.unwrap();
+
+		let response_body: ResponseBodyMock =
+			serde_json::from_slice(encoded_response_body.as_slice()).unwrap();
+
+		assert_eq!(response, Response::from_head(DEFAULT_HEAD).unwrap());
+		assert_eq!(response_body.method.as_str(), "GET");
+	}
+}

--- a/core/rest-client/src/mocks/mod.rs
+++ b/core/rest-client/src/mocks/mod.rs
@@ -1,0 +1,18 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+pub mod http_client_mock;

--- a/core/rest-client/src/rest_client.rs
+++ b/core/rest-client/src/rest_client.rs
@@ -1,0 +1,352 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use crate::{
+	error::Error, http_client::SendHttpRequest, Query, RestDelete, RestGet, RestPatch, RestPath,
+	RestPost, RestPut,
+};
+use http_req::{request::Method, response::Headers};
+use log::*;
+use std::string::{String, ToString};
+use url::Url;
+
+/// REST client to make HTTP GET and POST requests.
+pub struct RestClient<H> {
+	http_client: H,
+	baseurl: Url,
+	response_headers: Headers,
+	body_wash_fn: fn(String) -> String,
+}
+
+impl<H> RestClient<H>
+where
+	H: SendHttpRequest,
+{
+	/// Construct new client with default configuration to make HTTP requests.
+	///
+	/// Use `Builder` to configure the client.
+	pub fn new(http_client: H, baseurl: Url) -> Self {
+		RestClient {
+			http_client,
+			baseurl,
+			response_headers: Headers::new(),
+			body_wash_fn: std::convert::identity,
+		}
+	}
+
+	/// Set a function that cleans the response body up before deserializing it.
+	pub fn set_body_wash_fn(&mut self, func: fn(String) -> String) {
+		self.body_wash_fn = func;
+	}
+
+	/// Response headers captured from previous request
+	pub fn response_headers(&mut self) -> &Headers {
+		&self.response_headers
+	}
+
+	fn post_or_put<U, T>(&mut self, method: Method, params: U, data: &T) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
+
+		let _body = self.make_request::<U, T>(method, params, None, Some(data))?;
+		Ok(())
+	}
+
+	fn post_or_put_with<U, T>(
+		&mut self,
+		method: Method,
+		params: U,
+		data: &T,
+		query: &Query<'_>,
+	) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
+
+		let _body = self.make_request::<U, T>(method, params, Some(query), Some(data))?;
+		Ok(())
+	}
+
+	fn post_or_put_capture<U, T, K>(
+		&mut self,
+		method: Method,
+		params: U,
+		data: &T,
+	) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned,
+	{
+		let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
+
+		let body = self.make_request::<U, T>(method, params, None, Some(data))?;
+		serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
+	}
+
+	fn post_or_put_capture_with<U, T, K>(
+		&mut self,
+		method: Method,
+		params: U,
+		data: &T,
+		query: &Query<'_>,
+	) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned,
+	{
+		let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
+
+		let body = self.make_request::<U, T>(method, params, Some(query), Some(data))?;
+		serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
+	}
+
+	fn make_request<U, T>(
+		&mut self,
+		method: Method,
+		params: U,
+		query: Option<&Query<'_>>,
+		maybe_body: Option<String>,
+	) -> Result<String, Error>
+	where
+		T: RestPath<U>,
+	{
+		let (response, encoded_body) = self.http_client.send_request::<U, T>(
+			self.baseurl.clone(),
+			method,
+			params,
+			query,
+			maybe_body,
+		)?;
+
+		self.response_headers = response.headers().clone();
+		let status_code = response.status_code();
+
+		if !status_code.is_success() {
+			let status_code_num = u16::from(status_code);
+			let reason = String::from(status_code.reason().unwrap_or("none"));
+			return Err(Error::HttpError(status_code_num, reason))
+		}
+
+		let body = String::from_utf8_lossy(&encoded_body).to_string();
+
+		trace!("response headers: {:?}", self.response_headers);
+		trace!("response body: {}", body);
+		Ok((self.body_wash_fn)(body))
+	}
+}
+
+impl<H> RestGet for RestClient<H>
+where
+	H: SendHttpRequest,
+{
+	/// Make a GET request.
+	fn get<U, T>(&mut self, params: U) -> Result<T, Error>
+	where
+		T: serde::de::DeserializeOwned + RestPath<U>,
+	{
+		let body = self.make_request::<U, T>(Method::GET, params, None, None)?;
+
+		serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
+	}
+
+	/// Make a GET request with query parameters.
+	fn get_with<U, T>(&mut self, params: U, query: &Query<'_>) -> Result<T, Error>
+	where
+		T: serde::de::DeserializeOwned + RestPath<U>,
+	{
+		let body = self.make_request::<U, T>(Method::GET, params, Some(query), None)?;
+
+		serde_json::from_str(body.as_str()).map_err(|err| Error::DeserializeParseError(err, body))
+	}
+}
+
+impl<H> RestPost for RestClient<H>
+where
+	H: SendHttpRequest,
+{
+	/// Make a POST request.
+	fn post<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		self.post_or_put(Method::POST, params, data)
+	}
+
+	/// Make POST request with query parameters.
+	fn post_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		self.post_or_put_with(Method::POST, params, data, query)
+	}
+
+	/// Make a POST request and capture returned body.
+	fn post_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned,
+	{
+		self.post_or_put_capture(Method::POST, params, data)
+	}
+
+	/// Make a POST request with query parameters and capture returned body.
+	fn post_capture_with<U, T, K>(
+		&mut self,
+		params: U,
+		data: &T,
+		query: &Query<'_>,
+	) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned,
+	{
+		self.post_or_put_capture_with(Method::POST, params, data, query)
+	}
+}
+
+impl<H> RestPut for RestClient<H>
+where
+	H: SendHttpRequest,
+{
+	/// Make a PUT request.
+	fn put<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		self.post_or_put(Method::PUT, params, data)
+	}
+
+	/// Make PUT request with query parameters.
+	fn put_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		self.post_or_put_with(Method::PUT, params, data, query)
+	}
+
+	/// Make a PUT request and capture returned body.
+	fn put_capture<U, T, K>(&mut self, params: U, data: &T) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned,
+	{
+		self.post_or_put_capture(Method::PUT, params, data)
+	}
+
+	/// Make a PUT request with query parameters and capture returned body.
+	fn put_capture_with<U, T, K>(
+		&mut self,
+		params: U,
+		data: &T,
+		query: &Query<'_>,
+	) -> Result<K, Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+		K: serde::de::DeserializeOwned,
+	{
+		self.post_or_put_capture_with(Method::PUT, params, data, query)
+	}
+}
+
+impl<H> RestPatch for RestClient<H>
+where
+	H: SendHttpRequest,
+{
+	/// Make a PATCH request.
+	fn patch<U, T>(&mut self, params: U, data: &T) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		self.post_or_put(Method::PATCH, params, data)
+	}
+
+	/// Make PATCH request with query parameters.
+	fn patch_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		self.post_or_put_with(Method::PATCH, params, data, query)
+	}
+}
+
+impl<H> RestDelete for RestClient<H>
+where
+	H: SendHttpRequest,
+{
+	/// Make a DELETE request.
+	fn delete<U, T>(&mut self, params: U) -> Result<(), Error>
+	where
+		T: RestPath<U>,
+	{
+		self.make_request::<U, T>(Method::DELETE, params, None, None)?;
+		Ok(())
+	}
+
+	/// Make a DELETE request with query and body.
+	fn delete_with<U, T>(&mut self, params: U, data: &T, query: &Query<'_>) -> Result<(), Error>
+	where
+		T: serde::Serialize + RestPath<U>,
+	{
+		let data = serde_json::to_string(data).map_err(Error::SerializeParseError)?;
+		self.make_request::<U, T>(Method::DELETE, params, Some(query), Some(data))?;
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+
+	use super::*;
+	use crate::mocks::http_client_mock::{HttpClientMock, ResponseBodyMock};
+
+	#[test]
+	pub fn get_sends_proper_request() {
+		let mut rest_client = create_default_rest_client();
+
+		let get_response =
+			rest_client.get::<String, ResponseBodyMock>("/api/v2/get".to_string()).unwrap();
+
+		assert_eq!(get_response.method.as_str(), "GET");
+		assert_eq!(get_response.path.as_str(), "/api/v2/get");
+	}
+
+	#[test]
+	pub fn get_with_query_parameters_works() {
+		let mut rest_client = create_default_rest_client();
+
+		let get_response = rest_client
+			.get_with::<String, ResponseBodyMock>(
+				"/api/v1/get".to_string(),
+				&[("order", "desc"), ("user", "spongebob")],
+			)
+			.unwrap();
+
+		assert_eq!(2, get_response.query_parameters.len());
+	}
+
+	fn create_default_rest_client() -> RestClient<HttpClientMock> {
+		let base_url = Url::parse("https://example.com").unwrap();
+		let http_client = HttpClientMock::new(None);
+		RestClient::new(http_client, base_url)
+	}
+}


### PR DESCRIPTION
As discussed in #390 
- New crate for a REST client (`/core/rest-client/`) that allows secure connections (TLS, based on `rustls`)
- Uses the [http_req](https://github.com/jayjamesjay/http_req) and its corresponding SGX port for the HTTP(S) requests
- REST client is heavily inspired by (i.e. copied and modified from) [restson](https://github.com/spietika/restson-rust). This client however is based on `hyper` to do the HTTP requests, which is not available as a SGX port.
- All requests are done in a blocking fashion, no `async/await` since `http_req` is blocking (unlike `hyper`)

Closes #390