### PR TITLE
Abstract away the handling of (STF) state, introduce read/write locks

### DIFF
--- a/enclave-runtime/src/rpc/author/author_container.rs
+++ b/enclave-runtime/src/rpc/author/author_container.rs
@@ -20,7 +20,7 @@ use crate::{
 		atomic_container::AtomicContainer, Author, AuthorApi, AuthorTopFilter, OnBlockCreated,
 		SendState,
 	},
-	state::StateFacade,
+	state::GlobalFileStateHandler,
 	top_pool::pool_types::BPool,
 };
 use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
@@ -57,7 +57,7 @@ impl GlobalAuthorContainer {
 }
 
 impl GetAuthor for GlobalAuthorContainer {
-	type AuthorType = Author<BPool, AuthorTopFilter, StateFacade, Rsa3072KeyPair>;
+	type AuthorType = Author<BPool, AuthorTopFilter, GlobalFileStateHandler, Rsa3072KeyPair>;
 
 	fn get(&self) -> Option<&'static SgxMutex<Arc<Self::AuthorType>>> {
 		GLOBAL_AUTHOR_CONTAINER.load()

--- a/enclave-runtime/src/rpc/author/author_tests.rs
+++ b/enclave-runtime/src/rpc/author/author_tests.rs
@@ -106,8 +106,8 @@ pub mod tests {
 		let top_pool = Arc::new(TrustedOperationPoolMock::default());
 
 		let shard_id = shard_id();
-		let mut state_facade = HandleStateMock::default();
-		state_facade.init_shard(&shard_id).unwrap();
+		let state_facade = HandleStateMock::default();
+		let _ = state_facade.load_initialized(&shard_id).unwrap();
 
 		let encryption_key = ShieldingCryptoMock::default();
 

--- a/enclave-runtime/src/rpc/author/client_error.rs
+++ b/enclave-runtime/src/rpc/author/client_error.rs
@@ -129,7 +129,7 @@ impl From<Error> for rpc_core::Error {
 			},
 			Error::InvalidShard => rpc_core::Error {
 				code: rpc_core::ErrorCode::ServerError(VERIFICATION_ERROR),
-				message: "Shard does not exisit".into(),
+				message: "Shard does not exist".into(),
 				data: Some(format!("{:?}", e).into()),
 			},
 			Error::Pool(PoolError::InvalidTrustedOperation) => rpc_core::Error {


### PR DESCRIPTION
This is a refactoring step before moving on to separate trusted getter execution from trusted calls (see #400).
All previous calls to the static `state::` functions, are now routed through the `HandleState` trait and its corresponding implementation `GlobalFileStateHandler`.

As a result, in our tests, we can now use the mock for the state handling, which has an internal HashMap and does not require any file access.

- [x] Merge #462 first, then rebase this branch onto master