### PR TITLE
Separate parentchain sync from top execution

### DIFF
--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -37,7 +37,12 @@ extern "C" {
 		latest_header_size: usize,
 	) -> sgx_status_t;
 
-	pub fn sync_parentchain_and_execute_tops(
+	pub fn execute_trusted_operations(
+		eid: sgx_enclave_id_t,
+		retval: *mut sgx_status_t,
+	) -> sgx_status_t;
+
+	pub fn sync_parentchain(
 		eid: sgx_enclave_id_t,
 		retval: *mut sgx_status_t,
 		blocks: *const u8,

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -51,7 +51,9 @@ enclave {
             [out, size=latest_header_size] uint8_t* latest_header, size_t latest_header_size
         );
 
-        public sgx_status_t sync_parentchain_and_execute_tops(
+        public sgx_status_t execute_trusted_operations();
+
+        public sgx_status_t sync_parentchain(
             [in, size=blocks_size] uint8_t* blocks, size_t blocks_size,
             [in] uint32_t* nonce
         );

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
 	Codec(#[from] CodecError),
 	#[error("{0}")]
 	ApiClientError(#[from] ApiClientError),
+	#[error("Node API terminated subscription unexpectedly: {0}")]
+	ApiSubscriptionDisconnected(#[from] std::sync::mpsc::RecvError),
 	#[error("{0}")]
 	JsonRpSeeClient(#[from] jsonrpsee::types::Error),
 	#[error("{0}")]

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -16,6 +16,7 @@
 */
 use crate::{
 	direct_invocation::{watch_list_service::WatchListService, watching_client::WsWatchingClient},
+	error::Error,
 	globals::{
 		tokio_handle::{GetTokioHandle, GlobalTokioHandle},
 		worker::{GlobalWorker, Worker},
@@ -338,16 +339,31 @@ fn start_worker<E, T, D>(
 	let tx_hash = node_api.send_extrinsic(xthex, XtStatus::Finalized).unwrap();
 	println!("[<] Extrinsic got finalized. Hash: {:?}\n", tx_hash);
 
-	let latest_head = init_light_client(&node_api, enclave.as_ref());
+	let last_synced_header = init_light_client(&node_api, enclave.as_ref());
 	println!("*** [+] Finished syncing light client\n");
 
 	// ------------------------------------------------------------------------
 	// start interval block production
-	let api4 = node_api.clone();
+	let side_chain_enclave_api = enclave.clone();
 	thread::Builder::new()
 		.name("interval_block_production_timer".to_owned())
+		.spawn(move || start_interval_block_production(side_chain_enclave_api.as_ref()))
+		.unwrap();
+
+	// ------------------------------------------------------------------------
+	// start parentchain syncing loop (subscribe to header updates)
+	let api4 = node_api.clone();
+	thread::Builder::new()
+		.name("parent_chain_sync_loop".to_owned())
 		.spawn(move || {
-			start_interval_block_production(enclave.clone().as_ref(), &api4, latest_head)
+			if let Err(e) = subscribe_to_parentchain_new_headers(
+				enclave.clone().as_ref(),
+				&api4,
+				last_synced_header,
+			) {
+				error!("Parentchain block syncing terminated with a failure: {:?}", e);
+			}
+			println!("[+] Parentchain block syncing has terminated");
 		})
 		.unwrap();
 
@@ -388,11 +404,7 @@ fn start_worker<E, T, D>(
 }
 
 /// Triggers the enclave to produce a block based on a fixed time schedule
-fn start_interval_block_production<E: EnclaveBase + SideChain>(
-	enclave_api: &E,
-	api: &Api<sr25519::Pair, WsRpcClient>,
-	mut latest_head: Header,
-) {
+fn start_interval_block_production<E: EnclaveBase + SideChain>(enclave_api: &E) {
 	use itp_settings::sidechain::SLOT_DURATION;
 
 	let mut interval_start = SystemTime::now();
@@ -401,7 +413,6 @@ fn start_interval_block_production<E: EnclaveBase + SideChain>(
 			if elapsed >= SLOT_DURATION {
 				// update interval time
 				interval_start = SystemTime::now();
-				latest_head = sync_parentchain(enclave_api, api, latest_head);
 				execute_trusted_operations(enclave_api);
 			} else {
 				// sleep for the rest of the interval
@@ -528,12 +539,40 @@ pub fn init_light_client<E: EnclaveBase + SideChain>(
 		.init_light_client(genesis_header, authority_list, grandpa_proof)
 		.unwrap();
 
-	info!("Finished initializing light client, syncing....");
+	info!("Finished initializing light client, syncing parent chain...");
 
-	let last_synced_header = sync_parentchain(enclave_api, api, latest);
+	let latest_synced_header = sync_parentchain(enclave_api, api, latest);
+
+	info!("Execute trusted operations for the first time and start side chain block production");
+
 	execute_trusted_operations(enclave_api);
 
-	last_synced_header
+	latest_synced_header
+}
+
+/// Subscribe to the node API finalized heads stream and trigger a parent chain sync
+/// upon receiving a new header
+fn subscribe_to_parentchain_new_headers<E: EnclaveBase + SideChain>(
+	enclave_api: &E,
+	api: &Api<sr25519::Pair, WsRpcClient>,
+	mut last_synced_header: Header,
+) -> Result<(), Error> {
+	let (sender, receiver) = channel();
+	api.subscribe_finalized_heads(sender).map_err(Error::ApiClientError)?;
+
+	loop {
+		let new_header: Header = match receiver.recv() {
+			Ok(header_str) => serde_json::from_str(&header_str).map_err(Error::Serialization),
+			Err(e) => Err(Error::ApiSubscriptionDisconnected(e)),
+		}?;
+
+		println!(
+			"[+] Received finalized header update ({}), syncing parent chain...",
+			new_header.number
+		);
+
+		last_synced_header = sync_parentchain(enclave_api, api, last_synced_header);
+	}
 }
 
 /// Gets the amount of blocks to sync from the parentchain and feeds them to the enclave.
@@ -542,7 +581,7 @@ pub fn init_light_client<E: EnclaveBase + SideChain>(
 pub fn sync_parentchain<E: EnclaveBase + SideChain>(
 	enclave_api: &E,
 	api: &Api<sr25519::Pair, WsRpcClient>,
-	mut last_synced_header: Header,
+	last_synced_header: Header,
 ) -> Header {
 	let tee_accountid = enclave_account(enclave_api);
 
@@ -552,6 +591,10 @@ pub fn sync_parentchain<E: EnclaveBase + SideChain>(
 
 	let blocks_to_sync = get_blocks_to_sync(api, &last_synced_header, &curr_head);
 
+	println!("[+] Found {} block(s) to sync", blocks_to_sync.len());
+
+	let mut synced_header_until = last_synced_header;
+
 	// only feed BLOCK_SYNC_BATCH_SIZE blocks at a time into the enclave to save enclave state regularly
 	for chunk in blocks_to_sync.chunks(BLOCK_SYNC_BATCH_SIZE as usize) {
 		let tee_nonce = api.get_nonce_of(&tee_accountid).unwrap();
@@ -559,19 +602,19 @@ pub fn sync_parentchain<E: EnclaveBase + SideChain>(
 		if let Err(e) = enclave_api.sync_parentchain(chunk, tee_nonce) {
 			error!("{:?}", e);
 			// enclave might not have synced
-			return last_synced_header
+			return synced_header_until
 		};
 
-		last_synced_header =
+		synced_header_until =
 			chunk.last().map(|b| b.block.header.clone()).expect("Chunk can't be empty; qed");
 
 		println!(
 			"Synced {} out of {} finalized parentchain blocks",
-			last_synced_header.number, head_block_number,
+			synced_header_until.number, head_block_number,
 		)
 	}
 
-	last_synced_header
+	synced_header_until
 }
 
 /// Execute trusted operations in the enclave

--- a/service/src/tests/integration_tests.rs
+++ b/service/src/tests/integration_tests.rs
@@ -71,7 +71,7 @@ pub fn call_worker_encrypted_set_balance_works<E: EnclaveBase + SideChain>(
 	println!("Sleeping until block with shield funds is finalized...");
 	sleep(Duration::new(10, 0));
 	println!("Syncing light client to look for shield_funds extrinsic");
-	crate::sync_parentchain_and_execute_tops(enclave_api, &api, last_synced_head)
+	crate::sync_parentchain(enclave_api, &api, last_synced_head)
 }
 
 pub fn forward_encrypted_unshield_works<E: EnclaveBase + SideChain>(
@@ -93,7 +93,7 @@ pub fn forward_encrypted_unshield_works<E: EnclaveBase + SideChain>(
 	println!("Sleeping until block with shield funds is finalized...");
 	sleep(Duration::new(10, 0));
 	println!("Syncing light client to look for CallWorker with TrustedCall::unshield extrinsic");
-	crate::sync_parentchain_and_execute_tops(enclave_api, &api, last_synced_head)
+	crate::sync_parentchain(enclave_api, &api, last_synced_head)
 }
 
 pub fn init_light_client<E: EnclaveBase + SideChain>(port: &str, enclave_api: &E) -> Header {
@@ -122,5 +122,5 @@ pub fn shield_funds_workds<E: EnclaveBase + SideChain>(
 	println!("Sleeping until block with shield funds is finalized...");
 	sleep(Duration::new(10, 0));
 	println!("Syncing light client to look for shield_funds extrinsic");
-	crate::sync_parentchain_and_execute_tops(enclave_api, &api, last_synced_head)
+	crate::sync_parentchain(enclave_api, &api, last_synced_head)
 }


### PR DESCRIPTION
Up until now syncing the parent chain and executing trusted operations was done in the same loop. We now separate the two tasks and run them in separate threads. The parent chain syncing is triggered by subscribing to the new header event in the node API. The TOP execution is kept in the same 300ms time slot loop.

- [x] Merge #438 first and then rebase this branch onto master

Closes #404 