### PR TITLE
[itp-types] remove re-export of sidechain-primitives in itp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,6 +2303,7 @@ dependencies = [
  "itp-enclave-api",
  "itp-settings",
  "itp-types",
+ "its-primitives",
  "jsonrpsee",
  "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2388,6 +2389,7 @@ dependencies = [
  "integritee-node-runtime",
  "itp-storage",
  "itp-types",
+ "its-primitives",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "pallet-balances",
@@ -2491,6 +2493,7 @@ dependencies = [
  "env_logger 0.9.0",
  "itp-enclave-api",
  "itp-types",
+ "its-primitives",
  "jsonrpsee",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
@@ -2585,6 +2588,7 @@ name = "itp-ocall-api"
 version = "0.8.0"
 dependencies = [
  "itp-types",
+ "its-primitives",
  "parity-scale-codec",
  "sgx_types",
  "sp-runtime",
@@ -2690,7 +2694,6 @@ version = "0.8.0"
 dependencies = [
  "chrono",
  "itp-storage",
- "its-primitives",
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.130",

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -14,6 +14,7 @@ sgx = [
     "sgx-runtime",
     "derive_more",
     "itp-types",
+    "its-primitives",
 ]
 std = [
     "clap",
@@ -47,6 +48,7 @@ sgx_tstd = { rev = "v1.1.3", features = ["untrusted_fs","net","backtrace"], git 
 # local crates
 itp-storage = { path = "../../core-primitives/storage", default-features = false }
 itp-types = { default-features = false, path = "../../core-primitives/types", optional = true }
+its-primitives = { default-features = false, path = "../../sidechain/primitives", optional = true }
 
 # Substrate dependencies
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", features = ["full_crypto"] }

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use itp_storage::storage_value_key;
-use itp_types::{OpaqueCall, SidechainBlockNumber};
+use itp_types::OpaqueCall;
+use its_primitives::types::BlockNumber as SidechainBlockNumber;
 use log_sgx::*;
 use sgx_runtime::{BlockNumber as L1BlockNumer, Runtime};
 use sgx_tstd as std;

--- a/core-primitives/ocall-api/Cargo.toml
+++ b/core-primitives/ocall-api/Cargo.toml
@@ -17,6 +17,7 @@ sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.
 
 # local deps
 itp-types = { path = "../types", default-features = false }
+its-primitives = { path = "../../sidechain/primitives", default-features = false }
 
 [features]
 default = ["std"]
@@ -25,4 +26,5 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "itp-types/std",
+    "its-primitives/std",
 ]

--- a/core-primitives/ocall-api/src/lib.rs
+++ b/core-primitives/ocall-api/src/lib.rs
@@ -19,7 +19,8 @@
 
 use codec::{Decode, Encode};
 use core::fmt::Debug;
-use itp_types::{traits::SignedBlock, TrustedOperationStatus, WorkerRequest, WorkerResponse};
+use itp_types::{TrustedOperationStatus, WorkerRequest, WorkerResponse};
+use its_primitives::traits::SignedBlock;
 use sgx_types::*;
 use sp_runtime::OpaqueExtrinsic;
 use sp_std::prelude::Vec;

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -16,7 +16,6 @@ sgx_tstd = { rev = "v1.1.3", features = ["untrusted_fs","net","backtrace"], git 
 
 # local deps
 itp-storage = { path = "../storage", default-features = false }
-its-primitives = { path = "../../sidechain/primitives", default-features = false }
 
 # substrate-deps
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
@@ -31,9 +30,9 @@ std = [ 'codec/std',
         'serde/std',
         'serde_json/std',
         'primitive-types/std',
-        'its-primitives/std',
         'itp-storage/std',
         'sp-runtime/std',
+        'substrate-api-client/std',
 ]
 sgx = [ 'sgx_tstd' ]
 

--- a/core-primitives/types/src/lib.rs
+++ b/core-primitives/types/src/lib.rs
@@ -12,16 +12,6 @@ use sp_runtime::{
 use std::vec::Vec;
 
 use itp_storage::storage_entry::StorageEntry;
-pub use its_primitives::{
-	traits,
-	types::{
-		block,
-		block::{
-			BlockHash, BlockNumber as SidechainBlockNumber,
-			ShardIdentifier as SidechainShardIdentifier,
-		},
-	},
-};
 pub use rpc::*;
 pub mod rpc;
 
@@ -70,6 +60,8 @@ pub struct Request {
 pub type IpfsHash = [u8; 46];
 
 pub type MrEnclave = [u8; 32];
+
+pub type BlockHash = H256;
 
 pub type ConfirmCallFn = ([u8; 2], ShardIdentifier, H256, Vec<u8>);
 pub type ShieldFundsFn = ([u8; 2], Vec<u8>, u128, ShardIdentifier);

--- a/core/light-client/src/io.rs
+++ b/core/light-client/src/io.rs
@@ -45,7 +45,6 @@ impl<B: Block> SealedIO for LightClientSeal<B> {
 			warn!("could not backup previous light client state");
 		};
 		debug!("Seal light client State. Current state: {:?}", unsealed);
-
 		Ok(unsealed.using_encoded(|bytes| seal(bytes, LIGHT_CLIENT_DB))?)
 	}
 }

--- a/core/light-client/src/lib.rs
+++ b/core/light-client/src/lib.rs
@@ -35,8 +35,7 @@ use itp_storage::{Error as StorageError, StorageProof, StorageProofChecker};
 use justification::GrandpaJustification;
 use log::*;
 use sp_finality_grandpa::{
-	AuthorityId, AuthorityList, AuthorityWeight, ConsensusLog, ScheduledChange, SetId,
-	GRANDPA_ENGINE_ID,
+	AuthorityId, AuthorityWeight, ConsensusLog, ScheduledChange, GRANDPA_ENGINE_ID,
 };
 use sp_runtime::{
 	generic::{Digest as DigestG, OpaqueDigestItemId},
@@ -53,10 +52,11 @@ pub mod state;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 pub mod io;
 
-// reexport this one as we need the trait bound in dependant crates
+// reexport useful types.
 pub use finality_grandpa::BlockNumberOps;
+pub use sp_finality_grandpa::{AuthorityList, SetId};
 
-type RelayId = u64;
+pub type RelayId = u64;
 
 pub type AuthorityListRef<'a> = &'a [(AuthorityId, AuthorityWeight)];
 
@@ -257,7 +257,7 @@ where
 	) -> Result<(), Error> {
 		let mut relay = self.tracked_relays.get_mut(&relay_id).ok_or(Error::NoSuchRelayExists)?;
 
-		// Check that the new header is a decendent of the old header
+		// Check that the new header is a descendant of the old header
 		let last_header = &relay.last_finalized_block_header;
 		Self::verify_ancestry(ancestry_proof, last_header.hash(), &header)?;
 

--- a/core/light-client/src/state.rs
+++ b/core/light-client/src/state.rs
@@ -26,7 +26,6 @@ use std::{fmt, vec::Vec};
 #[derive(Encode, Decode, Clone, PartialEq)]
 pub struct RelayState<Block: BlockT> {
 	pub last_finalized_block_header: Block::Header,
-	pub penultimate_finalized_block_header: Block::Header,
 	pub current_validator_set: AuthorityList,
 	pub current_validator_set_id: SetId,
 	pub header_hashes: Vec<Block::Hash>,
@@ -46,19 +45,12 @@ impl<Block: BlockT> RelayState<Block> {
 		RelayState {
 			header_hashes: vec![block_header.hash()],
 			last_finalized_block_header: block_header.clone(),
-			// is it bad to initialize with the same? Header trait does no implement default...
-			penultimate_finalized_block_header: block_header,
 			current_validator_set: validator_set,
 			current_validator_set_id: 0,
 			unjustified_headers: Vec::new(),
 			verify_tx_inclusion: Vec::new(),
 			scheduled_change: None,
 		}
-	}
-
-	pub fn set_last_finalized_block_header(&mut self, header: Block::Header) {
-		self.penultimate_finalized_block_header = self.last_finalized_block_header.clone();
-		self.last_finalized_block_header = header;
 	}
 }
 

--- a/core/light-client/src/state.rs
+++ b/core/light-client/src/state.rs
@@ -44,7 +44,7 @@ impl<Block: BlockT> RelayState<Block> {
 	pub fn new(block_header: Block::Header, validator_set: AuthorityList) -> Self {
 		RelayState {
 			header_hashes: vec![block_header.hash()],
-			last_finalized_block_header: block_header.clone(),
+			last_finalized_block_header: block_header,
 			current_validator_set: validator_set,
 			current_validator_set_id: 0,
 			unjustified_headers: Vec::new(),

--- a/core/light-client/src/state.rs
+++ b/core/light-client/src/state.rs
@@ -26,6 +26,7 @@ use std::{fmt, vec::Vec};
 #[derive(Encode, Decode, Clone, PartialEq)]
 pub struct RelayState<Block: BlockT> {
 	pub last_finalized_block_header: Block::Header,
+	pub penultimate_finalized_block_header: Block::Header,
 	pub current_validator_set: AuthorityList,
 	pub current_validator_set_id: SetId,
 	pub header_hashes: Vec<Block::Hash>,
@@ -43,14 +44,21 @@ pub struct ScheduledChangeAtBlock<Header: HeaderT> {
 impl<Block: BlockT> RelayState<Block> {
 	pub fn new(block_header: Block::Header, validator_set: AuthorityList) -> Self {
 		RelayState {
+			header_hashes: vec![block_header.hash()],
 			last_finalized_block_header: block_header.clone(),
+			// is it bad to initialize with the same? Header trait does no implement default...
+			penultimate_finalized_block_header: block_header,
 			current_validator_set: validator_set,
 			current_validator_set_id: 0,
-			header_hashes: vec![block_header.hash()],
 			unjustified_headers: Vec::new(),
 			verify_tx_inclusion: Vec::new(),
 			scheduled_change: None,
 		}
+	}
+
+	pub fn set_last_finalized_block_header(&mut self, header: Block::Header) {
+		self.penultimate_finalized_block_header = self.last_finalized_block_header.clone();
+		self.last_finalized_block_header = header;
 	}
 }
 

--- a/core/rpc-server/Cargo.toml
+++ b/core/rpc-server/Cargo.toml
@@ -14,6 +14,7 @@ tokio = { version = "1.6.1", features = ["full"] }
 parity-scale-codec = "2.1.3"
 
 itp-enclave-api = { path = "../../core-primitives/enclave-api" }
+its-primitives = { path = "../../sidechain/primitives" }
 itp-types = { path = "../../core-primitives/types" }
 
 [features]

--- a/core/rpc-server/src/lib.rs
+++ b/core/rpc-server/src/lib.rs
@@ -26,7 +26,9 @@ use parity_scale_codec::Encode;
 use tokio::net::ToSocketAddrs;
 
 use itp_enclave_api::direct_request::DirectRequest;
-use itp_types::{block::SignedBlock, RpcRequest};
+use itp_types::RpcRequest;
+use its_primitives::types::SignedBlock;
+
 use std::sync::Arc;
 
 #[cfg(test)]

--- a/core/rpc-server/src/mock.rs
+++ b/core/rpc-server/src/mock.rs
@@ -1,10 +1,10 @@
 use parity_scale_codec::Encode;
 
 use itp_enclave_api::{direct_request::DirectRequest, EnclaveResult};
-use itp_types::{
-	block::{Block, SignedBlock},
+use itp_types::{RpcResponse, ShardIdentifier};
+use its_primitives::{
 	traits::{Block as BlockT, SignBlock},
-	RpcResponse, ShardIdentifier,
+	types::{Block, SignedBlock},
 };
 
 pub struct TestEnclave;

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
  "frame-system",
  "itp-storage",
  "itp-types",
+ "its-primitives",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "pallet-balances",
  "parity-scale-codec",
@@ -1213,6 +1214,7 @@ name = "itp-ocall-api"
 version = "0.8.0"
 dependencies = [
  "itp-types",
+ "its-primitives",
  "parity-scale-codec",
  "sgx_types",
  "sp-runtime",
@@ -1314,7 +1316,6 @@ version = "0.8.0"
 dependencies = [
  "chrono 0.4.19",
  "itp-storage",
- "its-primitives",
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.130",

--- a/enclave-runtime/src/rpc/basic_pool.rs
+++ b/enclave-runtime/src/rpc/basic_pool.rs
@@ -13,7 +13,7 @@ use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::pin::Pin;
 use ita_stf::{ShardIdentifier, TrustedOperation as StfTrustedOperation};
 use itc_direct_rpc_server::SendRpcResponse;
-use itp_types::BlockHash as SidechainBlockHash;
+use its_primitives::types::BlockHash as SidechainBlockHash;
 use jsonrpc_core::futures::{
 	channel::oneshot,
 	future::{ready, Future, FutureExt},

--- a/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -35,9 +35,8 @@ use codec::{Decode, Encode};
 use core::result::Result;
 use ita_stf::ShardIdentifier;
 use itp_sgx_crypto::Rsa3072Seal;
-use itp_types::{
-	block::SignedBlock, DirectRequestStatus, Request, RpcReturnValue, TrustedOperationStatus, H256,
-};
+use itp_types::{DirectRequestStatus, Request, RpcReturnValue, TrustedOperationStatus, H256};
+use its_primitives::types::SignedBlock;
 use jsonrpc_core::{futures::executor, Error as RpcError, *};
 use log::*;
 use sgx_types::*;

--- a/enclave-runtime/src/tests.rs
+++ b/enclave-runtime/src/tests.rs
@@ -36,10 +36,10 @@ use itp_settings::{
 use itp_sgx_crypto::{AesSeal, Rsa3072Seal, ShieldingCrypto, StateCrypto};
 use itp_sgx_io::SealedIO;
 use itp_storage::storage_value_key;
-use itp_types::{Block, Header, MrEnclave, OpaqueCall, SidechainBlockNumber};
+use itp_types::{Block, Header, MrEnclave, OpaqueCall};
 use its_primitives::{
 	traits::{Block as BlockT, SignedBlock as SignedBlockT},
-	types::block::SignedBlock,
+	types::{BlockNumber as SidechainBlockNumber, SignedBlock},
 };
 use jsonrpc_core::futures::executor;
 use log::*;

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -47,6 +47,7 @@ itp-api-client-extensions = { path = "../core-primitives/api-client-extensions" 
 itc-rpc-client = { path = "../core/rpc-client" }
 itc-rpc-server = { path = "../core/rpc-server" }
 itp-enclave-api = { path = "../core-primitives/enclave-api" }
+its-primitives = { path = "../sidechain/primitives"}
 ita-stf = { path = "../app-libs/stf" }
 
 # scs / integritee

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -52,7 +52,8 @@ use itp_settings::{
 	},
 	worker::MIN_FUND_INCREASE_FACTOR,
 };
-use itp_types::{block::SignedBlock as SignedSidechainBlock, Block, SignedBlock};
+use itp_types::{Block, SignedBlock};
+use its_primitives::types::SignedBlock as SignedSidechainBlock;
 use log::*;
 use my_node_runtime::{pallet_teerex::ShardIdentifier, Event, Hash, Header};
 use sgx_types::*;

--- a/service/src/ocall_bridge/component_factory.rs
+++ b/service/src/ocall_bridge/component_factory.rs
@@ -16,7 +16,6 @@
 
 */
 
-use super::worker_on_chain_ocall::SignedSidechainBlock;
 use crate::{
 	direct_invocation::{
 		direct_invocation_ocall::DirectInvocationOCall, watch_list_service::WatchList,
@@ -35,6 +34,7 @@ use crate::{
 	sync_block_gossiper::GossipBlocks,
 };
 use itp_enclave_api::remote_attestation::RemoteAttestationCallBacks;
+use its_primitives::types::SignedBlock as SignedSidechainBlock;
 use std::sync::Arc;
 
 /// Concrete implementation, should be moved out of the OCall Bridge, into the worker

--- a/service/src/ocall_bridge/worker_on_chain_ocall.rs
+++ b/service/src/ocall_bridge/worker_on_chain_ocall.rs
@@ -24,8 +24,8 @@ use crate::{
 	utils::hex_encode,
 };
 use codec::{Decode, Encode};
-pub use itp_types::block::SignedBlock as SignedSidechainBlock;
 use itp_types::{WorkerRequest, WorkerResponse};
+use its_primitives::types::SignedBlock as SignedSidechainBlock;
 use log::*;
 use sp_core::storage::StorageKey;
 use sp_runtime::OpaqueExtrinsic;

--- a/service/src/sidechain_storage/interface.rs
+++ b/service/src/sidechain_storage/interface.rs
@@ -11,7 +11,7 @@
 	limitations under the License.
 */
 use super::{storage::SidechainStorage, Result};
-use itp_types::{block::BlockNumber, traits::SignedBlock as SignedBlockT};
+use its_primitives::{traits::SignedBlock as SignedBlockT, types::BlockNumber};
 #[cfg(test)]
 use mockall::predicate::*;
 #[cfg(test)]

--- a/service/src/sidechain_storage/mod.rs
+++ b/service/src/sidechain_storage/mod.rs
@@ -10,7 +10,7 @@
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */
-use itp_types::block::BlockNumber;
+use its_primitives::types::BlockNumber;
 use std::{
 	sync::Arc,
 	thread,

--- a/service/src/sidechain_storage/storage.rs
+++ b/service/src/sidechain_storage/storage.rs
@@ -13,9 +13,9 @@
 
 use super::{db::SidechainDB, Error, Result};
 use codec::{Decode, Encode};
-use itp_types::{
-	block::{BlockHash, BlockNumber},
+use its_primitives::{
 	traits::{Block as BlockT, SignedBlock as SignedBlockT},
+	types::{BlockHash, BlockNumber},
 };
 use log::*;
 use rocksdb::WriteBatch;
@@ -308,10 +308,10 @@ impl<SignedBlock: SignedBlockT> SidechainStorage<SignedBlock> {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use itp_types::{
-		block::{Block, SignedBlock},
+	use itp_types::ShardIdentifier;
+	use its_primitives::{
 		traits::{Block as BlockT, SignBlock, SignedBlock as SignedBlockT},
-		ShardIdentifier,
+		types::{Block, SignedBlock},
 	};
 	use rocksdb::{Options, DB};
 	use sp_core::{crypto::Pair, ed25519, H256};

--- a/service/src/sync_block_gossiper.rs
+++ b/service/src/sync_block_gossiper.rs
@@ -21,7 +21,7 @@ use crate::{
 	globals::{tokio_handle::GetTokioHandle, worker::GetWorker},
 	worker::{WorkerResult, WorkerT},
 };
-use itp_types::block::SignedBlock as SignedSidechainBlock;
+use its_primitives::types::SignedBlock as SignedSidechainBlock;
 use log::*;
 use std::sync::Arc;
 

--- a/service/src/tests/commons.rs
+++ b/service/src/tests/commons.rs
@@ -32,9 +32,9 @@ use substrate_api_client::{rpc::WsRpcClient, Api};
 #[cfg(test)]
 use crate::config::Config;
 #[cfg(test)]
-use itp_types::{
-	block::{Block, SignedBlock},
+use its_primitives::{
 	traits::{Block as BlockT, SignBlock},
+	types::{Block, SignedBlock},
 };
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/service/src/worker.rs
+++ b/service/src/worker.rs
@@ -12,7 +12,8 @@ use log::info;
 use std::num::ParseIntError;
 
 use itp_api_client_extensions::PalletTeerexApi;
-use itp_types::{block::SignedBlock as SignedSidechainBlock, Enclave as EnclaveMetadata};
+use itp_types::Enclave as EnclaveMetadata;
+use its_primitives::types::SignedBlock as SignedSidechainBlock;
 
 use crate::{config::Config, error::Error};
 use std::sync::Arc;
@@ -115,7 +116,7 @@ pub fn worker_url_into_async_rpc_url(url: &str) -> WorkerResult<String> {
 #[cfg(test)]
 mod tests {
 	use frame_support::assert_ok;
-	use itp_types::block::SignedBlock as SignedSidechainBlock;
+	use its_primitives::types::SignedBlock as SignedSidechainBlock;
 	use jsonrpsee::{ws_server::WsServerBuilder, RpcModule};
 	use log::debug;
 	use std::net::SocketAddr;

--- a/sidechain/primitives/src/types/mod.rs
+++ b/sidechain/primitives/src/types/mod.rs
@@ -1,1 +1,3 @@
 pub mod block;
+
+pub use block::*;


### PR DESCRIPTION
I needed some type from `itp_type` in `its-primitives` in aura, which resulted in cyclic dependencies. In the end, I removed that again, so this PR would not be strictly necessary. :)

However, I think we should have these two crates clearly separated.