### PR TITLE
Add new filter feature for trusted operations in the RPC author

### DIFF
--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -38,7 +38,7 @@ use crate::{
 	rpc::{
 		author::{
 			author_container::{GetAuthor, GlobalAuthorContainer},
-			OnBlockCreated, SendState,
+			AuthorTopFilter, OnBlockCreated, SendState,
 		},
 		worker_api_direct::{public_api_rpc_handler, side_chain_io_handler},
 	},
@@ -468,7 +468,8 @@ pub unsafe extern "C" fn init_direct_invocation_server(
 		},
 	};
 
-	let rpc_author = Arc::new(Author::new(top_pool, state_facade, rsa_shielding_key));
+	let rpc_author =
+		Arc::new(Author::new(top_pool, AuthorTopFilter {}, state_facade, rsa_shielding_key));
 
 	GlobalAuthorContainer::initialize(rpc_author.clone());
 

--- a/enclave-runtime/src/rpc/author/author_container.rs
+++ b/enclave-runtime/src/rpc/author/author_container.rs
@@ -17,7 +17,8 @@
 
 use crate::{
 	rpc::author::{
-		atomic_container::AtomicContainer, Author, AuthorApi, OnBlockCreated, SendState,
+		atomic_container::AtomicContainer, Author, AuthorApi, AuthorTopFilter, OnBlockCreated,
+		SendState,
 	},
 	state::StateFacade,
 	top_pool::pool_types::BPool,
@@ -56,7 +57,7 @@ impl GlobalAuthorContainer {
 }
 
 impl GetAuthor for GlobalAuthorContainer {
-	type AuthorType = Author<BPool, StateFacade, Rsa3072KeyPair>;
+	type AuthorType = Author<BPool, AuthorTopFilter, StateFacade, Rsa3072KeyPair>;
 
 	fn get(&self) -> Option<&'static SgxMutex<Arc<Self::AuthorType>>> {
 		GLOBAL_AUTHOR_CONTAINER.load()

--- a/enclave-runtime/src/rpc/author/author_tests.rs
+++ b/enclave-runtime/src/rpc/author/author_tests.rs
@@ -18,25 +18,91 @@
 #[cfg(feature = "test")]
 pub mod tests {
 	use crate::{
-		rpc::author::{Author, AuthorApi},
+		rpc::author::{
+			test_utils::submit_and_execute_top,
+			top_filter::{AllowAllTopsFilter, Filter, GettersOnlyFilter},
+			Author,
+		},
 		state::HandleState,
 		test::mocks::{
 			handle_state_mock::HandleStateMock, shielding_crypto_mock::ShieldingCryptoMock,
 			trusted_operation_pool_mock::TrustedOperationPoolMock,
 		},
 	};
-	use codec::Encode;
+	use codec::{Decode, Encode};
 	use frame_support::sp_runtime::traits::{BlakeTwo256, Hash};
-	use ita_stf::{Getter, KeyPair, ShardIdentifier, TrustedGetter, TrustedOperation};
+	use ita_stf::{
+		Getter, KeyPair, ShardIdentifier, TrustedCall, TrustedCallSigned, TrustedGetter,
+		TrustedOperation,
+	};
 	use itp_sgx_crypto::ShieldingCrypto;
-	use jsonrpc_core::futures::executor;
+	use sgx_crypto_helper::{rsa3072::Rsa3072KeyPair, RsaKeyPair};
 	use sp_core::{ed25519, Pair, H256};
 	use std::sync::Arc;
 
 	type Seed = [u8; 32];
 	const TEST_SEED: Seed = *b"12345678901234567890123456789012";
 
+	type TestAuthor<F> = Author<TrustedOperationPoolMock, F, HandleStateMock, ShieldingCryptoMock>;
+
+	pub fn top_encryption_works() {
+		// the sgx crypto crate lacks unit tests, one of the reasons being that the
+		// crypto structs are only available in SGX mode and cannot be tested using cargo test
+		// so we test some of the functionality here, where we encrypt and decrypt trusted operations
+		// using a RSA3072 key
+
+		let trusted_call = TrustedOperation::from(trusted_call_signed());
+		let trusted_getter = TrustedOperation::from(trusted_getter_signed());
+
+		assert_eq!(trusted_call, encrypt_and_decrypt_top(&trusted_call));
+		assert_eq!(trusted_getter, encrypt_and_decrypt_top(&trusted_getter));
+	}
+
+	fn encrypt_and_decrypt_top(top: &TrustedOperation) -> TrustedOperation {
+		let encryption_key = Rsa3072KeyPair::new().unwrap();
+		let encrypted_top = encryption_key.encrypt(top.encode().as_slice()).unwrap();
+		let decrypted_top = encryption_key.decrypt(encrypted_top.as_slice()).unwrap();
+
+		TrustedOperation::decode(&mut decrypted_top.as_slice()).unwrap()
+	}
+
 	pub fn submitting_to_author_inserts_in_pool() {
+		let (author, top_pool, shielding_key) = create_author_with_filter(AllowAllTopsFilter);
+		let top = TrustedOperation::from(trusted_getter_signed());
+
+		let submit_response: H256 =
+			submit_and_execute_top(&author, &top, &shielding_key, shard_id()).unwrap();
+
+		assert!(!submit_response.is_zero());
+
+		let submitted_transactions = top_pool.get_last_submitted_transactions();
+		assert_eq!(1, submitted_transactions.len());
+	}
+
+	pub fn submitting_call_to_author_when_top_is_filtered_returns_error() {
+		let (author, top_pool, shielding_key) = create_author_with_filter(GettersOnlyFilter);
+		let top = TrustedOperation::from(trusted_call_signed());
+
+		let submit_response = submit_and_execute_top(&author, &top, &shielding_key, shard_id());
+
+		assert!(submit_response.is_err());
+		assert!(top_pool.get_last_submitted_transactions().is_empty());
+	}
+
+	pub fn submitting_getter_to_author_when_top_is_filtered_inserts_in_pool() {
+		let (author, top_pool, shielding_key) = create_author_with_filter(GettersOnlyFilter);
+		let top = TrustedOperation::from(trusted_getter_signed());
+
+		let submit_response =
+			submit_and_execute_top(&author, &top, &shielding_key, shard_id()).unwrap();
+
+		assert!(!submit_response.is_zero());
+		assert_eq!(1, top_pool.get_last_submitted_transactions().len());
+	}
+
+	fn create_author_with_filter<F: Filter<Value = TrustedOperation>>(
+		filter: F,
+	) -> (TestAuthor<F>, Arc<TrustedOperationPoolMock>, ShieldingCryptoMock) {
 		let top_pool = Arc::new(TrustedOperationPoolMock::default());
 
 		let shard_id = shard_id();
@@ -45,23 +111,28 @@ pub mod tests {
 
 		let encryption_key = ShieldingCryptoMock::default();
 
-		let author = Author::new(top_pool.clone(), Arc::new(state_facade), encryption_key.clone());
-		let top = TrustedOperation::from(trusted_getter_signed());
-		let top_encrypted = encryption_key.encrypt(top.encode().as_slice()).unwrap();
+		(
+			Author::new(top_pool.clone(), filter, Arc::new(state_facade), encryption_key.clone()),
+			top_pool,
+			encryption_key,
+		)
+	}
 
-		let submit_future = async { author.submit_top(top_encrypted, shard_id).await };
-		let submit_response: H256 = executor::block_on(submit_future).unwrap();
-
-		assert!(!submit_response.is_zero());
-
-		let submitted_transactions = top_pool.get_last_submitted_transactions();
-		assert_eq!(1, submitted_transactions.len());
+	fn trusted_call_signed() -> TrustedCallSigned {
+		let account = ed25519::Pair::from_seed(&TEST_SEED);
+		let call =
+			TrustedCall::balance_shield(account.public().into(), account.public().into(), 12u128);
+		call.sign(&KeyPair::Ed25519(account), 0, &mr_enclave(), &shard_id())
 	}
 
 	fn trusted_getter_signed() -> Getter {
-		let who_key_pair = ed25519::Pair::from_seed(&TEST_SEED);
-		let getter = TrustedGetter::free_balance(who_key_pair.public().into());
-		Getter::trusted(getter.sign(&KeyPair::Ed25519(who_key_pair)))
+		let account = ed25519::Pair::from_seed(&TEST_SEED);
+		let getter = TrustedGetter::free_balance(account.public().into());
+		Getter::trusted(getter.sign(&KeyPair::Ed25519(account)))
+	}
+
+	fn mr_enclave() -> [u8; 32] {
+		[1u8; 32]
 	}
 
 	fn shard_id() -> ShardIdentifier {

--- a/enclave-runtime/src/rpc/author/client_error.rs
+++ b/enclave-runtime/src/rpc/author/client_error.rs
@@ -67,6 +67,9 @@ pub enum Error {
 	/// Shard does not exist.
 	#[display(fmt = "Shard does not exist")]
 	InvalidShard,
+	/// Unsupported trusted operation (in case we allow only certain types of operations, using filters)
+	#[display(fmt = "Unsupported operation type")]
+	UnsupportedOperation,
 }
 
 impl std::error::Error for Error {

--- a/enclave-runtime/src/rpc/author/test_utils.rs
+++ b/enclave-runtime/src/rpc/author/test_utils.rs
@@ -1,0 +1,56 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::rpc::author::AuthorApi;
+use codec::Encode;
+use ita_stf::{ShardIdentifier, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
+use itp_sgx_crypto::ShieldingCrypto;
+use jsonrpc_core::futures::executor;
+use sp_core::H256;
+use std::{fmt::Debug, vec::Vec};
+
+/// Test utility function to submit and execute a trusted operation on an RPC author
+///
+/// The trusted operation will be executed in a blocking (i.e. synchronous) fashion
+pub fn submit_and_execute_top<R, S>(
+	author: &R,
+	top: &TrustedOperation,
+	shielding_key: &S,
+	shard: ShardIdentifier,
+) -> Result<H256, jsonrpc_core::Error>
+where
+	R: AuthorApi<H256, H256>,
+	S: ShieldingCrypto,
+	S::Error: Debug,
+{
+	let top_encrypted = shielding_key.encrypt(top.encode().as_slice()).unwrap();
+	let submit_future = async { author.submit_top(top_encrypted, shard).await };
+	executor::block_on(submit_future)
+}
+
+/// Get all pending trusted operations, grouped into calls and getters
+///
+///
+pub fn get_pending_tops_separated<R>(
+	rpc_author: &R,
+	shard: ShardIdentifier,
+) -> (Vec<TrustedCallSigned>, Vec<TrustedGetterSigned>)
+where
+	R: AuthorApi<H256, H256>,
+{
+	rpc_author.get_pending_tops_separated(shard).unwrap()
+}

--- a/enclave-runtime/src/rpc/author/top_filter.rs
+++ b/enclave-runtime/src/rpc/author/top_filter.rs
@@ -1,0 +1,119 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use ita_stf::TrustedOperation;
+
+/// Trait for filtering values
+///
+/// Returns `Some` if a value should be included and `None` if discarded
+pub trait Filter {
+	type Value;
+
+	fn filter(&self, value: &Self::Value) -> bool;
+}
+
+/// Filter that allows all TOPs (i.e. not filter at all)
+pub struct AllowAllTopsFilter;
+
+impl Filter for AllowAllTopsFilter {
+	type Value = TrustedOperation;
+
+	fn filter(&self, _value: &Self::Value) -> bool {
+		true
+	}
+}
+
+/// Filter that allows only trusted getters
+pub struct GettersOnlyFilter;
+
+impl Filter for GettersOnlyFilter {
+	type Value = TrustedOperation;
+
+	fn filter(&self, value: &Self::Value) -> bool {
+		matches!(value, TrustedOperation::get(_))
+	}
+}
+
+#[cfg(feature = "test")]
+pub mod tests {
+
+	use super::*;
+	use codec::Encode;
+	use frame_support::sp_runtime::traits::{BlakeTwo256, Hash};
+	use ita_stf::{Getter, KeyPair, TrustedCall, TrustedGetter};
+	use itp_types::ShardIdentifier;
+	use sp_core::{ed25519, Pair};
+	use std::string::{String, ToString};
+
+	type Seed = [u8; 32];
+	const TEST_SEED: Seed = *b"12345678901234567890123456789012";
+
+	pub fn filter_returns_none_if_values_is_filtered_out() {
+		struct WorldFilter;
+		impl Filter for WorldFilter {
+			type Value = String;
+
+			fn filter(&self, value: &Self::Value) -> bool {
+				if value.eq(&String::from("world")) {
+					return true
+				}
+				false
+			}
+		}
+
+		let filter = WorldFilter;
+
+		assert!(!filter.filter(&"hello".to_string()));
+		assert!(filter.filter(&"world".to_string()));
+	}
+
+	pub fn getters_only_filter_allows_trusted_getters() {
+		let account = test_account();
+
+		let getter = TrustedGetter::free_balance(account.public().into());
+		let trusted_getter_signed = Getter::trusted(getter.sign(&KeyPair::Ed25519(account)));
+		let trusted_operation = TrustedOperation::from(trusted_getter_signed);
+
+		let filter = GettersOnlyFilter;
+
+		assert!(filter.filter(&trusted_operation));
+	}
+
+	pub fn getters_only_filter_denies_trusted_calls() {
+		let account = test_account();
+		let call =
+			TrustedCall::balance_shield(account.public().into(), account.public().into(), 12u128);
+		let call_signed = call.sign(&KeyPair::Ed25519(account), 0, &mr_enclave(), &shard_id());
+		let trusted_operation = TrustedOperation::from(call_signed);
+
+		let filter = GettersOnlyFilter;
+
+		assert!(!filter.filter(&trusted_operation));
+	}
+
+	fn test_account() -> ed25519::Pair {
+		ed25519::Pair::from_seed(&TEST_SEED)
+	}
+
+	fn shard_id() -> ShardIdentifier {
+		BlakeTwo256::hash(vec![1u8, 2u8, 3u8].as_slice().encode().as_slice())
+	}
+
+	fn mr_enclave() -> [u8; 32] {
+		[1u8; 32]
+	}
+}

--- a/enclave-runtime/src/top_pool/validated_pool.rs
+++ b/enclave-runtime/src/top_pool/validated_pool.rs
@@ -102,7 +102,6 @@ where
 
 impl<B: ChainApi, R> ValidatedPool<B, R>
 where
-	//<<B as ChainApi>::Block as sp_runtime::traits::Block>::Hash: Serialize
 	R: SendRpcResponse<Hash = ExtrinsicHash<B>>,
 {
 	/// Create a new operation pool.


### PR DESCRIPTION
The RPC author now takes a filter for the trusted operations, which allows to disable certain trusted operations, like trusted calls (to only allow trusted getters).

- by default, all tops are allowed in the author
- if an operation is received that is filtered out, an error is
returned

- [x] Merge #430 first and then rebase this branch onto master

Closes #415 #416