### PR TITLE
Update to new node: indirect block confirm: genesis hash -> mrenclave

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -172,10 +172,10 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: ci.yml
-          name: integritee-node-dev-ubuntu-18.04-505c0d2babd14825f713ddf4a254d28c0c305628
+          name: integritee-node-dev-1e07b44ce79a053b8d2845fe6d5172697fbf0d66
           # in fact this action should download the latest artifact, but sometimes fails. Then we need to
           # set the `run_id` to force a download of an updated binary.
-          run_id: 1384450796
+          run_id: 1393847669
           path: node
           repo: integritee-network/integritee-node
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -172,10 +172,10 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: ci.yml
-          name: integritee-node-dev-1e07b44ce79a053b8d2845fe6d5172697fbf0d66
+          name: integritee-node-dev-6b3f13932775f71c414d02bed8abac808cb75f73
           # in fact this action should download the latest artifact, but sometimes fails. Then we need to
           # set the `run_id` to force a download of an updated binary.
-          run_id: 1393847669
+          run_id: 1384450796
           path: node
           repo: integritee-network/integritee-node
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -175,7 +175,7 @@ jobs:
           name: integritee-node-dev-ubuntu-18.04-505c0d2babd14825f713ddf4a254d28c0c305628
           # in fact this action should download the latest artifact, but sometimes fails. Then we need to
           # set the `run_id` to force a download of an updated binary.
-          run_id: 1306804818
+          run_id: 1384450796
           path: node
           repo: integritee-network/integritee-node
 

--- a/cli/demo_direct_call.sh
+++ b/cli/demo_direct_call.sh
@@ -93,6 +93,7 @@ echo ""
 
 echo "* Bob's incognito account balance"
 RESULT=$($TIMEOUT ${CLIENT} trusted balance ${ICGACCOUNTBOB} --mrenclave ${MRENCLAVE} | xargs)
+echo $RESULT
 echo ""
 
 

--- a/cli/demo_shielding_unshielding.sh
+++ b/cli/demo_shielding_unshielding.sh
@@ -107,6 +107,9 @@ echo ""
 
 echo "* Send ${AMOUNTTRANSFER} funds from Alice's incognito account to Bob's incognito account"
 $TIMEOUT $CLIENT trusted transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER} --mrenclave ${MRENCLAVE}
+
+echo "* Waiting 5 seconds"
+sleep 5
 echo ""
 
 echo "* Get balance of Alice's incognito account"
@@ -121,8 +124,8 @@ echo "* Un-shield ${AMOUNTUNSHIELD} tokens from Alice's incognito account"
 $TIMEOUT ${CLIENT} trusted unshield-funds ${ICGACCOUNTALICE} //Alice ${AMOUNTUNSHIELD} ${MRENCLAVE} --mrenclave ${MRENCLAVE} --xt-signer //Alice
 echo ""
 
-echo "* Waiting 10 seconds"
-sleep 10
+echo "* Waiting 20 seconds"
+sleep 20
 echo ""
 
 echo "Get balance of Alice's incognito account"

--- a/cli/demo_shielding_unshielding.sh
+++ b/cli/demo_shielding_unshielding.sh
@@ -107,9 +107,6 @@ echo ""
 
 echo "* Send ${AMOUNTTRANSFER} funds from Alice's incognito account to Bob's incognito account"
 $TIMEOUT $CLIENT trusted transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER} --mrenclave ${MRENCLAVE}
-
-echo "* Waiting 5 seconds"
-sleep 5
 echo ""
 
 echo "* Get balance of Alice's incognito account"
@@ -124,8 +121,8 @@ echo "* Un-shield ${AMOUNTUNSHIELD} tokens from Alice's incognito account"
 $TIMEOUT ${CLIENT} trusted unshield-funds ${ICGACCOUNTALICE} //Alice ${AMOUNTUNSHIELD} ${MRENCLAVE} --mrenclave ${MRENCLAVE} --xt-signer //Alice
 echo ""
 
-echo "* Waiting 20 seconds"
-sleep 20
+echo "* Waiting 10 seconds"
+sleep 10
 echo ""
 
 echo "Get balance of Alice's incognito account"

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -101,7 +101,7 @@ pub mod node {
 	pub static BLOCK_CONFIRMED: u8 = 4u8;
 	pub static SHIELD_FUNDS: u8 = 5u8;
 	// bump this to be consistent with integritee-node runtime
-	pub static RUNTIME_SPEC_VERSION: u32 = 2;
+	pub static RUNTIME_SPEC_VERSION: u32 = 3;
 	pub static RUNTIME_TRANSACTION_VERSION: u32 = 1;
 	pub static UNSHIELD: u8 = 6u8;
 }

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -756,7 +756,7 @@ where
 		let prev_state_hash = signed_block.block.header().parent_hash();
 		calls.push(OpaqueCall::from_tuple(&(
 			xt_block,
-			mrenclave, // 'block_confirmed' only accepts shard == mrenclave. Will be changed with #457
+			mrenclave, // 'block_confirmed' only accepts shard == mrenclave. Will be adjusted with #457
 			block_hash,
 			prev_state_hash.encode(),
 		)));

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -756,7 +756,7 @@ where
 		let prev_state_hash = signed_block.block.header().parent_hash();
 		calls.push(OpaqueCall::from_tuple(&(
 			xt_block,
-			mrenclave, // pallet teerex only accepts shard == mrenclave for now
+			mrenclave, // 'block_confirmed' only accepts shard == mrenclave. Will be changed with #457
 			block_hash,
 			prev_state_hash.encode(),
 		)));

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -756,7 +756,7 @@ where
 		let prev_state_hash = signed_block.block.header().parent_hash();
 		calls.push(OpaqueCall::from_tuple(&(
 			xt_block,
-			mrenclave, // 'block_confirmed' only accepts shard == mrenclave. Will be adjusted with #457
+			mrenclave, // 'block_confirmed' only accepts shard == mrenclave. Overall 'block_confirmed' construct will be adjusted with #457
 			block_hash,
 			prev_state_hash.encode(),
 		)));

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -749,13 +749,14 @@ where
 		};
 
 		// compose indirect block confirmation
+		// should be changed to ParentchainBlockProcessed, see worker issue #457
 		let xt_block = [TEEREX_MODULE, BLOCK_CONFIRMED];
-		let genesis_hash = validator.genesis_hash(validator.num_relays()).unwrap();
+		let mrenclave: ShardIdentifier = on_chain_ocall_api.get_mrenclave_of_self()?.m.into();
 		let block_hash = signed_block.block.header().hash();
 		let prev_state_hash = signed_block.block.header().parent_hash();
 		calls.push(OpaqueCall::from_tuple(&(
 			xt_block,
-			genesis_hash,
+			mrenclave, // pallet teerex only accepts shard == mrenclave for now
 			block_hash,
 			prev_state_hash.encode(),
 		)));


### PR DESCRIPTION
- update spec-version from 2 -> 3
- change indirect block confirmation that used genesis hash as shard to mrenclave. This is necessary becasue pallet teerex throws an error otherwise: https://github.com/integritee-network/pallets/blob/master/teerex/src/lib.rs#L202
Temporary fix only. Will be cleaned up with issue https://github.com/integritee-network/worker/issues/457

closes #475 