### PR TITLE
RPC Author encapsulates top pool and mutex access

### DIFF
--- a/enclave-runtime/src/rpc/author/mod.rs
+++ b/enclave-runtime/src/rpc/author/mod.rs
@@ -19,19 +19,21 @@
 //! Substrate block-author/full-node API.
 pub extern crate alloc;
 use crate::{
-	rpc::error::{Error as StateRpcError, FutureResult, Result},
+	rpc::error::{Error as StateRpcError, Error, Result},
 	state,
 	top_pool::{
-		error::{Error as PoolError, IntoPoolError},
+		error::{Error as PoolError, Error as TopPoolError, IntoPoolError},
 		primitives::{
-			BlockHash, InPoolOperation, TrustedOperationPool, TrustedOperationSource, TxHash,
+			BlockHash, InPoolOperation, PoolFuture, TrustedOperationPool, TrustedOperationSource,
+			TxHash,
 		},
+		top_pool_container::GetTopPool,
 	},
 };
 use alloc::{boxed::Box, vec::Vec};
 use client_error::Error as ClientError;
 use codec::{Decode, Encode};
-use core::iter::Iterator;
+use core::{iter::Iterator, ops::Deref};
 use ita_stf::{Getter, ShardIdentifier, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_sgx_crypto::{Rsa3072Seal, ShieldingCrypto};
 use itp_sgx_io::SealedIO;
@@ -50,14 +52,10 @@ pub mod hash;
 /// Substrate authoring RPC API
 pub trait AuthorApi<Hash, BlockHash> {
 	/// Submit encoded extrinsic for inclusion in block.
-	fn submit_top(
-		&self,
-		extrinsic: Vec<u8>,
-		shard: ShardIdentifier,
-	) -> FutureResult<Hash, RpcError>;
+	fn submit_top(&self, extrinsic: Vec<u8>, shard: ShardIdentifier) -> PoolFuture<Hash, RpcError>;
 
 	/// Return hash of Trusted Operation
-	fn hash_of(&self, xt: &TrustedOperation) -> Hash;
+	fn hash_of(&self, xt: &TrustedOperation) -> Result<Hash>;
 
 	/// Returns all pending operations, potentially grouped by sender.
 	fn pending_tops(&self, shard: ShardIdentifier) -> Result<Vec<Vec<u8>>>;
@@ -68,7 +66,7 @@ pub trait AuthorApi<Hash, BlockHash> {
 		shard: ShardIdentifier,
 	) -> Result<(Vec<TrustedCallSigned>, Vec<TrustedGetterSigned>)>;
 
-	fn get_shards(&self) -> Vec<ShardIdentifier>;
+	fn get_shards(&self) -> Result<Vec<ShardIdentifier>>;
 
 	/// Remove given call from the pool and temporarily ban it to prevent reimporting.
 	fn remove_top(
@@ -82,7 +80,7 @@ pub trait AuthorApi<Hash, BlockHash> {
 	///
 	/// See [`TrustedOperationStatus`](sp_transaction_pool::TrustedOperationStatus) for details on transaction
 	/// life cycle.
-	fn watch_top(&self, ext: Vec<u8>, shard: ShardIdentifier) -> FutureResult<Hash, RpcError>;
+	fn watch_top(&self, ext: Vec<u8>, shard: ShardIdentifier) -> PoolFuture<Hash, RpcError>;
 }
 
 /// Trait to send state of a trusted getter back to the client
@@ -100,21 +98,20 @@ pub trait OnBlockCreated {
 }
 
 /// Authoring API
-pub struct Author<'a, P>
+pub struct Author<TopPoolGetter>
 where
-	P: TrustedOperationPool + Sync + Send + 'static,
+	TopPoolGetter: GetTopPool + Sync + Send + 'static,
 {
-	/// Trusted Operation pool
-	pool: Arc<&'a P>,
+	top_pool_getter: Arc<TopPoolGetter>,
 }
 
-impl<'a, P> Author<'a, P>
+impl<TopPoolGetter> Author<TopPoolGetter>
 where
-	P: TrustedOperationPool + Sync + Send + 'static,
+	TopPoolGetter: GetTopPool + Sync + Send + 'static,
 {
 	/// Create new instance of Authoring API.
-	pub fn new(pool: Arc<&'a P>) -> Self {
-		Author { pool }
+	pub fn new(top_pool_getter: Arc<TopPoolGetter>) -> Self {
+		Author { top_pool_getter }
 	}
 }
 
@@ -130,16 +127,38 @@ enum TopSubmissionMode {
 	SubmitWatch,
 }
 
-impl<'a, P> Author<'a, P>
+impl<TopPoolGetter> Author<TopPoolGetter>
 where
-	P: TrustedOperationPool + Sync + Send + 'static,
+	TopPoolGetter: GetTopPool + Sync + Send + 'static,
 {
+	/// Execute a specific task or function on the TOP pool
+	///
+	/// Needed to get a clean way around the mutexes in which the pool are wrapped.
+	/// Other approaches require lots of code duplication for the mutex locking and
+	/// unwrapping.
+	fn execute_on_top_pool<F, E, R>(&self, function_to_execute: F, mutex_error_func: E) -> R
+	where
+		F: FnOnce(&TopPoolGetter::TrustedOperationPool) -> R,
+		E: FnOnce(Error) -> R,
+	{
+		let pool_mutex = match self.top_pool_getter.get() {
+			Some(mutex) => mutex,
+			None => {
+				error!("Could not get mutex to trusted operation pool");
+				return (mutex_error_func)(Error::PoolError(TopPoolError::UnlockError))
+			},
+		};
+
+		let tx_pool_guard = pool_mutex.lock().unwrap();
+		(function_to_execute)(tx_pool_guard.deref())
+	}
+
 	fn process_top(
 		&self,
 		ext: Vec<u8>,
 		shard: ShardIdentifier,
 		submission_mode: TopSubmissionMode,
-	) -> FutureResult<TxHash<P>, RpcError> {
+	) -> PoolFuture<TxHash<TopPoolGetter::TrustedOperationPool>, RpcError> {
 		// check if shard already exists
 		if !state::exists(&shard) {
 			//FIXME: Should this be an error? -> Issue error handling
@@ -161,25 +180,38 @@ where
 		let best_block_hash = Default::default();
 
 		match submission_mode {
-			TopSubmissionMode::Submit => Box::pin(
-				self.pool
-					.submit_one(
-						&generic::BlockId::hash(best_block_hash),
-						TX_SOURCE,
-						stf_operation,
-						shard,
+			TopSubmissionMode::Submit => self.execute_on_top_pool(
+				|t: &TopPoolGetter::TrustedOperationPool| -> PoolFuture<TxHash<TopPoolGetter::TrustedOperationPool>, RpcError> {
+					Box::pin(
+						t.submit_one(
+							&generic::BlockId::hash(best_block_hash),
+							TX_SOURCE,
+							stf_operation,
+							shard,
+						)
+						.map_err(map_top_error::<TopPoolGetter::TrustedOperationPool>),
 					)
-					.map_err(map_top_error::<P>),
+				},
+				|e| -> PoolFuture<TxHash<TopPoolGetter::TrustedOperationPool>, RpcError> {
+						Box::pin(ready(Err(e.into())))
+					},
 			),
-			TopSubmissionMode::SubmitWatch => Box::pin(
-				self.pool
-					.submit_and_watch(
+
+			TopSubmissionMode::SubmitWatch => self.execute_on_top_pool(
+				|t: &TopPoolGetter::TrustedOperationPool| -> PoolFuture<TxHash<TopPoolGetter::TrustedOperationPool>, RpcError> {
+					Box::pin(
+					t.submit_and_watch(
 						&generic::BlockId::hash(best_block_hash),
 						TX_SOURCE,
 						stf_operation,
 						shard,
 					)
-					.map_err(map_top_error::<P>),
+					.map_err(map_top_error::<TopPoolGetter::TrustedOperationPool>)
+					)
+				},
+				|e| -> PoolFuture<TxHash<TopPoolGetter::TrustedOperationPool>, RpcError> {
+						Box::pin(ready(Err(e.into())))
+					},
 			),
 		}
 	}
@@ -195,102 +227,137 @@ fn map_top_error<P: TrustedOperationPool>(error: P::Error) -> RpcError {
 	.into()
 }
 
-impl<'a, P> AuthorApi<TxHash<P>, BlockHash<P>> for Author<'a, P>
+impl<TopPoolGetter>
+	AuthorApi<
+		TxHash<TopPoolGetter::TrustedOperationPool>,
+		BlockHash<TopPoolGetter::TrustedOperationPool>,
+	> for Author<TopPoolGetter>
 where
-	P: TrustedOperationPool + Sync + Send + 'static,
+	TopPoolGetter: GetTopPool + Sync + Send + 'static,
 {
 	fn submit_top(
 		&self,
 		ext: Vec<u8>,
 		shard: ShardIdentifier,
-	) -> FutureResult<TxHash<P>, RpcError> {
+	) -> PoolFuture<TxHash<TopPoolGetter::TrustedOperationPool>, RpcError> {
 		self.process_top(ext, shard, TopSubmissionMode::Submit)
 	}
 
 	/// Get hash of TrustedOperation
-	fn hash_of(&self, xt: &TrustedOperation) -> TxHash<P> {
-		self.pool.hash_of(xt)
+	fn hash_of(
+		&self,
+		xt: &TrustedOperation,
+	) -> Result<TxHash<TopPoolGetter::TrustedOperationPool>> {
+		self.execute_on_top_pool(|t| Ok(t.hash_of(xt)), Err)
 	}
 
 	fn pending_tops(&self, shard: ShardIdentifier) -> Result<Vec<Vec<u8>>> {
-		Ok(self.pool.ready(shard).map(|top| top.data().encode()).collect())
+		self.execute_on_top_pool(
+			|t| Ok(t.ready(shard).map(|top| top.data().encode()).collect()),
+			Err,
+		)
 	}
 
 	fn get_pending_tops_separated(
 		&self,
 		shard: ShardIdentifier,
 	) -> Result<(Vec<TrustedCallSigned>, Vec<TrustedGetterSigned>)> {
-		let mut calls: Vec<TrustedCallSigned> = vec![];
-		let mut getters: Vec<TrustedGetterSigned> = vec![];
-		for operation in self.pool.ready(shard) {
-			match operation.data() {
-				TrustedOperation::direct_call(call) => calls.push(call.clone()),
-				TrustedOperation::get(getter) => match getter {
-					Getter::trusted(trusted_getter_signed) =>
-						getters.push(trusted_getter_signed.clone()),
-					_ => error!("Found invalid trusted getter in top pool"),
-				},
-				_ => { // might be emtpy?
-				},
-			}
-		}
+		self.execute_on_top_pool(
+			|t| {
+				let mut calls: Vec<TrustedCallSigned> = vec![];
+				let mut getters: Vec<TrustedGetterSigned> = vec![];
+				for operation in t.ready(shard) {
+					match operation.data() {
+						TrustedOperation::direct_call(call) => calls.push(call.clone()),
+						TrustedOperation::get(getter) => match getter {
+							Getter::trusted(trusted_getter_signed) =>
+								getters.push(trusted_getter_signed.clone()),
+							_ => error!("Found invalid trusted getter in top pool"),
+						},
+						_ => { // might be emtpy?
+						},
+					}
+				}
 
-		Ok((calls, getters))
+				Ok((calls, getters))
+			},
+			Err,
+		)
 	}
 
-	fn get_shards(&self) -> Vec<ShardIdentifier> {
-		self.pool.shards()
+	fn get_shards(&self) -> Result<Vec<ShardIdentifier>> {
+		self.execute_on_top_pool(|t| Ok(t.shards()), Err)
 	}
 
 	fn remove_top(
 		&self,
-		bytes_or_hash: Vec<hash::TrustedOperationOrHash<TxHash<P>>>,
+		bytes_or_hash: Vec<
+			hash::TrustedOperationOrHash<TxHash<TopPoolGetter::TrustedOperationPool>>,
+		>,
 		shard: ShardIdentifier,
 		inblock: bool,
-	) -> Result<Vec<TxHash<P>>> {
-		let hashes = bytes_or_hash
-			.into_iter()
-			.map(|x| match x {
-				hash::TrustedOperationOrHash::Hash(h) => Ok(h),
-				hash::TrustedOperationOrHash::OperationEncoded(bytes) => {
-					let op = Decode::decode(&mut &bytes[..]).unwrap();
-					Ok(self.pool.hash_of(&op))
-				},
-				hash::TrustedOperationOrHash::Operation(op) => Ok(self.pool.hash_of(&op)),
-			})
-			.collect::<Result<Vec<_>>>()?;
-		debug!("removing {:?} from top pool", hashes);
-		Ok(self
-			.pool
-			.remove_invalid(&hashes, shard, inblock)
-			.into_iter()
-			.map(|op| op.hash().clone())
-			.collect())
+	) -> Result<Vec<TxHash<TopPoolGetter::TrustedOperationPool>>> {
+		self.execute_on_top_pool(
+			|t| {
+				let hashes = bytes_or_hash
+					.into_iter()
+					.map(|x| match x {
+						hash::TrustedOperationOrHash::Hash(h) => Ok(h),
+						hash::TrustedOperationOrHash::OperationEncoded(bytes) => {
+							let op = Decode::decode(&mut &bytes[..]).unwrap();
+							Ok(t.hash_of(&op))
+						},
+						hash::TrustedOperationOrHash::Operation(op) => Ok(t.hash_of(&op)),
+					})
+					.collect::<Result<Vec<_>>>()?;
+				debug!("removing {:?} from top pool", hashes);
+
+				Ok(t.remove_invalid(&hashes, shard, inblock)
+					.into_iter()
+					.map(|op| *op.hash())
+					.collect())
+			},
+			Err,
+		)
 	}
 
-	fn watch_top(&self, ext: Vec<u8>, shard: ShardIdentifier) -> FutureResult<TxHash<P>, RpcError> {
+	fn watch_top(
+		&self,
+		ext: Vec<u8>,
+		shard: ShardIdentifier,
+	) -> PoolFuture<TxHash<TopPoolGetter::TrustedOperationPool>, RpcError> {
 		self.process_top(ext, shard, TopSubmissionMode::SubmitWatch)
 	}
 }
 
-impl<'a, P> OnBlockCreated for Author<'a, P>
+impl<TopPoolGetter> OnBlockCreated for Author<TopPoolGetter>
 where
-	P: TrustedOperationPool + Sync + Send + 'static,
+	TopPoolGetter: GetTopPool + Sync + Send + 'static,
 {
-	type Hash = P::Hash;
+	type Hash = <<TopPoolGetter as GetTopPool>::TrustedOperationPool as TrustedOperationPool>::Hash;
 
 	fn on_block_created(&self, hashes: &[Self::Hash], block_hash: SidechainBlockHash) {
-		self.pool.on_block_created(hashes, block_hash)
+		self.execute_on_top_pool(
+			|t| {
+				t.on_block_created(hashes, block_hash);
+			},
+			|e| {
+				error!("Failed to notify listeners about new block creation: {:?}", e);
+			},
+		);
 	}
 }
 
-impl<'a, P> SendState for Author<'a, P>
+impl<TopPoolGetter> SendState for Author<TopPoolGetter>
 where
-	P: TrustedOperationPool + Sync + Send + 'static,
+	TopPoolGetter: GetTopPool + Sync + Send + 'static,
 {
-	type Hash = P::Hash;
+	type Hash = <<TopPoolGetter as GetTopPool>::TrustedOperationPool as TrustedOperationPool>::Hash;
 
 	fn send_state(&self, hash: Self::Hash, state_encoded: Vec<u8>) -> Result<()> {
-		self.pool.rpc_send_state(hash, state_encoded).map_err(|e| e.into())
+		self.execute_on_top_pool(
+			|t| t.rpc_send_state(hash, state_encoded).map_err(|e| e.into()),
+			Err,
+		)
 	}
 }

--- a/enclave-runtime/src/top_pool/error.rs
+++ b/enclave-runtime/src/top_pool/error.rs
@@ -73,6 +73,9 @@ pub enum Error {
 
 	#[display(fmt = "Failed to send result of trusted operation to RPC client")]
 	FailedToSendUpdateToRpcClient(String),
+
+	#[display(fmt = "Failed to unlock pool (mutex)")]
+	UnlockError,
 }
 
 /// TrustedOperation pool error conversion.


### PR DESCRIPTION
The RPC author is now responsible for locking and unwrapping the top pool it uses. Now owns a top pool getter and does not have to be constructed on the fly. 

This is done in preparation for the `Author` to have a filter feature and use an internal member to access the Rsa3072 shielding key, rather than using static/global access (which is a 'hidden' dependency and very difficult to test)