### PR TITLE
Fix build for SGX_DEBUG=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,11 @@ endif
 endif
 
 ifeq ($(SGX_DEBUG), 1)
+	# we build with cargo --release, even in SGX DEBUG mode
 	SGX_COMMON_CFLAGS += -O0 -g -ggdb
-	OUTPUT_PATH := debug
-	CARGO_TARGET :=
+	# cargo sets this automatically, cannot use 'debug'
+	OUTPUT_PATH := release
+	CARGO_TARGET := --release
 else
 	SGX_COMMON_CFLAGS += -O2
 	OUTPUT_PATH := release

--- a/enclave-runtime/Makefile
+++ b/enclave-runtime/Makefile
@@ -31,8 +31,8 @@ Rust_Enclave_Files := $(wildcard src/*.rs) $(wildcard ../stf/src/*.rs)
 Rust_Target_Path := $(CURDIR)/../../../xargo
 
 ifeq ($(SGX_DEBUG), 1)
-	OUTPUT_PATH := debug
-	CARGO_TARGET :=
+	OUTPUT_PATH := release
+	CARGO_TARGET := --release
 else
 	OUTPUT_PATH := release
 	CARGO_TARGET := --release


### PR DESCRIPTION
Use `cargo --release` also in case of `SGX_DEBUG=1` and hence also the corresponding `target/release` folder. 

This still might not be the best debugging experience - but that would be a lot tougher to achieve (if not impossible), considering the nature of the enclave (which cannot be debugged by design).

Closes #375