### PR TITLE
Add runtime check bypass to enclave

### DIFF
--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -442,7 +442,7 @@ dependencies = [
  "curve25519-dalek 3.2.0",
  "ed25519",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -1105,7 +1105,7 @@ dependencies = [
  "either",
  "multihash",
  "quick-protobuf",
- "sha2 0.9.6",
+ "sha2 0.9.8",
 ]
 
 [[package]]
@@ -1595,7 +1595,7 @@ dependencies = [
  "blake2s_simd",
  "digest 0.9.0",
  "sha-1",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "sha3",
  "unsigned-varint",
 ]
@@ -2778,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -2953,7 +2953,7 @@ dependencies = [
  "primitive-types",
  "schnorrkel",
  "secrecy",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "sp-debug-derive",
  "sp-runtime-interface",
  "sp-std",
@@ -3433,7 +3433,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/enclave-runtime/Makefile
+++ b/enclave-runtime/Makefile
@@ -29,6 +29,7 @@
 Rust_Enclave_Name := libenclave.a
 Rust_Enclave_Files := $(wildcard src/*.rs) $(wildcard ../stf/src/*.rs)
 Rust_Target_Path := $(CURDIR)/../../../xargo
+RUSTFLAGS :="-C target-feature=+avx2"
 
 ifeq ($(SGX_DEBUG), 1)
 	OUTPUT_PATH := release
@@ -53,6 +54,6 @@ ifeq ($(XARGO_SGX), 1)
 	RUST_TARGET_PATH=$(Rust_Target_Path) xargo build --target x86_64-unknown-linux-sgx $(CARGO_TARGET)
 	cp ./target/x86_64-unknown-linux-sgx/$(OUTPUT_PATH)/libenclave_runtime.a ../lib/libenclave.a
 else
-	cargo build $(CARGO_TARGET) $(ENCLAVE_FEATURES)
+	RUSTFLAGS=$(RUSTFLAGS) cargo build $(CARGO_TARGET) $(ENCLAVE_FEATURES)
 	cp ./target/$(OUTPUT_PATH)/libenclave_runtime.a ../lib/libenclave.a
 endif


### PR DESCRIPTION
This commit solves a future issue : https://github.com/RustCrypto/hashes/issues/321
It basically adds a rust target flag to bypass runtime check in the enclave.

`sha2` was upadted to `v0.9.8` to verify if the flag is working.