### PR TITLE
Refactor RPC author as facade

### DIFF
--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -447,7 +447,7 @@ pub unsafe extern "C" fn sync_parentchain_and_execute_tops(
 ///
 /// Sync parentchain blocks to the light-client and execute pending trusted operations.
 ///
-/// This function makes an ecall that does the following:
+/// This function makes an ocall that does the following:
 ///
 /// *   send `confirm_call` xt's of the `Stf` functions executed due to in-/direct invocation to the
 ///     to the parentchain


### PR DESCRIPTION
I refactored the RPC author API so we only have this one facade to do all the operations, instead of having a mixture of author and top pool directly. This will allow us to pass in only the author and hide the top pool for most of the functions.