### PR TITLE
Extract the top pool direct invocation RPC interface to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,6 +2808,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "its-rpc-handler"
+version = "0.8.0"
+dependencies = [
+ "itp-types",
+ "its-primitives",
+ "its-top-pool-rpc-author",
+ "jsonrpc-core 16.0.0",
+ "jsonrpc-core 16.1.0",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec",
+ "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
+ "sgx_tstd",
+ "sgx_types",
+ "sp-core",
+]
+
+[[package]]
 name = "its-sidechain"
 version = "0.8.0"
 dependencies = [
@@ -2815,6 +2833,7 @@ dependencies = [
  "its-consensus-common",
  "its-consensus-slots",
  "its-primitives",
+ "its-rpc-handler",
  "its-state",
  "its-top-pool",
  "its-top-pool-rpc-author",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "sidechain/consensus/aura",
     "sidechain/consensus/common",
     "sidechain/consensus/slots",
+    "sidechain/rpc-handler",
     "sidechain/state",
     "sidechain/top-pool",
     "sidechain/top-pool-rpc-author",

--- a/core-primitives/types/src/rpc.rs
+++ b/core-primitives/types/src/rpc.rs
@@ -21,6 +21,14 @@ impl RpcReturnValue {
 			//signature: sign,
 		}
 	}
+
+	pub fn from_error_message(error_msg: &str) -> Self {
+		RpcReturnValue {
+			value: error_msg.encode(),
+			do_watch: false,
+			status: DirectRequestStatus::Error,
+		}
+	}
 }
 
 #[derive(Clone, Encode, Decode, Serialize, Deserialize)]

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1423,6 +1423,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "its-rpc-handler"
+version = "0.8.0"
+dependencies = [
+ "itp-types",
+ "its-primitives",
+ "its-top-pool-rpc-author",
+ "jsonrpc-core",
+ "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "parity-scale-codec",
+ "rust-base58",
+ "sgx_tstd",
+ "sgx_types",
+ "sp-core",
+]
+
+[[package]]
 name = "its-sidechain"
 version = "0.8.0"
 dependencies = [
@@ -1430,6 +1446,7 @@ dependencies = [
  "its-consensus-common",
  "its-consensus-slots",
  "its-primitives",
+ "its-rpc-handler",
  "its-state",
  "its-top-pool",
  "its-top-pool-rpc-author",

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -52,7 +52,7 @@ use ita_stf::{
 };
 use itc_direct_rpc_server::{
 	create_determine_watch, rpc_connection_registry::ConnectionRegistry,
-	rpc_responder::RpcResponder, rpc_ws_handler::RpcWsHandler,
+	rpc_ws_handler::RpcWsHandler,
 };
 use itc_light_client::{
 	io::LightClientSeal, BlockNumberOps, HashFor, LightClientState, NumberFor, Validator,
@@ -84,13 +84,9 @@ use its_sidechain::{
 	},
 	slots::{duration_now, sgx::LastSlotSeal, yield_next_slot},
 	state::{LastBlockExt, SidechainDB, SidechainState, SidechainSystemExt},
-	top_pool::pool::Options as PoolOptions,
 	top_pool_rpc_author::{
-		api::SideChainApi,
-		author::{Author, AuthorTopFilter},
 		global_author_container::GlobalAuthorContainer,
 		hash::TrustedOperationOrHash,
-		pool_types::BPool,
 		traits::{AuthorApi, GetAuthor, OnBlockCreated, SendState},
 	},
 };
@@ -107,7 +103,6 @@ use sp_runtime::{
 };
 use std::{
 	collections::HashMap,
-	ops::Deref,
 	slice,
 	string::ToString,
 	sync::{Arc, SgxRwLock},
@@ -377,7 +372,7 @@ where
 	// 	import_sidechain_blocks::<PB, _, _, _>(signed_blocks, &header, importer.clone(), &ocall_api)
 	// });
 
-	let io = side_chain_io_handler(move |signed_blocks| {
+	let io = side_chain_io_handler::<_, crate::error::Error>(move |signed_blocks| {
 		log::info!("[sidechain] Imported blocks: {:?}", signed_blocks);
 		Ok(())
 	});
@@ -448,11 +443,6 @@ pub unsafe extern "C" fn init_direct_invocation_server(
 
 	let watch_extractor = Arc::new(create_determine_watch::<Hash>());
 	let connection_registry = Arc::new(ConnectionRegistry::<Hash, TungsteniteWsConnection>::new());
-	let rpc_responder = Arc::new(RpcResponder::new(connection_registry.clone()));
-
-	let side_chain_api = Arc::new(SideChainApi::<itp_types::Block>::new());
-	let top_pool = Arc::new(BPool::create(PoolOptions::default(), side_chain_api, rpc_responder));
-	let state_facade = Arc::new(GlobalFileStateHandler);
 
 	let rsa_shielding_key = match Rsa3072Seal::unseal() {
 		Ok(k) => k,
@@ -462,10 +452,18 @@ pub unsafe extern "C" fn init_direct_invocation_server(
 		},
 	};
 
-	let rpc_author =
-		Arc::new(Author::new(top_pool, AuthorTopFilter {}, state_facade, rsa_shielding_key));
+	its_sidechain::top_pool_rpc_author::initializer::initialize_top_pool_rpc_author(
+		connection_registry.clone(),
+		rsa_shielding_key,
+	);
 
-	GlobalAuthorContainer::initialize(rpc_author.clone());
+	let rpc_author = match GlobalAuthorContainer.get() {
+		Some(a) => a,
+		None => {
+			error!("Failed to retrieve global top pool author");
+			return sgx_status_t::SGX_ERROR_UNEXPECTED
+		},
+	};
 
 	let io_handler = public_api_rpc_handler(rpc_author);
 	let rpc_handler = Arc::new(RpcWsHandler::new(io_handler, watch_extractor, connection_registry));
@@ -526,7 +524,7 @@ pub unsafe extern "C" fn init_light_client(
 
 #[no_mangle]
 pub unsafe extern "C" fn execute_trusted_getters() -> sgx_status_t {
-	if let Err(e) = execute_trusted_getters_on_all_shards() {
+	if let Err(e) = execute_top_pool_trusted_getters_on_all_shards() {
 		return e.into()
 	}
 
@@ -536,15 +534,13 @@ pub unsafe extern "C" fn execute_trusted_getters() -> sgx_status_t {
 /// Internal [`execute_trusted_getters`] function to be able to use the `?` operator.
 ///
 /// Executes trusted getters for a scheduled amount of time (defined by settings).
-fn execute_trusted_getters_on_all_shards() -> Result<()> {
+fn execute_top_pool_trusted_getters_on_all_shards() -> Result<()> {
 	use itp_settings::enclave::MAX_TRUSTED_GETTERS_EXEC_DURATION;
 
-	let author_mutex = GlobalAuthorContainer.get().ok_or_else(|| {
+	let rpc_author = GlobalAuthorContainer.get().ok_or_else(|| {
 		error!("Failed to retrieve author mutex. It might not be initialized?");
 		Error::MutexAccess
 	})?;
-
-	let rpc_author = author_mutex.lock().unwrap().deref().clone();
 
 	let state_handler = GlobalFileStateHandler;
 
@@ -566,7 +562,7 @@ fn execute_trusted_getters_on_all_shards() -> Result<()> {
 			},
 		};
 
-		match execute_trusted_getters_on_shard(
+		match execute_top_pool_trusted_getters_on_shard(
 			rpc_author.as_ref(),
 			&state_handler,
 			shard,
@@ -584,7 +580,7 @@ fn execute_trusted_getters_on_all_shards() -> Result<()> {
 
 #[no_mangle]
 pub unsafe extern "C" fn execute_trusted_calls() -> sgx_status_t {
-	if let Err(e) = execute_trusted_calls_internal::<Block>() {
+	if let Err(e) = execute_top_pool_trusted_calls_internal::<Block>() {
 		return e.into()
 	}
 
@@ -599,7 +595,7 @@ pub unsafe extern "C" fn execute_trusted_calls() -> sgx_status_t {
 ///
 /// *   sends sidechain `confirm_block` xt's with the produced sidechain blocks
 /// *   gossip produced sidechain blocks to peer validateers.
-fn execute_trusted_calls_internal<PB>() -> Result<()>
+fn execute_top_pool_trusted_calls_internal<PB>() -> Result<()>
 where
 	PB: BlockT<Hash = H256>,
 	NumberFor<PB>: BlockNumberOps,
@@ -613,12 +609,11 @@ where
 
 	let authority = Ed25519Seal::unseal()?;
 
-	let author_mutex = GlobalAuthorContainer.get().ok_or_else(|| {
-		error!("Failed to retrieve author mutex. It might not be initialized?");
+	let rpc_author = GlobalAuthorContainer.get().ok_or_else(|| {
+		error!("Failed to retrieve author mutex. Maybe it's not initialized?");
 		Error::MutexAccess
 	})?;
 
-	let rpc_author = author_mutex.lock().unwrap().deref().clone();
 	let state_handler = Arc::new(GlobalFileStateHandler);
 
 	let latest_onchain_header = validator.latest_finalized_header(validator.num_relays()).unwrap();
@@ -807,7 +802,7 @@ where
 ///
 /// Todo: This will probably be used again if we decide to make sidechain optional?
 #[allow(unused)]
-fn exec_trusted_calls_for_all_shards<PB, SB, OCallApi, RpcAuthor, StateHandler>(
+fn execute_top_pool_trusted_calls_for_all_shards<PB, SB, OCallApi, RpcAuthor, StateHandler>(
 	ocall_api: &OCallApi,
 	rpc_author: &RpcAuthor,
 	state_handler: &StateHandler,
@@ -842,7 +837,7 @@ where
 			},
 		};
 
-		match exec_trusted_calls::<PB, SB, _, _, _>(
+		match execute_top_pool_trusted_calls::<PB, SB, _, _, _>(
 			ocall_api,
 			rpc_author,
 			state_handler,
@@ -873,7 +868,7 @@ where
 ///
 /// Todo: This function does too much, but it needs anyhow some refactoring here to make the code
 /// more readable.
-fn exec_trusted_calls<PB, SB, OCallApi, RpcAuthor, StateHandler>(
+fn execute_top_pool_trusted_calls<PB, SB, OCallApi, RpcAuthor, StateHandler>(
 	on_chain_ocall: &OCallApi,
 	rpc_author: &RpcAuthor,
 	state_handler: &StateHandler,
@@ -994,7 +989,7 @@ where
 }
 
 /// Execute pending trusted getters for the `shard` until `max_exec_duration` is reached.
-fn execute_trusted_getters_on_shard<RpcAuthor, StateHandler>(
+fn execute_top_pool_trusted_getters_on_shard<RpcAuthor, StateHandler>(
 	rpc_author: &RpcAuthor,
 	state_handler: &StateHandler,
 	shard: H256,
@@ -1072,7 +1067,7 @@ fn get_stf_state(
 }
 
 /// Composes a sidechain block of a shard
-pub fn compose_block_and_confirmation<PB, SB, SidechainDB>(
+fn compose_block_and_confirmation<PB, SB, SidechainDB>(
 	latest_onchain_header: &PB::Header,
 	top_call_hashes: Vec<H256>,
 	shard: ShardIdentifier,
@@ -1130,7 +1125,7 @@ where
 	Ok((opaque_call, block.sign_block(&signer_pair)))
 }
 
-pub fn update_states<PB, O, StateHandler>(
+fn update_states<PB, O, StateHandler>(
 	header: PB::Header,
 	on_chain_ocall_api: &O,
 	state_handler: &StateHandler,
@@ -1192,7 +1187,7 @@ where
 /// Scans blocks for extrinsics that ask the enclave to execute some actions.
 /// Executes indirect invocation calls, as well as shielding and unshielding calls
 /// Returns all unshielding call confirmations as opaque calls
-pub fn scan_block_for_relevant_xt<PB, O, StateHandler>(
+fn scan_block_for_relevant_xt<PB, O, StateHandler>(
 	block: &PB,
 	on_chain_ocall: &O,
 	state_handler: &StateHandler,
@@ -1363,7 +1358,7 @@ where
 	Ok(Some((H256::from(call_hash), H256::from(operation_hash))))
 }
 
-pub fn into_map(
+fn into_map(
 	storage_entries: Vec<StorageEntryVerified<Vec<u8>>>,
 ) -> HashMap<Vec<u8>, Option<Vec<u8>>> {
 	storage_entries.into_iter().map(|e| e.into_tuple()).collect()

--- a/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -15,19 +15,17 @@
 
 */
 
-use base58::FromBase58;
-use codec::{Decode, Encode};
+use codec::Encode;
 use core::result::Result;
-use ita_stf::ShardIdentifier;
 use itp_sgx_crypto::Rsa3072Seal;
-use itp_types::{DirectRequestStatus, Request, RpcReturnValue, TrustedOperationStatus, H256};
-use its_sidechain::{primitives::types::SignedBlock, top_pool_rpc_author::traits::AuthorApi};
-use jsonrpc_core::{
-	futures::executor, serde_json::json, Error as RpcError, IoHandler, Params, Value,
+use itp_types::{DirectRequestStatus, RpcReturnValue, H256};
+use its_sidechain::{
+	primitives::types::SignedBlock,
+	rpc_handler::{direct_top_pool_api, import_block_api},
+	top_pool_rpc_author::traits::AuthorApi,
 };
-use log::*;
+use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
 use sgx_types::sgx_status_t;
-use sp_core::H256 as Hash;
 use std::{borrow::ToOwned, format, str, string::String, sync::Arc, vec::Vec};
 
 // TODO: remove this e-call - includes EDL file and e-call bridge on untrusted worker side
@@ -40,162 +38,37 @@ pub unsafe extern "C" fn initialize_pool() -> sgx_status_t {
 	sgx_status_t::SGX_SUCCESS
 }
 
-// converts the rpc methods vector to a string and adds commas and brackets for readability
-fn convert_vec_to_string(vec_methods: Vec<&str>) -> String {
-	let mut method_string = String::new();
-	for i in 0..vec_methods.len() {
-		method_string.push_str(vec_methods[i]);
-		if vec_methods.len() > (i + 1) {
-			method_string.push_str(", ");
-		}
-	}
+fn compute_encoded_return_error(error_msg: &str) -> Vec<u8> {
+	RpcReturnValue::from_error_message(error_msg).encode()
+}
+
+fn get_all_rpc_methods_string(io_handler: &IoHandler) -> String {
+	let method_string = io_handler
+		.iter()
+		.map(|rp_tuple| rp_tuple.0.to_owned())
+		.collect::<Vec<String>>()
+		.join(", ");
+
 	format!("methods: [{}]", method_string)
-}
-
-// converts the rpc methods vector to a string and adds commas and brackets for readability
-fn decode_shard_from_base58(shard_base58: String) -> Result<ShardIdentifier, String> {
-	let shard_vec = match shard_base58.from_base58() {
-		Ok(vec) => vec,
-		Err(_) => return Err("Invalid base58 format of shard id".to_owned()),
-	};
-	let shard = match ShardIdentifier::decode(&mut shard_vec.as_slice()) {
-		Ok(hash) => hash,
-		Err(_) => return Err("Shard ID is not of type H256".to_owned()),
-	};
-	Ok(shard)
-}
-
-fn compute_encoded_return_error(error_msg: String) -> Vec<u8> {
-	let return_value = RpcReturnValue {
-		value: error_msg.encode(),
-		do_watch: false,
-		status: DirectRequestStatus::Error,
-	};
-	return_value.encode()
 }
 
 pub fn public_api_rpc_handler<R>(rpc_author: Arc<R>) -> IoHandler
 where
 	R: AuthorApi<H256, H256> + Send + Sync + 'static,
 {
-	let mut io = IoHandler::new();
-	let mut rpc_methods_vec: Vec<&str> = Vec::new();
+	let io = IoHandler::new();
 
-	// Add rpc methods
-	// author_submitAndWatchExtrinsic
-	let author_submit_and_watch_extrinsic_name: &str = "author_submitAndWatchExtrinsic";
-	let submit_watch_author = rpc_author.clone();
-	rpc_methods_vec.push(author_submit_and_watch_extrinsic_name);
-	io.add_sync_method(author_submit_and_watch_extrinsic_name, move |params: Params| match params
-		.parse::<Vec<u8>>()
-	{
-		Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
-			Ok(request) => {
-				let shard: ShardIdentifier = request.shard;
-				let encrypted_trusted_call: Vec<u8> = request.cyphertext;
-				let result = async {
-					submit_watch_author.watch_top(encrypted_trusted_call.clone(), shard).await
-				};
-				let response: Result<Hash, RpcError> = executor::block_on(result);
-				let json_value = match response {
-					Ok(hash_value) => RpcReturnValue {
-						do_watch: true,
-						value: hash_value.encode(),
-						status: DirectRequestStatus::TrustedOperationStatus(
-							TrustedOperationStatus::Submitted,
-						),
-					}
-					.encode(),
-					Err(rpc_error) => compute_encoded_return_error(rpc_error.message),
-				};
-				Ok(json!(json_value))
-			},
-			Err(_) =>
-				Ok(json!(compute_encoded_return_error("Could not decode request".to_owned()))),
-		},
-		Err(e) => {
-			let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-			Ok(json!(compute_encoded_return_error(error_msg)))
-		},
-	});
-
-	// author_submitExtrinsic
-	let author_submit_extrinsic_name: &str = "author_submitExtrinsic";
-	let submit_author = rpc_author.clone();
-	rpc_methods_vec.push(author_submit_extrinsic_name);
-	io.add_sync_method(author_submit_extrinsic_name, move |params: Params| {
-		match params.parse::<Vec<u8>>() {
-			Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
-				Ok(request) => {
-					let shard: ShardIdentifier = request.shard;
-					let encrypted_trusted_op: Vec<u8> = request.cyphertext;
-					let result = async {
-						submit_author.submit_top(encrypted_trusted_op.clone(), shard).await
-					};
-					let response: Result<Hash, RpcError> = executor::block_on(result);
-					let json_value = match response {
-						Ok(hash_value) => RpcReturnValue {
-							do_watch: false,
-							value: hash_value.encode(),
-							status: DirectRequestStatus::TrustedOperationStatus(
-								TrustedOperationStatus::Submitted,
-							),
-						}
-						.encode(),
-						Err(rpc_error) => compute_encoded_return_error(rpc_error.message),
-					};
-					Ok(json!(json_value))
-				},
-				Err(_) =>
-					Ok(json!(compute_encoded_return_error("Could not decode request".to_owned()))),
-			},
-			Err(e) => {
-				let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-				Ok(json!(compute_encoded_return_error(error_msg)))
-			},
-		}
-	});
-
-	// author_pendingExtrinsics
-	let author_pending_extrinsic_name: &str = "author_pendingExtrinsics";
-	let pending_author = rpc_author;
-	rpc_methods_vec.push(author_pending_extrinsic_name);
-	io.add_sync_method(author_pending_extrinsic_name, move |params: Params| {
-		match params.parse::<Vec<String>>() {
-			Ok(shards) => {
-				let mut retrieved_operations = vec![];
-				for shard_base58 in shards.iter() {
-					let shard = match decode_shard_from_base58(shard_base58.clone()) {
-						Ok(id) => id,
-						Err(msg) => return Ok(Value::String(msg)),
-					};
-					if let Ok(vec_of_operations) = pending_author.pending_tops(shard) {
-						retrieved_operations.push(vec_of_operations);
-					}
-				}
-				let json_value = RpcReturnValue {
-					do_watch: false,
-					value: retrieved_operations.encode(),
-					status: DirectRequestStatus::Ok,
-				};
-				Ok(json!(json_value.encode()))
-			},
-			Err(e) => {
-				let error_msg: String = format!("Could not retrieve pending calls due to: {}", e);
-				Ok(json!(compute_encoded_return_error(error_msg)))
-			},
-		}
-	});
+	// Add direct TOP pool rpc methods
+	let mut io = direct_top_pool_api::add_top_pool_direct_rpc_methods(rpc_author, io);
 
 	// author_getShieldingKey
 	let rsa_pubkey_name: &str = "author_getShieldingKey";
-	rpc_methods_vec.push(rsa_pubkey_name);
 	io.add_sync_method(rsa_pubkey_name, move |_: Params| {
 		let rsa_pubkey = match Rsa3072Seal::unseal_pubkey() {
 			Ok(key) => key,
 			Err(status) => {
 				let error_msg: String = format!("Could not get rsa pubkey due to: {}", status);
-				return Ok(json!(compute_encoded_return_error(error_msg)))
+				return Ok(json!(compute_encoded_return_error(error_msg.as_str())))
 			},
 		};
 
@@ -204,7 +77,7 @@ where
 			Err(x) => {
 				let error_msg: String =
 					format!("[Enclave] can't serialize rsa_pubkey {:?} {}", rsa_pubkey, x);
-				return Ok(json!(compute_encoded_return_error(error_msg)))
+				return Ok(json!(compute_encoded_return_error(error_msg.as_str())))
 			},
 		};
 		let json_value =
@@ -214,7 +87,6 @@ where
 
 	// chain_subscribeAllHeads
 	let chain_subscribe_all_heads_name: &str = "chain_subscribeAllHeads";
-	rpc_methods_vec.push(chain_subscribe_all_heads_name);
 	io.add_sync_method(chain_subscribe_all_heads_name, |_: Params| {
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
@@ -222,7 +94,6 @@ where
 
 	// state_getMetadata
 	let state_get_metadata_name: &str = "state_getMetadata";
-	rpc_methods_vec.push(state_get_metadata_name);
 	io.add_sync_method(state_get_metadata_name, |_: Params| {
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
@@ -230,7 +101,6 @@ where
 
 	// state_getRuntimeVersion
 	let state_get_runtime_version_name: &str = "state_getRuntimeVersion";
-	rpc_methods_vec.push(state_get_runtime_version_name);
 	io.add_sync_method(state_get_runtime_version_name, |_: Params| {
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
@@ -238,7 +108,6 @@ where
 
 	// state_get
 	let state_get_name: &str = "state_get";
-	rpc_methods_vec.push(state_get_name);
 	io.add_sync_method(state_get_name, |_: Params| {
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
@@ -246,7 +115,6 @@ where
 
 	// system_health
 	let state_health_name: &str = "system_health";
-	rpc_methods_vec.push(state_health_name);
 	io.add_sync_method(state_health_name, |_: Params| {
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
@@ -254,7 +122,6 @@ where
 
 	// system_name
 	let state_name_name: &str = "system_name";
-	rpc_methods_vec.push(state_name_name);
 	io.add_sync_method(state_name_name, |_: Params| {
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
@@ -262,14 +129,13 @@ where
 
 	// system_version
 	let state_version_name: &str = "system_version";
-	rpc_methods_vec.push(state_version_name);
 	io.add_sync_method(state_version_name, |_: Params| {
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
 	});
 
 	// returns all rpcs methods
-	let rpc_methods_string: String = convert_vec_to_string(rpc_methods_vec);
+	let rpc_methods_string = get_all_rpc_methods_string(&io);
 	io.add_sync_method("rpc_methods", move |_: Params| {
 		Ok(Value::String(rpc_methods_string.to_owned()))
 	});
@@ -277,77 +143,32 @@ where
 	io
 }
 
-pub fn side_chain_io_handler<ImportFn>(import_fn: ImportFn) -> IoHandler
+pub fn side_chain_io_handler<ImportFn, Error>(import_fn: ImportFn) -> IoHandler
 where
-	ImportFn: Fn(Vec<SignedBlock>) -> Result<(), crate::error::Error> + Sync + Send + 'static,
+	ImportFn: Fn(Vec<SignedBlock>) -> Result<(), Error> + Sync + Send + 'static,
+	Error: std::fmt::Debug,
 {
-	let mut io = IoHandler::new();
-
-	let sidechain_import_import_name: &str = "sidechain_importBlock";
-	io.add_sync_method(sidechain_import_import_name, move |sidechain_blocks: Params| {
-		debug!("sidechain_importBlock rpc. Params: {:?}", sidechain_blocks);
-
-		let block_vec: Vec<u8> = sidechain_blocks.parse()?;
-
-		let blocks: Vec<SignedBlock> = Decode::decode(&mut block_vec.as_slice()).map_err(|_| {
-			jsonrpc_core::error::Error::invalid_params_with_details(
-				"Could not decode Vec<SignedBlock>",
-				block_vec,
-			)
-		})?;
-
-		info!("sidechain_importBlock. Blocks: {:?}", blocks);
-
-		let _ = import_fn(blocks).map_err(|e| {
-			jsonrpc_core::error::Error::invalid_params_with_details("Failed to import Block.", e)
-		})?;
-
-		Ok(Value::String("ok".to_owned()))
-	});
-
-	io
+	let io = IoHandler::new();
+	import_block_api::add_import_block_rpc_method(import_fn, io)
 }
 
+#[cfg(feature = "test")]
 pub mod tests {
-	use super::side_chain_io_handler;
-	use jsonrpc_core::IoHandler;
-	use std::string::{String, ToString};
+	use super::*;
+	use std::string::ToString;
 
-	fn rpc_response<T: ToString>(result: T) -> String {
-		format!(r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#, result.to_string())
-	}
+	pub fn test_given_io_handler_methods_then_retrieve_all_names_as_string() {
+		let mut io = IoHandler::new();
+		let method_names: [&str; 4] = ["method1", "another_method", "fancy_thing", "solve_all"];
 
-	fn io_handler() -> IoHandler {
-		side_chain_io_handler(|_| Ok(()))
-	}
+		for method_name in method_names.iter() {
+			io.add_sync_method(method_name, |_: Params| Ok(Value::String("".to_string())));
+		}
 
-	pub fn sidechain_import_block_is_ok() {
-		let io = io_handler();
-		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":[4,0,0,0,0,0,0,0,0,228,0,145,188,97,251,138,131,108,29,6,107,10,152,67,29,148,190,114,167,223,169,197,163,93,228,76,169,171,80,15,209,101,11,211,96,0,0,0,0,83,52,167,255,37,229,185,231,38,66,122,3,55,139,5,190,125,85,94,177,190,99,22,149,92,97,154,30,142,89,24,144,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,136,220,52,23,213,5,142,196,180,80,62,12,18,234,26,10,137,190,32,15,233,137,34,66,61,67,52,1,79,166,176,238,0,0,0,175,124,84,84,32,238,162,224,130,203,26,66,7,121,44,59,196,200,100,31,173,226,165,106,187,135,223,149,30,46,191,95,116,203,205,102,100,85,82,74,158,197,166,218,181,130,119,127,162,134,227,129,118,85,123,76,21,113,90,1,160,77,110,15],"id":1}"#;
+		let method_string = get_all_rpc_methods_string(&io);
 
-		let response_string = io.handle_request_sync(enclave_req).unwrap();
-
-		assert_eq!(response_string, rpc_response("\"ok\""));
-	}
-
-	pub fn sidechain_import_block_returns_invalid_param_err() {
-		let io = io_handler();
-		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":["SophisticatedInvalidParam"],"id":1}"#;
-
-		let response_string = io.handle_request_sync(enclave_req).unwrap();
-
-		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: invalid type: string \"SophisticatedInvalidParam\", expected u8."},"id":1}"#;
-		assert_eq!(response_string, err_msg);
-	}
-
-	pub fn sidechain_import_block_returns_decode_err() {
-		let io = io_handler();
-		let enclave_req =
-			r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":[2],"id":1}"#;
-
-		let response_string = io.handle_request_sync(enclave_req).unwrap();
-
-		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: Could not decode Vec<SignedBlock>","data":"[2]"},"id":1}"#;
-		assert_eq!(response_string, err_msg);
+		for method_name in method_names.iter() {
+			assert!(method_string.contains(method_name));
+		}
 	}
 }

--- a/enclave-runtime/src/sidechain_impl.rs
+++ b/enclave-runtime/src/sidechain_impl.rs
@@ -3,7 +3,9 @@
 //! Todo: Once we have put the `top_pool` stuff in an entirely different crate we can
 //! move most parts here to the sidechain crate.
 
-use crate::{exec_trusted_calls, prepare_and_send_xts_and_block, Result as EnclaveResult};
+use crate::{
+	execute_top_pool_trusted_calls, prepare_and_send_xts_and_block, Result as EnclaveResult,
+};
 use codec::Encode;
 use core::time::Duration;
 use itc_light_client::{BlockNumberOps, LightClientState, NumberFor, Validator};
@@ -106,7 +108,7 @@ where
 	StateHandler: HandleState + Send + Sync + 'static,
 {
 	fn propose(&self, max_duration: Duration) -> Result<Proposal<SB>, ConsensusError> {
-		let (calls, blocks) = exec_trusted_calls::<PB, SB, _, _, _>(
+		let (calls, blocks) = execute_top_pool_trusted_calls::<PB, SB, _, _, _>(
 			self.ocall_api.as_ref(),
 			self.author.as_ref(),
 			self.state_handler.as_ref(),

--- a/enclave-runtime/src/tests.rs
+++ b/enclave-runtime/src/tests.rs
@@ -92,9 +92,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		// its_sidechain::state::tests::apply_state_update_returns_invalid_storage_diff_err,
 		its_sidechain::state::tests::sp_io_storage_set_creates_storage_diff,
 		its_sidechain::state::tests::create_state_diff_without_setting_externalities_works,
-		rpc::worker_api_direct::tests::sidechain_import_block_is_ok,
-		rpc::worker_api_direct::tests::sidechain_import_block_returns_invalid_param_err,
-		rpc::worker_api_direct::tests::sidechain_import_block_returns_decode_err,
+		rpc::worker_api_direct::tests::test_given_io_handler_methods_then_retrieve_all_names_as_string,
 		author_tests::top_encryption_works,
 		author_tests::submitting_to_author_inserts_in_pool,
 		author_tests::submitting_call_to_author_when_top_is_filtered_returns_error,
@@ -232,7 +230,7 @@ fn test_create_block_and_confirmation_works() {
 
 	// when
 	let (confirm_calls, signed_blocks) =
-		crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
+		crate::execute_top_pool_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
 			&OcallApi,
 			&rpc_author,
 			state_handler.as_ref(),
@@ -281,7 +279,7 @@ fn test_create_state_diff() {
 
 	// when
 	let (_, signed_blocks) =
-		crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
+		crate::execute_top_pool_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
 			&OcallApi,
 			&rpc_author,
 			state_handler.as_ref(),
@@ -322,14 +320,15 @@ fn test_executing_call_updates_account_nonce() {
 	submit_and_execute_top(&rpc_author, &direct_top(signed_call), &shielding_key, shard).unwrap();
 
 	// when
-	let (_, _) = crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
-		&OcallApi,
-		&rpc_author,
-		state_handler.as_ref(),
-		&latest_parentchain_header(),
-		MAX_TRUSTED_OPS_EXEC_DURATION,
-	)
-	.unwrap();
+	let (_, _) =
+		crate::execute_top_pool_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
+			&OcallApi,
+			&rpc_author,
+			state_handler.as_ref(),
+			&latest_parentchain_header(),
+			MAX_TRUSTED_OPS_EXEC_DURATION,
+		)
+		.unwrap();
 
 	// then
 	let mut state = state_handler.load_initialized(&shard).unwrap();
@@ -351,14 +350,15 @@ fn test_invalid_nonce_call_is_not_executed() {
 	submit_and_execute_top(&rpc_author, &direct_top(signed_call), &shielding_key, shard).unwrap();
 
 	// when
-	let (_, _) = crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
-		&OcallApi,
-		&rpc_author,
-		state_handler.as_ref(),
-		&latest_parentchain_header(),
-		MAX_TRUSTED_OPS_EXEC_DURATION,
-	)
-	.unwrap();
+	let (_, _) =
+		crate::execute_top_pool_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
+			&OcallApi,
+			&rpc_author,
+			state_handler.as_ref(),
+			&latest_parentchain_header(),
+			MAX_TRUSTED_OPS_EXEC_DURATION,
+		)
+		.unwrap();
 
 	// then
 	let mut updated_state = state_handler.load_initialized(&shard).unwrap();
@@ -384,14 +384,15 @@ fn test_non_root_shielding_call_is_not_executed() {
 	submit_and_execute_top(&rpc_author, &direct_top(signed_call), &shielding_key, shard).unwrap();
 
 	// when
-	let (_, _) = crate::exec_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
-		&OcallApi,
-		&rpc_author,
-		state_handler.as_ref(),
-		&latest_parentchain_header(),
-		MAX_TRUSTED_OPS_EXEC_DURATION,
-	)
-	.unwrap();
+	let (_, _) =
+		crate::execute_top_pool_trusted_calls_for_all_shards::<Block, SignedBlock, _, _, _>(
+			&OcallApi,
+			&rpc_author,
+			state_handler.as_ref(),
+			&latest_parentchain_header(),
+			MAX_TRUSTED_OPS_EXEC_DURATION,
+		)
+		.unwrap();
 
 	// then
 	let mut updated_state = state_handler.load_initialized(&shard).unwrap();

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "its-rpc-handler"
+version = "0.8.0"
+authors = ["Integritee AG <hello@integritee.network>"]
+edition = "2018"
+resolver = "2"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["std"]
+std = [
+    "itp-types/std",
+    "its-primitives/std",
+    "its-top-pool-rpc-author/std",
+    "jsonrpc-core",
+    "log/std",
+    "rust-base58",
+]
+sgx = [
+    "sgx_tstd",
+    "itp-types/sgx",
+    "its-top-pool-rpc-author/sgx",
+    "jsonrpc-core_sgx",
+    "rust-base58_sgx",
+]
+
+[dependencies]
+# sgx dependencies
+sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+
+# local dependencies
+itp-types = { path = "../../core-primitives/types", default-features = false }
+its-primitives = { path = "../primitives", default-features = false }
+its-top-pool-rpc-author = { path = "../top-pool-rpc-author", default-features = false }
+
+# sgx enabled external libraries
+rust-base58_sgx = { package = "rust-base58", rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/rust-base58-sgx", optional = true, default-features = false, features = ["mesalock_sgx"] }
+jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
+
+# std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
+rust-base58 = { package = "rust-base58", version = "0.0.4", optional = true }
+jsonrpc-core = { version = "16", optional = true }
+
+# no-std compatible libraries
+codec  = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+log = { version = "0.4", default-features = false }
+sp-core = { version = "4.0.0-dev", default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -1,0 +1,164 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+#[cfg(feature = "std")]
+use rust_base58::base58::FromBase58;
+
+#[cfg(feature = "sgx")]
+use base58::FromBase58;
+
+use codec::{Decode, Encode};
+use itp_types::{
+	DirectRequestStatus, Request, RpcReturnValue, ShardIdentifier, TrustedOperationStatus,
+};
+use its_top_pool_rpc_author::traits::AuthorApi;
+use jsonrpc_core::{
+	futures::executor, serde_json::json, Error as RpcError, IoHandler, Params, Value,
+};
+use std::{borrow::ToOwned, format, string::String, sync::Arc, vec, vec::Vec};
+
+type Hash = sp_core::H256;
+
+pub fn add_top_pool_direct_rpc_methods<R>(
+	rpc_author: Arc<R>,
+	mut io_handler: IoHandler,
+) -> IoHandler
+where
+	R: AuthorApi<Hash, Hash> + Send + Sync + 'static,
+{
+	// author_submitAndWatchExtrinsic
+	let author_submit_and_watch_extrinsic_name: &str = "author_submitAndWatchExtrinsic";
+	let submit_watch_author = rpc_author.clone();
+	io_handler.add_sync_method(author_submit_and_watch_extrinsic_name, move |params: Params| {
+		match params.parse::<Vec<u8>>() {
+			Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
+				Ok(request) => {
+					let shard: ShardIdentifier = request.shard;
+					let encrypted_trusted_call: Vec<u8> = request.cyphertext;
+					let result = async {
+						submit_watch_author.watch_top(encrypted_trusted_call.clone(), shard).await
+					};
+					let response: Result<Hash, RpcError> = executor::block_on(result);
+					let json_value = match response {
+						Ok(hash_value) => RpcReturnValue {
+							do_watch: true,
+							value: hash_value.encode(),
+							status: DirectRequestStatus::TrustedOperationStatus(
+								TrustedOperationStatus::Submitted,
+							),
+						}
+						.encode(),
+						Err(rpc_error) => compute_encoded_return_error(rpc_error.message.as_str()),
+					};
+					Ok(json!(json_value))
+				},
+				Err(_) => Ok(json!(compute_encoded_return_error("Could not decode request"))),
+			},
+			Err(e) => {
+				let error_msg: String = format!("Could not submit trusted call due to: {}", e);
+				Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+			},
+		}
+	});
+
+	// author_submitExtrinsic
+	let author_submit_extrinsic_name: &str = "author_submitExtrinsic";
+	let submit_author = rpc_author.clone();
+	io_handler.add_sync_method(author_submit_extrinsic_name, move |params: Params| {
+		match params.parse::<Vec<u8>>() {
+			Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
+				Ok(request) => {
+					let shard: ShardIdentifier = request.shard;
+					let encrypted_trusted_op: Vec<u8> = request.cyphertext;
+					let result = async {
+						submit_author.submit_top(encrypted_trusted_op.clone(), shard).await
+					};
+					let response: Result<Hash, RpcError> = executor::block_on(result);
+					let json_value = match response {
+						Ok(hash_value) => RpcReturnValue {
+							do_watch: false,
+							value: hash_value.encode(),
+							status: DirectRequestStatus::TrustedOperationStatus(
+								TrustedOperationStatus::Submitted,
+							),
+						}
+						.encode(),
+						Err(rpc_error) => compute_encoded_return_error(rpc_error.message.as_str()),
+					};
+					Ok(json!(json_value))
+				},
+				Err(_) => Ok(json!(compute_encoded_return_error("Could not decode request"))),
+			},
+			Err(e) => {
+				let error_msg: String = format!("Could not submit trusted call due to: {}", e);
+				Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+			},
+		}
+	});
+
+	// author_pendingExtrinsics
+	let author_pending_extrinsic_name: &str = "author_pendingExtrinsics";
+	let pending_author = rpc_author;
+	io_handler.add_sync_method(author_pending_extrinsic_name, move |params: Params| {
+		match params.parse::<Vec<String>>() {
+			Ok(shards) => {
+				let mut retrieved_operations = vec![];
+				for shard_base58 in shards.iter() {
+					let shard = match decode_shard_from_base58(shard_base58.as_str()) {
+						Ok(id) => id,
+						Err(msg) => return Ok(Value::String(msg)),
+					};
+					if let Ok(vec_of_operations) = pending_author.pending_tops(shard) {
+						retrieved_operations.push(vec_of_operations);
+					}
+				}
+				let json_value = RpcReturnValue {
+					do_watch: false,
+					value: retrieved_operations.encode(),
+					status: DirectRequestStatus::Ok,
+				};
+				Ok(json!(json_value.encode()))
+			},
+			Err(e) => {
+				let error_msg: String = format!("Could not retrieve pending calls due to: {}", e);
+				Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+			},
+		}
+	});
+
+	io_handler
+}
+
+// converts the rpc methods vector to a string and adds commas and brackets for readability
+fn decode_shard_from_base58(shard_base58: &str) -> Result<ShardIdentifier, String> {
+	let shard_vec = match shard_base58.from_base58() {
+		Ok(vec) => vec,
+		Err(_) => return Err("Invalid base58 format of shard id".to_owned()),
+	};
+	let shard = match ShardIdentifier::decode(&mut shard_vec.as_slice()) {
+		Ok(hash) => hash,
+		Err(_) => return Err("Shard ID is not of type H256".to_owned()),
+	};
+	Ok(shard)
+}
+
+fn compute_encoded_return_error(error_msg: &str) -> Vec<u8> {
+	RpcReturnValue::from_error_message(error_msg).encode()
+}

--- a/sidechain/rpc-handler/src/import_block_api.rs
+++ b/sidechain/rpc-handler/src/import_block_api.rs
@@ -1,0 +1,106 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use codec::Decode;
+use its_primitives::types::SignedBlock;
+use jsonrpc_core::{IoHandler, Params, Value};
+use log::*;
+use std::{borrow::ToOwned, fmt::Debug, vec::Vec};
+
+pub fn add_import_block_rpc_method<ImportFn, Error>(
+	import_fn: ImportFn,
+	mut io_handler: IoHandler,
+) -> IoHandler
+where
+	ImportFn: Fn(Vec<SignedBlock>) -> Result<(), Error> + Sync + Send + 'static,
+	Error: Debug,
+{
+	let sidechain_import_import_name: &str = "sidechain_importBlock";
+	io_handler.add_sync_method(sidechain_import_import_name, move |sidechain_blocks: Params| {
+		debug!("sidechain_importBlock rpc. Params: {:?}", sidechain_blocks);
+
+		let block_vec: Vec<u8> = sidechain_blocks.parse()?;
+
+		let blocks: Vec<SignedBlock> = Decode::decode(&mut block_vec.as_slice()).map_err(|_| {
+			jsonrpc_core::error::Error::invalid_params_with_details(
+				"Could not decode Vec<SignedBlock>",
+				block_vec,
+			)
+		})?;
+
+		info!("sidechain_importBlock. Blocks: {:?}", blocks);
+
+		let _ = import_fn(blocks).map_err(|e| {
+			jsonrpc_core::error::Error::invalid_params_with_details("Failed to import Block.", e)
+		})?;
+
+		Ok(Value::String("ok".to_owned()))
+	});
+
+	io_handler
+}
+
+#[cfg(test)]
+pub mod tests {
+
+	use super::*;
+
+	fn rpc_response<T: ToString>(result: T) -> String {
+		format!(r#"{{"jsonrpc":"2.0","result":{},"id":1}}"#, result.to_string())
+	}
+
+	fn io_handler() -> IoHandler {
+		let io_handler = IoHandler::new();
+		add_import_block_rpc_method::<_, String>(|_| Ok(()), io_handler)
+	}
+
+	#[test]
+	pub fn sidechain_import_block_is_ok() {
+		let io = io_handler();
+		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":[4,0,0,0,0,0,0,0,0,228,0,145,188,97,251,138,131,108,29,6,107,10,152,67,29,148,190,114,167,223,169,197,163,93,228,76,169,171,80,15,209,101,11,211,96,0,0,0,0,83,52,167,255,37,229,185,231,38,66,122,3,55,139,5,190,125,85,94,177,190,99,22,149,92,97,154,30,142,89,24,144,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,136,220,52,23,213,5,142,196,180,80,62,12,18,234,26,10,137,190,32,15,233,137,34,66,61,67,52,1,79,166,176,238,0,0,0,175,124,84,84,32,238,162,224,130,203,26,66,7,121,44,59,196,200,100,31,173,226,165,106,187,135,223,149,30,46,191,95,116,203,205,102,100,85,82,74,158,197,166,218,181,130,119,127,162,134,227,129,118,85,123,76,21,113,90,1,160,77,110,15],"id":1}"#;
+
+		let response_string = io.handle_request_sync(enclave_req).unwrap();
+
+		assert_eq!(response_string, rpc_response("\"ok\""));
+	}
+
+	#[test]
+	pub fn sidechain_import_block_returns_invalid_param_err() {
+		let io = io_handler();
+		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":["SophisticatedInvalidParam"],"id":1}"#;
+
+		let response_string = io.handle_request_sync(enclave_req).unwrap();
+
+		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: invalid type: string \"SophisticatedInvalidParam\", expected u8."},"id":1}"#;
+		assert_eq!(response_string, err_msg);
+	}
+
+	#[test]
+	pub fn sidechain_import_block_returns_decode_err() {
+		let io = io_handler();
+		let enclave_req =
+			r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":[2],"id":1}"#;
+
+		let response_string = io.handle_request_sync(enclave_req).unwrap();
+
+		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: Could not decode Vec<SignedBlock>","data":"[2]"},"id":1}"#;
+		assert_eq!(response_string, err_msg);
+	}
+}

--- a/sidechain/rpc-handler/src/lib.rs
+++ b/sidechain/rpc-handler/src/lib.rs
@@ -28,28 +28,8 @@ extern crate sgx_tstd as std;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 pub mod sgx_reexport_prelude {
 	pub use jsonrpc_core_sgx as jsonrpc_core;
-	pub use thiserror_sgx as thiserror;
+	pub use rust_base58_sgx as base58;
 }
 
-pub mod api;
-pub mod atomic_container;
-pub mod author;
-pub mod author_container;
-pub mod client_error;
-pub mod error;
-pub mod hash;
-pub mod pool_types;
-pub mod top_filter;
-pub mod traits;
-
-#[cfg(feature = "sgx")]
-pub mod initializer;
-
-#[cfg(feature = "sgx")]
-pub mod global_author_container;
-
-#[cfg(all(feature = "sgx", feature = "test"))]
-pub mod author_tests;
-
-#[cfg(feature = "test")]
-pub mod test_utils;
+pub mod direct_top_pool_api;
+pub mod import_block_api;

--- a/sidechain/sidechain-crate/Cargo.toml
+++ b/sidechain/sidechain-crate/Cargo.toml
@@ -11,6 +11,7 @@ std = [
     "its-consensus-common/std",
     "its-consensus-slots/std",
     "its-primitives/std",
+    "its-rpc-handler/std",
     "its-state/std",
     "its-top-pool/std",
     "its-top-pool-rpc-author/std",
@@ -20,6 +21,7 @@ sgx = [
     "its-consensus-aura/sgx",
     "its-consensus-common/sgx",
     "its-consensus-slots/sgx",
+    "its-rpc-handler/sgx",
     "its-state/sgx",
     "its-top-pool/sgx",
     "its-top-pool-rpc-author/sgx",
@@ -31,6 +33,7 @@ its-consensus-aura = { path = "../consensus/aura", default-features = false }
 its-consensus-common = { path = "../consensus/common", default-features = false }
 its-consensus-slots = { path = "../consensus/slots", default-features = false }
 its-primitives = { path = "../primitives", default-features = false }
+its-rpc-handler = { path = "../rpc-handler", default-features = false }
 its-state = { path = "../state", default-features = false }
 its-top-pool = { path = "../top-pool", default-features = false }
 its-top-pool-rpc-author = { path = "../top-pool-rpc-author", default-features = false }

--- a/sidechain/sidechain-crate/src/lib.rs
+++ b/sidechain/sidechain-crate/src/lib.rs
@@ -30,6 +30,8 @@ pub use its_consensus_slots as slots;
 
 pub use its_primitives as primitives;
 
+pub use its_rpc_handler as rpc_handler;
+
 pub use its_state as state;
 
 pub use its_top_pool as top_pool;

--- a/sidechain/top-pool-rpc-author/src/author_container.rs
+++ b/sidechain/top-pool-rpc-author/src/author_container.rs
@@ -52,7 +52,9 @@ where
 {
 	type AuthorType = AuthorT;
 
-	fn get(&self) -> Option<&'static Mutex<Arc<Self::AuthorType>>> {
-		self.atomic_container.load()
+	fn get(&self) -> Option<Arc<Self::AuthorType>> {
+		let author_mutex: &'static Mutex<Arc<Self::AuthorType>> = self.atomic_container.load()?;
+
+		Some(author_mutex.lock().unwrap().clone())
 	}
 }

--- a/sidechain/top-pool-rpc-author/src/initializer.rs
+++ b/sidechain/top-pool-rpc-author/src/initializer.rs
@@ -1,0 +1,49 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	api::SideChainApi,
+	author::{Author, AuthorTopFilter},
+	global_author_container::GlobalAuthorContainer,
+	pool_types::{BPool, EnclaveRpcConnectionRegistry},
+};
+use itc_direct_rpc_server::rpc_responder::RpcResponder;
+use itp_stf_state_handler::GlobalFileStateHandler;
+use its_top_pool::pool::Options as PoolOptions;
+use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
+use std::sync::Arc;
+
+/// Initialize the author components.
+///
+/// Creates and initializes the global author container from which the
+/// RPC author can be accessed. We do this in a centralized manner, to allow
+/// easy feature-gating of the entire sidechain/top-pool feature.
+pub fn initialize_top_pool_rpc_author(
+	connection_registry: Arc<EnclaveRpcConnectionRegistry>,
+	shielding_key: Rsa3072KeyPair,
+) {
+	let rpc_responder = Arc::new(RpcResponder::new(connection_registry));
+
+	let side_chain_api = Arc::new(SideChainApi::<itp_types::Block>::new());
+	let top_pool = Arc::new(BPool::create(PoolOptions::default(), side_chain_api, rpc_responder));
+	let state_handler = Arc::new(GlobalFileStateHandler);
+
+	let rpc_author =
+		Arc::new(Author::new(top_pool, AuthorTopFilter {}, state_handler, shielding_key));
+
+	GlobalAuthorContainer::initialize(rpc_author.clone());
+}

--- a/sidechain/top-pool-rpc-author/src/pool_types.rs
+++ b/sidechain/top-pool-rpc-author/src/pool_types.rs
@@ -25,7 +25,7 @@ use its_top_pool::basic_pool::BasicPool;
 
 type Hash = sp_core::H256;
 
-type EnclaveRpcConnectionRegistry = ConnectionRegistry<Hash, TungsteniteWsConnection>;
+pub(crate) type EnclaveRpcConnectionRegistry = ConnectionRegistry<Hash, TungsteniteWsConnection>;
 
 pub type EnclaveRpcResponder =
 	RpcResponder<EnclaveRpcConnectionRegistry, Hash, TungsteniteWsConnection>;

--- a/sidechain/top-pool-rpc-author/src/traits.rs
+++ b/sidechain/top-pool-rpc-author/src/traits.rs
@@ -18,12 +18,6 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 use crate::sgx_reexport_prelude::*;
 
-#[cfg(feature = "sgx")]
-use std::sync::SgxMutex as Mutex;
-
-#[cfg(feature = "std")]
-use std::sync::Mutex;
-
 use crate::{error::Result, hash};
 use ita_stf::{TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_types::{BlockHash as SidechainBlockHash, ShardIdentifier, H256};
@@ -43,7 +37,7 @@ pub trait FullAuthor = AuthorApi<H256, H256>
 pub trait GetAuthor: Send + Sync + 'static {
 	type AuthorType: FullAuthor;
 
-	fn get(&self) -> Option<&'static Mutex<Arc<Self::AuthorType>>>;
+	fn get(&self) -> Option<Arc<Self::AuthorType>>;
 }
 
 /// Authoring RPC API


### PR DESCRIPTION
The new crate is 'top-pool-rpc' in the 'sidechain' folder. Extracted code from `worker_api_direct.rs` in the `enclave_runtime`.
This is a further step towards moving sidechain features out of the `enclave-runtime`.

- [x] Merge #472 first, then rebase this onto master