### PR TITLE
Separate trusted getters execution from trusted calls

### DIFF
--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -37,10 +37,12 @@ extern "C" {
 		latest_header_size: usize,
 	) -> sgx_status_t;
 
-	pub fn execute_trusted_operations(
+	pub fn execute_trusted_getters(
 		eid: sgx_enclave_id_t,
 		retval: *mut sgx_status_t,
 	) -> sgx_status_t;
+
+	pub fn execute_trusted_calls(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
 
 	pub fn sync_parentchain(
 		eid: sgx_enclave_id_t,

--- a/core-primitives/enclave-api/src/side_chain.rs
+++ b/core-primitives/enclave-api/src/side_chain.rs
@@ -32,7 +32,9 @@ pub trait SideChain: Send + Sync + 'static {
 		nonce: u32,
 	) -> EnclaveResult<()>;
 
-	fn execute_trusted_operations(&self) -> EnclaveResult<()>;
+	fn execute_trusted_getters(&self) -> EnclaveResult<()>;
+
+	fn execute_trusted_calls(&self) -> EnclaveResult<()>;
 }
 
 impl SideChain for Enclave {
@@ -60,10 +62,21 @@ impl SideChain for Enclave {
 		Ok(())
 	}
 
-	fn execute_trusted_operations(&self) -> EnclaveResult<()> {
+	fn execute_trusted_getters(&self) -> EnclaveResult<()> {
 		let mut retval = sgx_status_t::SGX_SUCCESS;
 
-		let result = unsafe { ffi::execute_trusted_operations(self.eid, &mut retval) };
+		let result = unsafe { ffi::execute_trusted_getters(self.eid, &mut retval) };
+
+		ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
+		ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
+
+		Ok(())
+	}
+
+	fn execute_trusted_calls(&self) -> EnclaveResult<()> {
+		let mut retval = sgx_status_t::SGX_SUCCESS;
+
+		let result = unsafe { ffi::execute_trusted_calls(self.eid, &mut retval) };
 
 		ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 		ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -82,6 +82,9 @@ pub mod enclave {
 	use core::time::Duration;
 
 	pub static MAX_TRUSTED_OPS_EXEC_DURATION: Duration = Duration::from_millis(600);
+
+	pub static MAX_TRUSTED_GETTERS_EXEC_DURATION: Duration = Duration::from_millis(150);
+	pub static TRUSTED_GETTERS_SLOT_DURATION: Duration = Duration::from_millis(400);
 }
 
 /// Settings concerning the node

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -51,7 +51,9 @@ enclave {
             [out, size=latest_header_size] uint8_t* latest_header, size_t latest_header_size
         );
 
-        public sgx_status_t execute_trusted_operations();
+        public sgx_status_t execute_trusted_getters();
+
+        public sgx_status_t execute_trusted_calls();
 
         public sgx_status_t sync_parentchain(
             [in, size=blocks_size] uint8_t* blocks, size_t blocks_size,

--- a/enclave-runtime/src/sidechain_impl.rs
+++ b/enclave-runtime/src/sidechain_impl.rs
@@ -4,7 +4,7 @@
 //! move most parts here to the sidechain crate.
 
 use crate::{
-	exec_tops, prepare_and_send_xts_and_block,
+	exec_trusted_calls, prepare_and_send_xts_and_block,
 	rpc::author::{AuthorApi, OnBlockCreated, SendState},
 	state::HandleState,
 	Result as EnclaveResult,
@@ -110,7 +110,7 @@ where
 	StateHandler: HandleState + Send + Sync + 'static,
 {
 	fn propose(&self, max_duration: Duration) -> Result<Proposal<SB>, ConsensusError> {
-		let (calls, blocks) = exec_tops::<PB, SB, _, _, _>(
+		let (calls, blocks) = exec_trusted_calls::<PB, SB, _, _, _>(
 			self.ocall_api.as_ref(),
 			self.author.as_ref(),
 			self.state_handler.as_ref(),

--- a/enclave-runtime/src/tests.rs
+++ b/enclave-runtime/src/tests.rs
@@ -267,7 +267,7 @@ fn test_create_block_and_confirmation_works() {
 
 	// when
 	let (confirm_calls, signed_blocks) =
-		crate::exec_tops_for_all_shards::<Block, SignedBlock, _, _, _>(
+		crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
 			&OcallApi,
 			&rpc_author,
 			state_handler.as_ref(),
@@ -315,14 +315,15 @@ fn test_create_state_diff() {
 	submit_and_execute_top(&rpc_author, &direct_top(signed_call), &shielding_key, shard).unwrap();
 
 	// when
-	let (_, signed_blocks) = crate::exec_tops_for_all_shards::<Block, SignedBlock, _, _, _>(
-		&OcallApi,
-		&rpc_author,
-		state_handler.as_ref(),
-		&latest_parentchain_header(),
-		MAX_TRUSTED_OPS_EXEC_DURATION,
-	)
-	.unwrap();
+	let (_, signed_blocks) =
+		crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
+			&OcallApi,
+			&rpc_author,
+			state_handler.as_ref(),
+			&latest_parentchain_header(),
+			MAX_TRUSTED_OPS_EXEC_DURATION,
+		)
+		.unwrap();
 
 	let state_payload = state_payload_from_encrypted(signed_blocks[index].block().state_payload());
 	let state_diff = state_payload.state_update();
@@ -356,7 +357,7 @@ fn test_executing_call_updates_account_nonce() {
 	submit_and_execute_top(&rpc_author, &direct_top(signed_call), &shielding_key, shard).unwrap();
 
 	// when
-	let (_, _) = crate::exec_tops_for_all_shards::<Block, SignedBlock, _, _, _>(
+	let (_, _) = crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
 		&OcallApi,
 		&rpc_author,
 		state_handler.as_ref(),
@@ -385,7 +386,7 @@ fn test_invalid_nonce_call_is_not_executed() {
 	submit_and_execute_top(&rpc_author, &direct_top(signed_call), &shielding_key, shard).unwrap();
 
 	// when
-	let (_, _) = crate::exec_tops_for_all_shards::<Block, SignedBlock, _, _, _>(
+	let (_, _) = crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
 		&OcallApi,
 		&rpc_author,
 		state_handler.as_ref(),
@@ -418,7 +419,7 @@ fn test_non_root_shielding_call_is_not_executed() {
 	submit_and_execute_top(&rpc_author, &direct_top(signed_call), &shielding_key, shard).unwrap();
 
 	// when
-	let (_, _) = crate::exec_tops_for_all_shards::<Block, SignedBlock, _, _, _>(
+	let (_, _) = crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
 		&OcallApi,
 		&rpc_author,
 		state_handler.as_ref(),


### PR DESCRIPTION
Separate the execution of trusted getters from trusted calls, by putting them into a separate task loop that only executes getters.
Getters are scheduled in `400 ms` slots, where `150 ms` is used for execution and `250 ms` for idle time.

- [x] Merge #464 first and then rebase this branch/PR onto master

Closes #400