### PR TITLE
Extract the STF execution logic to a separate crate 'stf-executor'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,6 +2636,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "itp-stf-executor"
+version = "0.8.0"
+dependencies = [
+ "ita-stf",
+ "itp-ocall-api",
+ "itp-stf-state-handler",
+ "itp-storage",
+ "itp-storage-verifier",
+ "itp-types",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec",
+ "sgx-externalities",
+ "sgx_tstd",
+ "sgx_types",
+ "sp-runtime",
+ "thiserror 1.0.29",
+ "thiserror 1.0.9",
+]
+
+[[package]]
 name = "itp-stf-state-handler"
 version = "0.8.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "core-primitives/settings",
     "core-primitives/sgx/crypto",
     "core-primitives/sgx/io",
+    "core-primitives/stf-executor",
     "core-primitives/stf-state-handler",
     "core-primitives/storage",
     "core-primitives/test",

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -12,7 +12,6 @@ sgx = [
     "log-sgx",
     "sp-io",
     "sgx-runtime",
-    "derive_more",
     "itp-types",
     "its-primitives",
     "its-state",
@@ -41,7 +40,7 @@ clap = { version = "2.33", optional = true }
 clap-nested = { version = "0.3.1", optional = true }
 log = { version = "0.4", optional = true }
 base58 = { version = "0.1", optional = true }
-derive_more = { version = "0.99.5", optional = true }
+derive_more = { version = "0.99.5" }
 hex = { version = "0.4.2", optional = true }
 codec = { version = "2.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 sgx_tstd = { rev = "v1.1.3", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/app-libs/stf/src/hash.rs
+++ b/app-libs/stf/src/hash.rs
@@ -15,16 +15,14 @@
 
 */
 
-//! Extrinsic helpers for author RPC module.
-
+use crate::TrustedOperation;
 use codec::{Decode, Encode};
-use ita_stf::TrustedOperation;
 use std::vec::Vec;
 
-/// RPC Trusted call or hash
+/// Trusted operation Or hash
 ///
 /// Allows to refer to trusted calls either by its raw representation or its hash.
-#[derive(Debug, Encode, Decode)]
+#[derive(Clone, Debug, Encode, Decode)]
 pub enum TrustedOperationOrHash<Hash> {
 	/// The hash of the call.
 	Hash(Hash),

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -14,10 +14,7 @@
 	limitations under the License.
 
 */
-use crate::{
-	stf_sgx_primitives::{types::*, StfError, StfResult},
-	AccountId, Index,
-};
+use crate::{stf_sgx_primitives::types::*, AccountId, Index, StfError, StfResult};
 use codec::{Decode, Encode};
 use itp_storage::{storage_double_map_key, storage_map_key, storage_value_key, StorageHasher};
 use log_sgx::*;

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -92,6 +92,8 @@ impl From<sr25519::Pair> for KeyPair {
 	}
 }
 
+pub mod hash;
+
 #[cfg(feature = "sgx")]
 pub mod stf_sgx;
 

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -23,16 +23,21 @@
 #![cfg_attr(all(not(target_env = "sgx"), not(feature = "std")), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
 
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
 extern crate alloc;
 
-use codec::{Compact, Decode, Encode};
 #[cfg(feature = "std")]
 use my_node_runtime::Balance;
 #[cfg(feature = "std")]
 pub use my_node_runtime::Index;
 
+use codec::{Compact, Decode, Encode};
+use derive_more::Display;
 use sp_core::{crypto::AccountId32, ed25519, sr25519, Pair, H256};
 use sp_runtime::{traits::Verify, MultiSignature};
+use std::string::String;
 
 pub type Signature = MultiSignature;
 pub type AuthorityId = <Signature as Verify>::Signer;
@@ -41,6 +46,24 @@ pub type Hash = sp_core::H256;
 pub type BalanceTransferFn = ([u8; 2], AccountId, Compact<u128>);
 
 pub type ShardIdentifier = H256;
+
+pub type StfResult<T> = Result<T, StfError>;
+
+#[derive(Debug, Display, PartialEq, Eq)]
+pub enum StfError {
+	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
+	MissingPrivileges(AccountId),
+	#[display(fmt = "Error dispatching runtime call. {:?}", _0)]
+	Dispatch(String),
+	#[display(fmt = "Not enough funds to perform operation")]
+	MissingFunds,
+	#[display(fmt = "Account does not exist {:?}", _0)]
+	InexistentAccount(AccountId),
+	#[display(fmt = "Invalid Nonce {:?}", _0)]
+	InvalidNonce(Index),
+	StorageHashMismatch,
+	InvalidStorageDiff,
+}
 
 #[derive(Clone)]
 pub enum KeyPair {

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -1,11 +1,27 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use crate::{
 	helpers::{
 		account_data, account_nonce, ensure_root, get_account_info, get_storage_value,
 		increment_nonce, root, validate_nonce,
 	},
-	stf_sgx_primitives::{StfError, StfResult},
 	AccountData, AccountId, Getter, Index, PublicGetter, ShardIdentifier, State, StateTypeDiff,
-	Stf, TrustedCall, TrustedCallSigned, TrustedGetter,
+	Stf, StfError, StfResult, TrustedCall, TrustedCallSigned, TrustedGetter,
 };
 use codec::Encode;
 use itp_settings::node::{TEEREX_MODULE, UNSHIELD};

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -108,7 +108,7 @@ impl Stf {
 	}
 
 	pub fn execute(
-		ext: &mut State,
+		ext: &mut impl SgxExternalitiesTrait,
 		call: TrustedCallSigned,
 		calls: &mut Vec<OpaqueCall>,
 	) -> StfResult<()> {

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -229,14 +229,19 @@ impl Stf {
 		});
 	}
 
-	pub fn update_layer_one_block_number(ext: &mut State, number: L1BlockNumer) {
+	pub fn update_layer_one_block_number(
+		ext: &mut impl SgxExternalitiesTrait,
+		number: L1BlockNumer,
+	) {
 		ext.execute_with(|| {
 			let key = storage_value_key("System", "LayerOneNumber");
 			sp_io::storage::set(&key, &number.encode());
 		});
 	}
 
-	pub fn get_layer_one_block_number(ext: &mut State) -> Option<L1BlockNumer> {
+	pub fn get_layer_one_block_number(
+		ext: &mut impl SgxExternalitiesTrait,
+	) -> Option<L1BlockNumer> {
 		ext.execute_with(|| get_storage_value("System", "LayerOneNumber"))
 	}
 
@@ -267,11 +272,11 @@ impl Stf {
 		key_hashes
 	}
 
-	pub fn get_root(ext: &mut State) -> AccountId {
+	pub fn get_root(ext: &mut impl SgxExternalitiesTrait) -> AccountId {
 		ext.execute_with(|| root())
 	}
 
-	pub fn account_nonce(ext: &mut State, account: &AccountId) -> Index {
+	pub fn account_nonce(ext: &mut impl SgxExternalitiesTrait, account: &AccountId) -> Index {
 		ext.execute_with(|| {
 			let nonce = account_nonce(account);
 			debug!("Account {:?} nonce is {}", account.encode(), nonce);
@@ -279,7 +284,10 @@ impl Stf {
 		})
 	}
 
-	pub fn account_data(ext: &mut State, account: &AccountId) -> Option<AccountData> {
+	pub fn account_data(
+		ext: &mut impl SgxExternalitiesTrait,
+		account: &AccountId,
+	) -> Option<AccountData> {
 		ext.execute_with(|| account_data(account))
 	}
 }

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -76,33 +76,30 @@ impl Stf {
 	pub fn get_state(ext: &mut impl SgxExternalitiesTrait, getter: Getter) -> Option<Vec<u8>> {
 		ext.execute_with(|| match getter {
 			Getter::trusted(g) => match g.getter {
-				TrustedGetter::free_balance(who) => {
+				TrustedGetter::free_balance(who) =>
 					if let Some(info) = get_account_info(&who) {
 						debug!("AccountInfo for {:x?} is {:?}", who.encode(), info);
 						debug!("Account free balance is {}", info.data.free);
 						Some(info.data.free.encode())
 					} else {
 						None
-					}
-				}
-				TrustedGetter::reserved_balance(who) => {
+					},
+				TrustedGetter::reserved_balance(who) =>
 					if let Some(info) = get_account_info(&who) {
 						debug!("AccountInfo for {:x?} is {:?}", who.encode(), info);
 						debug!("Account reserved balance is {}", info.data.reserved);
 						Some(info.data.reserved.encode())
 					} else {
 						None
-					}
-				}
-				TrustedGetter::nonce(who) => {
+					},
+				TrustedGetter::nonce(who) =>
 					if let Some(info) = get_account_info(&who) {
 						debug!("AccountInfo for {:x?} is {:?}", who.encode(), info);
 						debug!("Account nonce is {}", info.nonce);
 						Some(info.nonce.encode())
 					} else {
 						None
-					}
-				}
+					},
 			},
 			Getter::public(g) => match g {
 				PublicGetter::some_value => Some(42u32.encode()),
@@ -136,7 +133,7 @@ impl Stf {
 					.dispatch_bypass_filter(sgx_runtime::Origin::root())
 					.map_err(|_| StfError::Dispatch("balance_set_balance".to_string()))?;
 					Ok(())
-				}
+				},
 				TrustedCall::balance_transfer(from, to, value) => {
 					let origin = sgx_runtime::Origin::signed(from.clone());
 					debug!("balance_transfer({:x?}, {:x?}, {})", from.encode(), to.encode(), value);
@@ -149,7 +146,7 @@ impl Stf {
 						.dispatch_bypass_filter(origin)
 						.map_err(|_| StfError::Dispatch("balance_transfer".to_string()))?;
 					Ok(())
-				}
+				},
 				TrustedCall::balance_unshield(account_incognito, beneficiary, value, shard) => {
 					debug!(
 						"balance_unshield({:x?}, {:x?}, {}, {})",
@@ -168,13 +165,13 @@ impl Stf {
 						call_hash,
 					)));
 					Ok(())
-				}
+				},
 				TrustedCall::balance_shield(root, who, value) => {
 					ensure_root(root)?;
 					debug!("balance_shield({:x?}, {})", who.encode(), value);
 					Self::shield_funds(who, value)?;
 					Ok(())
-				}
+				},
 			}?;
 			increment_nonce(&sender);
 			Ok(())
@@ -205,7 +202,7 @@ impl Stf {
 		match get_account_info(&account) {
 			Some(account_info) => {
 				if account_info.data.free < amount {
-					return Err(StfError::MissingFunds);
+					return Err(StfError::MissingFunds)
 				}
 
 				sgx_runtime::BalancesCall::<Runtime>::set_balance(
@@ -216,7 +213,7 @@ impl Stf {
 				.dispatch_bypass_filter(sgx_runtime::Origin::root())
 				.map_err(|_| StfError::Dispatch("unshield_funds::set_balance".to_string()))?;
 				Ok(())
-			}
+			},
 			None => Err(StfError::InexistentAccount(account)),
 		}
 	}

--- a/app-libs/stf/src/stf_sgx_primitives.rs
+++ b/app-libs/stf/src/stf_sgx_primitives.rs
@@ -15,14 +15,9 @@
 
 */
 
-use crate::{AccountId, Index};
 use codec::{Decode, Encode};
-use derive_more::Display;
 use itp_types::H256;
-use sgx_tstd as std;
 use std::prelude::v1::*;
-
-pub type StfResult<T> = Result<T, StfError>;
 
 pub mod types {
 	pub use sgx_runtime::{Balance, Index};
@@ -72,20 +67,4 @@ impl StatePayload {
 			state_update: update,
 		}
 	}
-}
-
-#[derive(Debug, Display, PartialEq, Eq)]
-pub enum StfError {
-	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
-	MissingPrivileges(AccountId),
-	#[display(fmt = "Error dispatching runtime call. {:?}", _0)]
-	Dispatch(String),
-	#[display(fmt = "Not enough funds to perform operation")]
-	MissingFunds,
-	#[display(fmt = "Account does not exist {:?}", _0)]
-	InexistentAccount(AccountId),
-	#[display(fmt = "Invalid Nonce {:?}", _0)]
-	InvalidNonce(Index),
-	StorageHashMismatch,
-	InvalidStorageDiff,
 }

--- a/app-libs/stf/src/test_genesis.rs
+++ b/app-libs/stf/src/test_genesis.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::{helpers::get_account_info, stf_sgx_primitives::StfError};
+use crate::{helpers::get_account_info, StfError};
 use itp_storage::storage_value_key;
 use log_sgx::*;
 use sgx_externalities::SgxExternalitiesTrait;

--- a/core-primitives/ocall-api/src/lib.rs
+++ b/core-primitives/ocall-api/src/lib.rs
@@ -17,13 +17,15 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub extern crate alloc;
+
+use alloc::vec::Vec;
 use codec::{Decode, Encode};
 use core::fmt::Debug;
 use itp_types::{TrustedOperationStatus, WorkerRequest, WorkerResponse};
 use its_primitives::traits::SignedBlock;
 use sgx_types::*;
 use sp_runtime::OpaqueExtrinsic;
-use sp_std::prelude::Vec;
 
 /// Trait for the enclave to make o-calls related to remote attestation
 pub trait EnclaveAttestationOCallApi: Clone + Debug + Send + Sync {

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -15,6 +15,7 @@ std = [
     "itp-stf-state-handler/std",
     "itp-storage/std",
     "itp-storage-verifier/std",
+    "sgx-externalities/std",
     "sp-runtime/std",
     "thiserror",
 ]

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "itp-stf-executor"
+version = "0.8.0"
+authors = ["Integritee AG <hello@integritee.network>"]
+edition = "2018"
+resolver = "2"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["std"]
+std = [
+    "ita-stf/std",
+    "itp-ocall-api/std",
+    "itp-stf-state-handler/std",
+    "itp-storage/std",
+    "itp-storage-verifier/std",
+    "sp-runtime/std",
+    "thiserror",
+]
+sgx = [
+    "sgx_tstd",
+    "ita-stf/sgx",
+    "itp-stf-state-handler/sgx",
+    "itp-storage/sgx",
+    "sgx-externalities",
+    "thiserror_sgx",
+]
+test = []
+
+[dependencies]
+# sgx dependencies
+sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
+
+# local dependencies
+ita-stf = { path = "../../app-libs/stf", default-features = false }
+itp-ocall-api = { path = "../ocall-api", default-features = false }
+itp-stf-state-handler = { path = "../stf-state-handler", default-features = false }
+itp-storage = { path = "../storage", default-features = false }
+itp-storage-verifier = { path = "../storage-verified", default-features = false }
+itp-types = { path = "../types", default-features = false }
+
+# sgx enabled external libraries
+thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
+
+# std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
+thiserror = { version = "1.0", optional = true }
+
+# no-std dependencies
+log = { version = "0.4", default-features = false }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/core-primitives/stf-executor/src/error.rs
+++ b/core-primitives/stf-executor/src/error.rs
@@ -1,0 +1,62 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use sgx_types::sgx_status_t;
+use std::{boxed::Box, format};
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("SGX error, status: {0}")]
+	SgxError(sgx_status_t),
+	#[error("State handling error: {0}")]
+	StateHandlingError(#[from] itp_stf_state_handler::error::Error),
+	#[error("STF error: {0}")]
+	StfError(ita_stf::StfError),
+	#[error("Storage verified error: {0}")]
+	StorageVerifiedError(itp_storage_verifier::Error),
+	#[error(transparent)]
+	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
+}
+
+impl From<sgx_status_t> for Error {
+	fn from(sgx_status: sgx_status_t) -> Self {
+		Self::SgxError(sgx_status)
+	}
+}
+
+impl From<codec::Error> for Error {
+	fn from(e: codec::Error) -> Self {
+		Self::Other(format!("{:?}", e).into())
+	}
+}
+
+impl From<ita_stf::StfError> for Error {
+	fn from(error: ita_stf::StfError) -> Self {
+		Self::StfError(error)
+	}
+}
+
+impl From<itp_storage_verifier::Error> for Error {
+	fn from(error: itp_storage_verifier::Error) -> Self {
+		Self::StorageVerifiedError(error)
+	}
+}

--- a/core-primitives/stf-executor/src/error.rs
+++ b/core-primitives/stf-executor/src/error.rs
@@ -23,8 +23,11 @@ use std::{boxed::Box, format};
 
 pub type Result<T> = core::result::Result<T, Error>;
 
+/// STF-Executor error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+	#[error("Trusted call has invalid signature")]
+	CallHasInvalidSignature,
 	#[error("SGX error, status: {0}")]
 	SgxError(sgx_status_t),
 	#[error("State handling error: {0}")]

--- a/core-primitives/stf-executor/src/error.rs
+++ b/core-primitives/stf-executor/src/error.rs
@@ -26,8 +26,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 /// STF-Executor error
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("Trusted call has invalid signature")]
-	CallHasInvalidSignature,
+	#[error("Trusted operation has invalid signature")]
+	OperationHasInvalidSignature,
 	#[error("SGX error, status: {0}")]
 	SgxError(sgx_status_t),
 	#[error("State handling error: {0}")]

--- a/core-primitives/stf-executor/src/error.rs
+++ b/core-primitives/stf-executor/src/error.rs
@@ -29,20 +29,20 @@ pub enum Error {
 	#[error("Trusted operation has invalid signature")]
 	OperationHasInvalidSignature,
 	#[error("SGX error, status: {0}")]
-	SgxError(sgx_status_t),
+	Sgx(sgx_status_t),
 	#[error("State handling error: {0}")]
-	StateHandlingError(#[from] itp_stf_state_handler::error::Error),
+	StateHandler(#[from] itp_stf_state_handler::error::Error),
 	#[error("STF error: {0}")]
-	StfError(ita_stf::StfError),
+	Stf(ita_stf::StfError),
 	#[error("Storage verified error: {0}")]
-	StorageVerifiedError(itp_storage_verifier::Error),
+	StorageVerified(itp_storage_verifier::Error),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }
 
 impl From<sgx_status_t> for Error {
 	fn from(sgx_status: sgx_status_t) -> Self {
-		Self::SgxError(sgx_status)
+		Self::Sgx(sgx_status)
 	}
 }
 
@@ -54,12 +54,12 @@ impl From<codec::Error> for Error {
 
 impl From<ita_stf::StfError> for Error {
 	fn from(error: ita_stf::StfError) -> Self {
-		Self::StfError(error)
+		Self::Stf(error)
 	}
 }
 
 impl From<itp_storage_verifier::Error> for Error {
 	fn from(error: itp_storage_verifier::Error) -> Self {
-		Self::StorageVerifiedError(error)
+		Self::StorageVerified(error)
 	}
 }

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -61,7 +61,8 @@ use std::{
 
 /// STF Executor implementation
 ///
-///
+/// FIXME: Next time we change this class, we should add some unit tests
+/// (where they make sense and can be done with reasonable effort)
 pub struct StfExecutor<OCallApi, StateHandler, ExternalitiesT> {
 	ocall_api: Arc<OCallApi>,
 	state_handler: Arc<StateHandler>,

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -127,14 +127,15 @@ where
 			return Ok(ExecutedOperation::failed(top_or_hash))
 		}
 
-		let call_hash: H256 = blake2_256(&stf_call_signed.encode()).into();
-		debug!("Call hash {:?}", call_hash);
+		let operation = stf_call_signed.clone().into_trusted_operation(true);
+		let operation_hash: H256 = blake2_256(&operation.encode()).into();
+		debug!("Operation hash {:?}", operation_hash);
 
 		if let StatePostProcessing::Prune = post_processing {
 			state.prune_state_diff();
 		}
 
-		Ok(ExecutedOperation::success(call_hash, top_or_hash, extrinsic_call_backs))
+		Ok(ExecutedOperation::success(operation_hash, top_or_hash, extrinsic_call_backs))
 	}
 }
 

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -28,7 +28,7 @@ use crate::{
 		StfExecuteTimedCallsBatch, StfExecuteTimedGettersBatch, StfExecuteTrustedCall,
 		StfUpdateState,
 	},
-	ExecutedOperation, ExecutionHashes, ExecutionResult, ExecutionStatus,
+	BatchExecutionResult, ExecutedOperation, ExecutionHashes, ExecutionStatus,
 };
 use codec::{Decode, Encode};
 use ita_stf::{
@@ -286,7 +286,7 @@ where
 		shard: &ShardIdentifier,
 		max_exec_duration: Duration,
 		prepare_state_function: F,
-	) -> Result<ExecutionResult>
+	) -> Result<BatchExecutionResult>
 	where
 		PB: BlockT<Hash = H256>,
 		F: FnOnce(Self::Externalities) -> Self::Externalities,
@@ -324,9 +324,9 @@ where
 
 		self.state_handler
 			.write(state, state_lock, shard)
-			.map_err(|e| Error::StateHandlingError(e))?;
+			.map_err(|e| Error::StateHandler(e))?;
 
-		Ok(ExecutionResult { executed_operations: executed_calls, previous_state_hash })
+		Ok(BatchExecutionResult { executed_operations: executed_calls, previous_state_hash })
 	}
 }
 
@@ -398,7 +398,7 @@ where
 		let new_state_hash = self
 			.state_handler
 			.write(new_state, state_lock, shard)
-			.map_err(|e| Error::StateHandlingError(e))?;
+			.map_err(|e| Error::StateHandler(e))?;
 		Ok((result, new_state_hash))
 	}
 }

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -1,0 +1,217 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+// #[cfg(all(not(feature = "std"), feature = "sgx"))]
+// use crate::sgx_reexport_prelude::*;
+
+use crate::{
+	error::{Error, Result},
+	traits::{StatePostProcessing, StfExecuteShieldFunds, StfExecuteTrustedCall, StfUpdateState},
+};
+use codec::{Decode, Encode};
+use ita_stf::{
+	stf_sgx::{shards_key_hash, storage_hashes_to_update_per_shard},
+	AccountId, ShardIdentifier, StateTypeDiff, Stf, TrustedCall, TrustedCallSigned,
+};
+use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
+use itp_stf_state_handler::handle_state::HandleState;
+use itp_storage::StorageEntryVerified;
+use itp_storage_verifier::GetStorageVerified;
+use itp_types::{Amount, OpaqueCall, H256};
+use log::*;
+use sgx_externalities::SgxExternalitiesTrait;
+use sp_runtime::{
+	app_crypto::sp_core::blake2_256,
+	traits::{Block as BlockT, Header, UniqueSaturatedInto},
+};
+use std::{collections::HashMap, sync::Arc, vec::Vec};
+
+/// STF Executor implementation
+///
+///
+pub struct StfExecutor<OCallApi, StateHandler> {
+	ocall_api: Arc<OCallApi>,
+	state_handler: StateHandler,
+}
+
+impl<OCallApi, StateHandler> StfExecutor<OCallApi, StateHandler>
+where
+	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi + GetStorageVerified,
+	StateHandler: HandleState,
+{
+	pub fn new(ocall_api: Arc<OCallApi>, state_handler: StateHandler) -> Self {
+		StfExecutor { ocall_api, state_handler }
+	}
+}
+
+impl<OCallApi, StateHandler> StfExecuteTrustedCall for StfExecutor<OCallApi, StateHandler>
+where
+	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi + GetStorageVerified,
+	StateHandler: HandleState,
+{
+	fn execute_trusted_call<PB>(
+		&self,
+		calls: &mut Vec<OpaqueCall>,
+		stf_call_signed: &TrustedCallSigned,
+		header: &PB::Header,
+		shard: ShardIdentifier,
+		post_processing: StatePostProcessing,
+	) -> Result<Option<(H256, H256)>>
+	where
+		PB: BlockT<Hash = H256>,
+	{
+		// load state before executing any calls
+		let (state_lock, mut state) = self.state_handler.load_for_mutation(&shard)?;
+
+		debug!("query mrenclave of self");
+		let mrenclave = self.ocall_api.get_mrenclave_of_self()?;
+		//debug!("MRENCLAVE of self is {}", mrenclave.m.to_base58());
+
+		if let false = stf_call_signed.verify_signature(&mrenclave.m, &shard) {
+			error!("TrustedCallSigned: bad signature");
+			// do not panic here or users will be able to shoot workers dead by supplying a bad signature
+			return Ok(None)
+		}
+
+		// Necessary because light client sync may not be up to date
+		// see issue #208
+		debug!("Update STF storage!");
+		let storage_hashes = Stf::get_storage_hashes_to_update(&stf_call_signed);
+		let update_map = self
+			.ocall_api
+			.get_multiple_storages_verified(storage_hashes, header)
+			.map(into_map)?;
+		Stf::update_storage(&mut state, &update_map.into());
+
+		debug!("execute STF");
+		if let Err(e) = Stf::execute(&mut state, stf_call_signed.clone(), calls) {
+			error!("Error performing Stf::execute. Error: {:?}", e);
+			return Ok(None)
+		}
+
+		let call_hash = blake2_256(&stf_call_signed.encode());
+		let operation = stf_call_signed.clone().into_trusted_operation(true);
+		let operation_hash = blake2_256(&operation.encode());
+		debug!("Operation hash {:?}", operation_hash);
+		debug!("Call hash {:?}", call_hash);
+
+		if let StatePostProcessing::Prune = post_processing {
+			state.prune_state_diff();
+		}
+
+		trace!("Updating state of shard {:?}", shard);
+		self.state_handler.write(state, state_lock, &shard)?;
+
+		Ok(Some((H256::from(call_hash), H256::from(operation_hash))))
+	}
+}
+
+impl<OCallApi, StateHandler> StfExecuteShieldFunds for StfExecutor<OCallApi, StateHandler>
+where
+	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi + GetStorageVerified,
+	StateHandler: HandleState,
+{
+	fn execute_shield_funds(
+		&self,
+		account: AccountId,
+		amount: Amount,
+		shard: &ShardIdentifier,
+		calls: &mut Vec<OpaqueCall>,
+	) -> Result<H256> {
+		let (state_lock, mut state) = self.state_handler.load_for_mutation(&shard)?;
+
+		let root = Stf::get_root(&mut state);
+		let nonce = Stf::account_nonce(&mut state, &root);
+
+		let trusted_call = TrustedCallSigned::new(
+			TrustedCall::balance_shield(root, account, amount),
+			nonce,
+			Default::default(), //don't care about signature here
+		);
+
+		Stf::execute(&mut state, trusted_call, calls).map_err::<Error, _>(|e| e.into())?;
+
+		self.state_handler.write(state, state_lock, &shard).map_err(|e| e.into())
+	}
+}
+
+impl<OCallApi, StateHandler> StfUpdateState for StfExecutor<OCallApi, StateHandler>
+where
+	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi + GetStorageVerified,
+	StateHandler: HandleState,
+{
+	fn update_states<PB>(&self, header: &PB::Header) -> Result<()>
+	where
+		PB: BlockT<Hash = H256>,
+	{
+		debug!("Update STF storage upon block import!");
+		let storage_hashes = Stf::storage_hashes_to_update_on_block();
+
+		if storage_hashes.is_empty() {
+			return Ok(())
+		}
+
+		// global requests they are the same for every shard
+		let state_diff_update: StateTypeDiff = self
+			.ocall_api
+			.get_multiple_storages_verified(storage_hashes, header)
+			.map(into_map)?
+			.into();
+
+		// look for new shards an initialize them
+		if let Some(maybe_shards) = state_diff_update.get(&shards_key_hash()) {
+			match maybe_shards {
+				Some(shards) => {
+					let shards: Vec<ShardIdentifier> = Decode::decode(&mut shards.as_slice())?;
+
+					for shard_id in shards {
+						let (state_lock, mut state) =
+							self.state_handler.load_for_mutation(&shard_id)?;
+						trace!("Successfully loaded state, updating states ...");
+
+						// per shard (cid) requests
+						let per_shard_hashes = storage_hashes_to_update_per_shard(&shard_id);
+						let per_shard_update = self
+							.ocall_api
+							.get_multiple_storages_verified(per_shard_hashes, header)
+							.map(into_map)?;
+
+						Stf::update_storage(&mut state, &per_shard_update.into());
+						Stf::update_storage(&mut state, &state_diff_update);
+
+						// block number is purged from the substrate state so it can't be read like other storage values
+						// The number conversion is a bit unfortunate, but I wanted to prevent making the stf generic for now
+						Stf::update_layer_one_block_number(
+							&mut state,
+							(*header.number()).unique_saturated_into(),
+						);
+
+						self.state_handler.write(state, state_lock, &shard_id)?;
+					}
+				},
+				None => debug!("No shards are on the chain yet"),
+			};
+		};
+		Ok(())
+	}
+}
+
+fn into_map(
+	storage_entries: Vec<StorageEntryVerified<Vec<u8>>>,
+) -> HashMap<Vec<u8>, Option<Vec<u8>>> {
+	storage_entries.into_iter().map(|e| e.into_tuple()).collect()
+}

--- a/core-primitives/stf-executor/src/lib.rs
+++ b/core-primitives/stf-executor/src/lib.rs
@@ -115,12 +115,12 @@ impl ExecutedOperation {
 ///
 /// Contains multiple executed calls
 #[derive(Clone, Debug)]
-pub struct ExecutionResult {
+pub struct BatchExecutionResult {
 	pub previous_state_hash: H256,
 	pub executed_operations: Vec<ExecutedOperation>,
 }
 
-impl ExecutionResult {
+impl BatchExecutionResult {
 	pub fn get_extrinsic_callbacks(&self) -> Vec<OpaqueCall> {
 		self.executed_operations
 			.iter()
@@ -128,7 +128,7 @@ impl ExecutionResult {
 			.collect()
 	}
 
-	pub fn get_all_execution_hashes(&self) -> Vec<ExecutionHashes> {
+	pub fn get_executed_operation_hashes(&self) -> Vec<ExecutionHashes> {
 		self.executed_operations
 			.iter()
 			.flat_map(|ec| ec.status.get_execution_hashes())

--- a/core-primitives/stf-executor/src/lib.rs
+++ b/core-primitives/stf-executor/src/lib.rs
@@ -41,7 +41,7 @@ pub mod executor;
 
 /// Execution status of a trusted operation
 ///
-/// In case of success, it includes the call and operation hash, as well as
+/// In case of success, it includes the operation hash, as well as
 /// any extrinsic callbacks (e.g. unshield extrinsics) that need to be executed on-chain
 #[derive(Clone, Debug)]
 pub enum ExecutionStatus {
@@ -57,9 +57,9 @@ impl ExecutionStatus {
 		}
 	}
 
-	pub fn get_executed_call_hash(&self) -> Option<H256> {
+	pub fn get_executed_operation_hash(&self) -> Option<H256> {
 		match self {
-			ExecutionStatus::Success(call_hash, _) => Some(*call_hash),
+			ExecutionStatus::Success(operation_hash, _) => Some(*operation_hash),
 			_ => None,
 		}
 	}
@@ -77,22 +77,22 @@ pub struct ExecutedOperation {
 impl ExecutedOperation {
 	/// constructor for a successfully executed trusted operation
 	pub fn success(
-		call_hash: H256,
+		operation_hash: H256,
 		trusted_operation_or_hash: TrustedOperationOrHash<H256>,
 		extrinsic_call_backs: Vec<OpaqueCall>,
 	) -> Self {
 		ExecutedOperation {
-			status: ExecutionStatus::Success(call_hash, extrinsic_call_backs),
+			status: ExecutionStatus::Success(operation_hash, extrinsic_call_backs),
 			trusted_operation_or_hash,
 		}
 	}
 
-	/// constructor for a failed trusted call execution
+	/// constructor for a failed trusted operation execution
 	pub fn failed(trusted_operation_or_hash: TrustedOperationOrHash<H256>) -> Self {
 		ExecutedOperation { status: ExecutionStatus::Failure, trusted_operation_or_hash }
 	}
 
-	/// returns if the executed call was a success
+	/// returns if the executed operation was a success
 	pub fn is_success(&self) -> bool {
 		matches!(self.status, ExecutionStatus::Success(_, _))
 	}
@@ -100,7 +100,7 @@ impl ExecutedOperation {
 
 /// Result of an execution on the STF
 ///
-/// Contains multiple executed calls
+/// Contains multiple executed operations
 #[derive(Clone, Debug)]
 pub struct BatchExecutionResult {
 	pub previous_state_hash: H256,
@@ -115,10 +115,10 @@ impl BatchExecutionResult {
 			.collect()
 	}
 
-	pub fn get_executed_call_hashes(&self) -> Vec<H256> {
+	pub fn get_executed_operation_hashes(&self) -> Vec<H256> {
 		self.executed_operations
 			.iter()
-			.flat_map(|ec| ec.status.get_executed_call_hash())
+			.flat_map(|ec| ec.status.get_executed_operation_hash())
 			.collect()
 	}
 }

--- a/core-primitives/stf-executor/src/lib.rs
+++ b/core-primitives/stf-executor/src/lib.rs
@@ -1,0 +1,36 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+// re-export module to properly feature gate sgx and regular std environment
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+pub mod sgx_reexport_prelude {
+	pub use thiserror_sgx as thiserror;
+}
+
+pub mod error;
+pub mod traits;
+
+#[cfg(feature = "sgx")]
+pub mod executor;

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -17,7 +17,7 @@
 
 use crate::{error::Result, ExecutionResult};
 use codec::Encode;
-use ita_stf::{AccountId, ShardIdentifier, TrustedCallSigned};
+use ita_stf::{AccountId, ShardIdentifier, TrustedCallSigned, TrustedGetterSigned};
 use itp_types::{Amount, OpaqueCall, H256};
 use sgx_externalities::SgxExternalitiesTrait;
 use sp_runtime::traits::Block as BlockT;
@@ -74,6 +74,24 @@ pub trait StfExecuteTimedCallsBatch {
 		F: FnOnce(Self::Externalities) -> Self::Externalities;
 }
 
+/// Execute a batch of trusted getter within a given time window
+///
+///
+pub trait StfExecuteTimedGettersBatch {
+	type Externalities: SgxExternalitiesTrait + Encode;
+
+	fn execute_timed_getters_batch<F>(
+		&self,
+		trusted_getters: &[TrustedGetterSigned],
+		shard: &ShardIdentifier,
+		max_exec_duration: Duration,
+		getter_callback: F,
+	) -> Result<()>
+	where
+		F: Fn(&TrustedGetterSigned, Result<Option<Vec<u8>>>);
+}
+
+/// Execute a generic function on the STF state
 pub trait StfExecuteGenericUpdate {
 	type Externalities: SgxExternalitiesTrait + Encode;
 

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -49,7 +49,7 @@ pub trait StfExecuteTrustedCall {
 		header: &PB::Header,
 		shard: &ShardIdentifier,
 		post_processing: StatePostProcessing,
-	) -> Result<Option<(H256, H256)>>
+	) -> Result<Option<H256>>
 	where
 		PB: BlockT<Hash = H256>;
 }

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -1,0 +1,60 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::error::Result;
+use ita_stf::{AccountId, ShardIdentifier, TrustedCallSigned};
+use itp_types::{Amount, OpaqueCall, H256};
+use sp_runtime::traits::Block as BlockT;
+use std::vec::Vec;
+
+/// Post-processing steps after executing STF
+pub enum StatePostProcessing {
+	None,
+	Prune,
+}
+
+/// Execute shield funds on the STF
+pub trait StfExecuteShieldFunds {
+	fn execute_shield_funds(
+		&self,
+		account: AccountId,
+		amount: Amount,
+		shard: &ShardIdentifier,
+		calls: &mut Vec<OpaqueCall>,
+	) -> Result<H256>;
+}
+
+/// Execute a trusted call on the STF
+pub trait StfExecuteTrustedCall {
+	fn execute_trusted_call<PB>(
+		&self,
+		calls: &mut Vec<OpaqueCall>,
+		stf_call_signed: &TrustedCallSigned,
+		header: &PB::Header,
+		shard: ShardIdentifier,
+		post_processing: StatePostProcessing,
+	) -> Result<Option<(H256, H256)>>
+	where
+		PB: BlockT<Hash = H256>;
+}
+
+///
+pub trait StfUpdateState {
+	fn update_states<PB>(&self, header: &PB::Header) -> Result<()>
+	where
+		PB: BlockT<Hash = H256>;
+}

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -52,6 +52,21 @@ pub trait StfExecuteTrustedCall {
 		PB: BlockT<Hash = H256>;
 }
 
+/// Execute a batch of trusted calls within a given time window
+///
+/// If the time expires, any remaining trusted calls will be ignored
+/// All executed call hashes are returned.
+pub trait StfExecuteTimedCallsBatch {
+	fn execute_timed_calls_batch(
+		&self,
+		callback_calls: &mut Vec<OpaqueCall>,
+		trusted_calls: &Vec<TrustedCallSigned>,
+		header: &PB::Header,
+		shard: ShardIdentifier,
+		max_exec_duration: Duration,
+	) -> Result<Vec<Option<(H256, H256)>>>;
+}
+
 ///
 pub trait StfUpdateState {
 	fn update_states<PB>(&self, header: &PB::Header) -> Result<()>

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::{error::Result, ExecutionResult};
+use crate::{error::Result, BatchExecutionResult};
 use codec::Encode;
 use ita_stf::{AccountId, ShardIdentifier, TrustedCallSigned, TrustedGetterSigned};
 use itp_types::{Amount, OpaqueCall, H256};
@@ -68,7 +68,7 @@ pub trait StfExecuteTimedCallsBatch {
 		shard: &ShardIdentifier,
 		max_exec_duration: Duration,
 		prepare_state_function: F,
-	) -> Result<ExecutionResult>
+	) -> Result<BatchExecutionResult>
 	where
 		PB: BlockT<Hash = H256>,
 		F: FnOnce(Self::Externalities) -> Self::Externalities;

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -14,6 +14,7 @@ std = [
     "ita-stf/std",
     "itp-sgx-crypto/std",
     "itp-sgx-io/std",
+    "itp-types/std",
     "thiserror",
 ]
 sgx = [

--- a/core-primitives/stf-state-handler/src/handle_state.rs
+++ b/core-primitives/stf-state-handler/src/handle_state.rs
@@ -22,30 +22,30 @@ use std::sync::SgxRwLockWriteGuard as RwLockWriteGuard;
 use std::sync::RwLockWriteGuard;
 
 use crate::error::Result;
-use ita_stf::State as StfState;
 use itp_types::{ShardIdentifier, H256};
 
 /// Facade for handling STF state loading and storing (e.g. from file)
 pub trait HandleState {
 	type WriteLockPayload;
+	type StateT;
 
 	/// Load the state for a given shard
 	///
 	/// Initializes the shard and state if necessary, so this is guaranteed to
 	/// return a state
-	fn load_initialized(&self, shard: &ShardIdentifier) -> Result<StfState>;
+	fn load_initialized(&self, shard: &ShardIdentifier) -> Result<Self::StateT>;
 
 	fn load_for_mutation(
 		&self,
 		shard: &ShardIdentifier,
-	) -> Result<(RwLockWriteGuard<'_, Self::WriteLockPayload>, StfState)>;
+	) -> Result<(RwLockWriteGuard<'_, Self::WriteLockPayload>, Self::StateT)>;
 
 	/// Writes the state (without the state diff) encrypted into the enclave
 	///
 	/// Returns the hash of the saved state (independent of the diff!)
 	fn write(
 		&self,
-		state: StfState,
+		state: Self::StateT,
 		state_lock: RwLockWriteGuard<'_, Self::WriteLockPayload>,
 		shard: &ShardIdentifier,
 	) -> Result<H256>;

--- a/core-primitives/stf-state-handler/src/lib.rs
+++ b/core-primitives/stf-state-handler/src/lib.rs
@@ -31,13 +31,11 @@ pub mod sgx_reexport_prelude {
 }
 
 pub mod error;
+pub mod handle_state;
 pub mod query_shard_state;
 
 #[cfg(feature = "sgx")]
 pub mod global_file_state_handler;
-
-#[cfg(feature = "sgx")]
-pub mod handle_state;
 
 #[cfg(feature = "sgx")]
 pub use global_file_state_handler::GlobalFileStateHandler;

--- a/core-primitives/test/src/mock/handle_state_mock.rs
+++ b/core-primitives/test/src/mock/handle_state_mock.rs
@@ -45,6 +45,7 @@ impl Default for HandleStateMock {
 
 impl HandleState for HandleStateMock {
 	type WriteLockPayload = HashMap<ShardIdentifier, StfState>;
+	type StateT = StfState;
 
 	fn load_initialized(&self, shard: &ShardIdentifier) -> Result<StfState> {
 		let maybe_state = self.state_map.read().unwrap().get(shard).map(|s| s.clone());

--- a/core-primitives/types/src/lib.rs
+++ b/core-primitives/types/src/lib.rs
@@ -29,6 +29,7 @@ pub use substrate_api_client::{AccountData, AccountInfo};
 
 pub type ShardIdentifier = H256;
 pub type BlockNumber = u32;
+pub type Amount = u128;
 pub type Header = HeaderG<BlockNumber, BlakeTwo256>;
 pub type Block = BlockG<Header, OpaqueExtrinsic>;
 pub type SignedBlock = SignedBlockG<Block>;
@@ -64,7 +65,7 @@ pub type MrEnclave = [u8; 32];
 pub type BlockHash = H256;
 
 pub type ConfirmCallFn = ([u8; 2], ShardIdentifier, H256, Vec<u8>);
-pub type ShieldFundsFn = ([u8; 2], Vec<u8>, u128, ShardIdentifier);
+pub type ShieldFundsFn = ([u8; 2], Vec<u8>, Amount, ShardIdentifier);
 pub type CallWorkerFn = ([u8; 2], Request);
 
 // Todo: move this improved enclave definition into a primitives crate in the pallet_teerex repo.

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "itp-settings",
  "itp-sgx-crypto",
  "itp-sgx-io",
+ "itp-stf-executor",
  "itp-stf-state-handler",
  "itp-storage",
  "itp-storage-verifier",
@@ -1261,6 +1262,25 @@ name = "itp-sgx-io"
 version = "0.8.0"
 dependencies = [
  "sgx_tstd",
+]
+
+[[package]]
+name = "itp-stf-executor"
+version = "0.8.0"
+dependencies = [
+ "ita-stf",
+ "itp-ocall-api",
+ "itp-stf-state-handler",
+ "itp-storage",
+ "itp-storage-verifier",
+ "itp-types",
+ "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "parity-scale-codec",
+ "sgx-externalities",
+ "sgx_tstd",
+ "sgx_types",
+ "sp-runtime",
+ "thiserror 1.0.9",
 ]
 
 [[package]]

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.19.0"
-source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
+source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.19.0"
-source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
+source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.19.0"
-source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
+source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
@@ -2437,7 +2437,7 @@ dependencies = [
 [[package]]
 name = "rustls"
 version = "0.19.0"
-source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
+source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -87,11 +87,12 @@ itp-settings = { path = "../core-primitives/settings" }
 itp-sgx-io = { path = "../core-primitives/sgx/io", default-features = false, features = ["sgx"] }
 itp-storage = { path = "../core-primitives/storage", default-features = false, features = ["sgx"] }
 itp-storage-verifier = { path = "../core-primitives/storage-verified", default-features = false }
-itp-sgx-crypto= { path = "../core-primitives/sgx/crypto", default-features = false, features = ["sgx"] }
+itp-sgx-crypto = { path = "../core-primitives/sgx/crypto", default-features = false, features = ["sgx"] }
+itp-stf-executor = { path = "../core-primitives/stf-executor", default-features = false, features = ["sgx"] }
 itp-stf-state-handler = { path = "../core-primitives/stf-state-handler", default-features = false, features = ["sgx"] }
 itp-teerex-storage = { path = "../core-primitives/teerex-storage", default-features = false }
 itp-test = { path = "../core-primitives/test", default-features = false, optional = true }
-itp-types = {path = "../core-primitives/types", default-features = false, features = ["sgx"] }
+itp-types = { path = "../core-primitives/types", default-features = false, features = ["sgx"] }
 its-sidechain = { path = "../sidechain/sidechain-crate", default-features = false, features = ["sgx"] }
 
 # substrate deps

--- a/enclave-runtime/src/error.rs
+++ b/enclave-runtime/src/error.rs
@@ -33,6 +33,7 @@ pub enum Error {
 	Consensus(its_sidechain::consensus_common::Error),
 	Stf(String),
 	StfStateHandler(itp_stf_state_handler::error::Error),
+	StfExecution(itp_stf_executor::error::Error),
 	MutexAccess,
 	Other(Box<dyn std::error::Error>),
 }

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -46,9 +46,8 @@ use crate::{
 use base58::ToBase58;
 use codec::{alloc::string::String, Decode, Encode};
 use ita_stf::{
-	stf_sgx::{shards_key_hash, storage_hashes_to_update_per_shard},
-	AccountId, Getter, ShardIdentifier, State as StfState, StatePayload, StateTypeDiff, Stf,
-	TrustedCall, TrustedCallSigned, TrustedGetterSigned,
+	hash::TrustedOperationOrHash, AccountId, Getter, ShardIdentifier, State as StfState,
+	StatePayload, Stf, TrustedCallSigned, TrustedGetterSigned,
 };
 use itc_direct_rpc_server::{
 	create_determine_watch, rpc_connection_registry::ConnectionRegistry,
@@ -73,13 +72,15 @@ use itp_sgx_io as io;
 use itp_sgx_io::SealedIO;
 use itp_stf_executor::{
 	executor::StfExecutor,
-	traits::{StatePostProcessing, StfExecuteShieldFunds, StfExecuteTrustedCall, StfUpdateState},
+	traits::{
+		StatePostProcessing, StfExecuteGenericUpdate, StfExecuteShieldFunds,
+		StfExecuteTimedCallsBatch, StfExecuteTrustedCall, StfUpdateState,
+	},
 };
 use itp_stf_state_handler::{
 	handle_state::HandleState, query_shard_state::QueryShardState, GlobalFileStateHandler,
 };
-use itp_storage::{StorageEntryVerified, StorageProof};
-use itp_storage_verifier::GetStorageVerified;
+use itp_storage::StorageProof;
 use itp_types::{Block, CallWorkerFn, Header, OpaqueCall, ShieldFundsFn, SignedBlock};
 use its_sidechain::{
 	primitives::{
@@ -90,23 +91,21 @@ use its_sidechain::{
 	state::{LastBlockExt, SidechainDB, SidechainState, SidechainSystemExt},
 	top_pool_rpc_author::{
 		global_author_container::GlobalAuthorContainer,
-		hash::TrustedOperationOrHash,
 		traits::{AuthorApi, GetAuthor, OnBlockCreated, SendState},
 	},
 };
 use lazy_static::lazy_static;
 use log::*;
-use sgx_externalities::SgxExternalitiesTrait;
+use sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 use sgx_types::sgx_status_t;
 use sp_core::{blake2_256, crypto::Pair, H256};
 use sp_finality_grandpa::VersionedAuthorityList;
 use sp_runtime::{
 	generic::SignedBlock as SignedBlockG,
-	traits::{Block as BlockT, Header as HeaderT, UniqueSaturatedInto},
+	traits::{Block as BlockT, Header as HeaderT},
 	MultiSignature, OpaqueExtrinsic,
 };
 use std::{
-	collections::HashMap,
 	slice,
 	string::ToString,
 	sync::{Arc, SgxRwLock},
@@ -164,7 +163,7 @@ pub unsafe extern "C" fn init() -> sgx_status_t {
 	env_logger::init();
 
 	if let Err(e) = ed25519::create_sealed_if_absent().map_err(Error::Crypto) {
-		return e.into()
+		return e.into();
 	}
 
 	let signer = match Ed25519Seal::unseal().map_err(Error::Crypto) {
@@ -174,13 +173,13 @@ pub unsafe extern "C" fn init() -> sgx_status_t {
 	info!("[Enclave initialized] Ed25519 prim raw : {:?}", signer.public().0);
 
 	if let Err(e) = rsa3072::create_sealed_if_absent() {
-		return e.into()
+		return e.into();
 	}
 
 	// create the aes key that is used for state encryption such that a key is always present in tests.
 	// It will be overwritten anyway if mutual remote attastation is performed with the primary worker
 	if let Err(e) = aes::create_sealed_if_absent().map_err(Error::Crypto) {
-		return e.into()
+		return e.into();
 	}
 
 	let state_handler = GlobalFileStateHandler;
@@ -210,8 +209,8 @@ pub unsafe extern "C" fn get_rsa_encryption_pubkey(
 		Ok(k) => k,
 		Err(x) => {
 			println!("[Enclave] can't serialize rsa_pubkey {:?} {}", rsa_pubkey, x);
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	let pubkey_slice = slice::from_raw_parts_mut(pubkey, pubkey_size as usize);
@@ -223,7 +222,7 @@ pub unsafe extern "C" fn get_rsa_encryption_pubkey(
 #[no_mangle]
 pub unsafe extern "C" fn get_ecc_signing_pubkey(pubkey: *mut u8, pubkey_size: u32) -> sgx_status_t {
 	if let Err(e) = ed25519::create_sealed_if_absent().map_err(Error::Crypto) {
-		return e.into()
+		return e.into();
 	}
 
 	let signer = match Ed25519Seal::unseal().map_err(Error::Crypto) {
@@ -265,9 +264,7 @@ pub unsafe extern "C" fn mock_register_enclave_xt(
 	let extrinsic_slice =
 		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
 
-	let mre = OcallApi
-		.get_mrenclave_of_self()
-		.map_or_else(|_| Vec::<u8>::new(), |m| m.m.encode());
+	let mre = OcallApi.get_mrenclave_of_self().map_or_else(|_| Vec::<u8>::new(), |m| m.m.encode());
 
 	let signer = Ed25519Seal::unseal().unwrap();
 	let call = ([TEEREX_MODULE, REGISTER_ENCLAVE], mre, url);
@@ -343,8 +340,8 @@ pub unsafe extern "C" fn call_rpc_methods(
 		Ok(req) => req,
 		Err(e) => {
 			error!("[SidechainRpc] FFI: Invalid utf8 request: {:?}", e);
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	let res = match side_chain_rpc_int::<Block, _>(request, OcallApi) {
@@ -405,7 +402,7 @@ pub unsafe extern "C" fn get_state(
 		debug!("verifying signature of TrustedGetterSigned");
 		if let false = trusted_getter_signed.verify_signature() {
 			error!("bad signature");
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
 		}
 	}
 
@@ -441,8 +438,8 @@ pub unsafe extern "C" fn init_direct_invocation_server(
 		Ok(s) => s,
 		Err(e) => {
 			error!("Decoding RPC server address failed. Error: {:?}", e);
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	let watch_extractor = Arc::new(create_determine_watch::<Hash>());
@@ -452,8 +449,8 @@ pub unsafe extern "C" fn init_direct_invocation_server(
 		Ok(k) => k,
 		Err(e) => {
 			error!("Failed to unseal shielding key: {:?}", e);
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	its_sidechain::top_pool_rpc_author::initializer::initialize_top_pool_rpc_author(
@@ -465,8 +462,8 @@ pub unsafe extern "C" fn init_direct_invocation_server(
 		Some(a) => a,
 		None => {
 			error!("Failed to retrieve global top pool author");
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	let io_handler = public_api_rpc_handler(rpc_author);
@@ -499,24 +496,24 @@ pub unsafe extern "C" fn init_light_client(
 		Ok(h) => h,
 		Err(e) => {
 			error!("Decoding Header failed. Error: {:?}", e);
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	let auth = match VersionedAuthorityList::decode(&mut auth) {
 		Ok(a) => a,
 		Err(e) => {
 			error!("Decoding VersionedAuthorityList failed. Error: {:?}", e);
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	let proof = match StorageProof::decode(&mut proof) {
 		Ok(h) => h,
 		Err(e) => {
 			error!("Decoding Header failed. Error: {:?}", e);
-			return sgx_status_t::SGX_ERROR_UNEXPECTED
-		},
+			return sgx_status_t::SGX_ERROR_UNEXPECTED;
+		}
 	};
 
 	match itc_light_client::io::read_or_init_validator::<Block>(header, auth, proof) {
@@ -529,7 +526,7 @@ pub unsafe extern "C" fn init_light_client(
 #[no_mangle]
 pub unsafe extern "C" fn execute_trusted_getters() -> sgx_status_t {
 	if let Err(e) = execute_top_pool_trusted_getters_on_all_shards() {
-		return e.into()
+		return e.into();
 	}
 
 	sgx_status_t::SGX_SUCCESS
@@ -562,8 +559,8 @@ fn execute_top_pool_trusted_getters_on_all_shards() -> Result<()> {
 			Some(t) => t,
 			None => {
 				info!("[Enclave] Could not execute trusted operations for all shards. Remaining number of shards: {}.", remaining_shards);
-				break
-			},
+				break;
+			}
 		};
 
 		match execute_top_pool_trusted_getters_on_shard(
@@ -572,7 +569,7 @@ fn execute_top_pool_trusted_getters_on_all_shards() -> Result<()> {
 			shard,
 			shard_exec_time,
 		) {
-			Ok(()) => {},
+			Ok(()) => {}
 			Err(e) => error!("Error in trusted getter execution for shard {:?}: {:?}", shard, e),
 		}
 
@@ -585,7 +582,7 @@ fn execute_top_pool_trusted_getters_on_all_shards() -> Result<()> {
 #[no_mangle]
 pub unsafe extern "C" fn execute_trusted_calls() -> sgx_status_t {
 	if let Err(e) = execute_top_pool_trusted_calls_internal::<Block>() {
-		return e.into()
+		return e.into();
 	}
 
 	sgx_status_t::SGX_SUCCESS
@@ -619,6 +616,7 @@ where
 	})?;
 
 	let state_handler = Arc::new(GlobalFileStateHandler);
+	let stf_executor = Arc::new(StfExecutor::new(Arc::new(OcallApi), state_handler.clone()));
 
 	let latest_onchain_header = validator.latest_finalized_header(validator.num_relays()).unwrap();
 
@@ -626,7 +624,7 @@ where
 	{
 		Some(slot) => {
 			let shards = state_handler.list_shards()?;
-			let env = ProposerFactory::new(Arc::new(OcallApi), rpc_author, state_handler);
+			let env = ProposerFactory::new(rpc_author, stf_executor);
 
 			exec_aura_on_slot::<_, _, SignedSidechainBlock, _, _, _>(
 				slot,
@@ -637,11 +635,11 @@ where
 				&mut nonce,
 				shards,
 			)?
-		},
+		}
 		None => {
 			debug!("No slot yielded. Skipping block production.");
-			return Ok(())
-		},
+			return Ok(());
+		}
 	};
 
 	LightClientSeal::seal(validator)?;
@@ -661,7 +659,7 @@ pub unsafe extern "C" fn sync_parentchain(
 	};
 
 	if let Err(e) = sync_parentchain_internal::<Block>(blocks_to_sync, *nonce) {
-		return e.into()
+		return e.into();
 	}
 
 	sgx_status_t::SGX_SUCCESS
@@ -685,7 +683,7 @@ where
 
 	let mut validator = LightClientSeal::<PB>::unseal()?;
 	let mut nonce = NONCE.write().expect("Encountered poisoned NONCE lock");
-	let stf_executor = StfExecutor::new(Arc::new(OcallApi), GlobalFileStateHandler);
+	let stf_executor = StfExecutor::new(Arc::new(OcallApi), Arc::new(GlobalFileStateHandler));
 
 	sync_blocks_on_light_client(
 		blocks_to_sync,
@@ -712,16 +710,15 @@ where
 	PB: BlockT<Hash = H256>,
 	NumberFor<PB>: BlockNumberOps,
 	V: Validator<PB> + LightClientState<PB>,
-	OCallApi: EnclaveOnChainOCallApi,
+	OCallApi: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
 	StfExecutor: StfUpdateState + StfExecuteTrustedCall + StfExecuteShieldFunds,
 {
 	let mut calls = Vec::<OpaqueCall>::new();
+	let mrenclave: ShardIdentifier = on_chain_ocall_api.get_mrenclave_of_self()?.m.into();
 
 	debug!("Syncing light client!");
 	for signed_block in blocks_to_sync.into_iter() {
-		validator
-			.check_xt_inclusion(validator.num_relays(), &signed_block.block)
-			.unwrap(); // panic can only happen if relay_id does not exist
+		validator.check_xt_inclusion(validator.num_relays(), &signed_block.block).unwrap(); // panic can only happen if relay_id does not exist
 
 		if let Err(e) = validator.submit_simple_header(
 			validator.num_relays(),
@@ -729,12 +726,12 @@ where
 			signed_block.justifications.clone(),
 		) {
 			error!("Block verification failed. Error : {:?}", e);
-			return Err(e.into())
+			return Err(e.into());
 		}
 
 		if let Err(e) = stf_executor.update_states::<PB>(&signed_block.block.header()) {
 			error!("Error performing state updates upon block import");
-			return Err(e.into())
+			return Err(e.into());
 		}
 
 		// execute indirect calls, incl. shielding and unshielding
@@ -747,7 +744,6 @@ where
 		// compose indirect block confirmation
 		// should be changed to ParentchainBlockProcessed, see worker issue #457
 		let xt_block = [TEEREX_MODULE, BLOCK_CONFIRMED];
-		let mrenclave: ShardIdentifier = on_chain_ocall_api.get_mrenclave_of_self()?.m.into();
 		let block_hash = signed_block.block.header().hash();
 		let prev_state_hash = signed_block.block.header().parent_hash();
 		calls.push(OpaqueCall::from_tuple(&(
@@ -804,10 +800,10 @@ where
 ///
 /// Todo: This will probably be used again if we decide to make sidechain optional?
 #[allow(unused)]
-fn execute_top_pool_trusted_calls_for_all_shards<PB, SB, OCallApi, RpcAuthor, StateHandler>(
-	ocall_api: &OCallApi,
+fn execute_top_pool_trusted_calls_for_all_shards<PB, SB, RpcAuthor, StateHandler, StfExecutor>(
 	rpc_author: &RpcAuthor,
 	state_handler: &StateHandler,
+	stf_executor: &StfExecutor,
 	latest_onchain_header: &PB::Header,
 	max_exec_duration: Duration,
 ) -> Result<(Vec<OpaqueCall>, Vec<SB>)>
@@ -815,10 +811,11 @@ where
 	PB: BlockT<Hash = H256>,
 	SB: SignedBlockT<Public = sp_core::ed25519::Public, Signature = MultiSignature>,
 	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
-	OCallApi: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
 	RpcAuthor:
 		AuthorApi<H256, PB::Hash> + SendState<Hash = PB::Hash> + OnBlockCreated<Hash = PB::Hash>,
-	StateHandler: HandleState + QueryShardState,
+	StateHandler: QueryShardState,
+	StfExecutor: StfExecuteTimedCallsBatch<Externalities = SgxExternalities>
+		+ StfExecuteGenericUpdate<Externalities = SgxExternalities>,
 {
 	let shards = state_handler.list_shards()?;
 	let mut calls: Vec<OpaqueCall> = Vec::new();
@@ -835,14 +832,13 @@ where
 			Some(t) => t,
 			None => {
 				info!("[Enclave] Could not execute trusted operations for all shards. Remaining shards: {}.", remaining_shards);
-				break
-			},
+				break;
+			}
 		};
 
-		match execute_top_pool_trusted_calls::<PB, SB, _, _, _>(
-			ocall_api,
+		match execute_top_pool_trusted_calls::<PB, SB, _, _>(
 			rpc_author,
-			state_handler,
+			stf_executor,
 			&latest_onchain_header,
 			shard,
 			shard_exec_time,
@@ -852,7 +848,7 @@ where
 				if let Some(sb) = sb {
 					signed_blocks.push(sb);
 				}
-			},
+			}
 			Err(e) => error!("Error in top execution for shard {:?}: {:?}", shard, e),
 		}
 
@@ -870,10 +866,9 @@ where
 ///
 /// Todo: This function does too much, but it needs anyhow some refactoring here to make the code
 /// more readable.
-fn execute_top_pool_trusted_calls<PB, SB, OCallApi, RpcAuthor, StateHandler>(
-	on_chain_ocall: &OCallApi,
+fn execute_top_pool_trusted_calls<PB, SB, RpcAuthor, StfExecutor>(
 	rpc_author: &RpcAuthor,
-	state_handler: &StateHandler,
+	stf_executor: &StfExecutor,
 	latest_onchain_header: &PB::Header,
 	shard: H256,
 	max_exec_duration: Duration,
@@ -882,12 +877,10 @@ where
 	PB: BlockT<Hash = H256>,
 	SB: SignedBlockT<Public = sp_core::ed25519::Public, Signature = MultiSignature>,
 	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
-	OCallApi: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
 	RpcAuthor: AuthorApi<H256, PB::Hash> + OnBlockCreated<Hash = PB::Hash>,
-	StateHandler: HandleState,
+	StfExecutor: StfExecuteTimedCallsBatch<Externalities = SgxExternalities>
+		+ StfExecuteGenericUpdate<Externalities = SgxExternalities>,
 {
-	let ends_at = duration_now() + max_exec_duration;
-
 	// retrieve trusted operations from pool
 	let trusted_calls = rpc_author.get_pending_tops_separated(shard)?.0;
 
@@ -906,54 +899,31 @@ where
 		debug!("Got following trusted calls from pool: {:?}", trusted_calls);
 	}
 
-	let mut calls = Vec::<OpaqueCall>::new();
-	let mut call_hashes = Vec::<H256>::new();
+	let execution_result = stf_executor.execute_timed_calls_batch::<PB, _>(
+		&trusted_calls,
+		latest_onchain_header,
+		&shard,
+		max_exec_duration,
+		|s| {
+			let mut sidechain_db = SidechainDB::<SB::Block, _>::new(s);
+			sidechain_db.set_block_number(&sidechain_db.get_block_number().map_or(1, |n| n + 1));
+			sidechain_db.set_timestamp(&now_as_u64());
+			sidechain_db.ext
+		},
+	)?;
 
-	// load state before executing any calls
-	let (mut sidechain_db, state_lock) = state_handler
-		.load_for_mutation(&shard)
-		.map(|(l, s)| (SidechainDB::<SB::Block, _>::new(s), l))?;
+	let mut extrinsic_callbacks = execution_result.get_extrinsic_callbacks();
+	let call_hashes =
+		execution_result.get_all_execution_hashes().iter().map(|eh| eh.operation_hash).collect();
 
-	let prev_state_hash = sidechain_db.state_hash();
-	trace!("state apriori hash: {:?}", prev_state_hash);
-
-	// update state needed for pallets
-	sidechain_db.set_block_number(&sidechain_db.get_block_number().map_or(1, |n| n + 1));
-	sidechain_db.set_timestamp(&now_as_u64());
-
-	// retrieve trusted operations from pool
-	let trusted_calls = rpc_author.get_pending_tops_separated(shard)?.0;
-
-	debug!("Got following trusted calls from pool: {:?}", trusted_calls);
-	// call execution
-	for trusted_call_signed in trusted_calls.into_iter() {
-		match handle_trusted_worker_call::<PB, _>(
-			&mut calls,
-			&mut sidechain_db.ext,
-			&trusted_call_signed,
-			latest_onchain_header,
-			shard,
-			on_chain_ocall,
-		) {
-			Ok(hashes) => {
-				if let Some((_, op_hash)) = hashes {
-					call_hashes.push(op_hash)
-				}
-				rpc_author
-					.remove_top(
-						vec![top_or_hash(trusted_call_signed, true)],
-						shard,
-						hashes.is_some(),
-					)
-					.unwrap();
-			},
-			Err(e) =>
-				error!("Error performing worker call (will not push top hash): Error: {:?}", e),
-		};
-		// Check time
-		if ends_at < duration_now() {
-			break
-		}
+	for executed_operation in execution_result.executed_operations.iter() {
+		rpc_author
+			.remove_top(
+				vec![executed_operation.trusted_operation_or_hash.clone()],
+				shard,
+				executed_operation.is_success(),
+			)
+			.unwrap();
 	}
 
 	// Todo: this function should return here. Composing the block should be done by the caller.
@@ -962,32 +932,29 @@ where
 		latest_onchain_header,
 		call_hashes,
 		shard,
-		prev_state_hash,
-		&mut sidechain_db,
+		execution_result.previous_state_hash,
+		stf_executor,
 	) {
 		Ok((block_confirm, signed_block)) => {
-			calls.push(block_confirm);
+			extrinsic_callbacks.push(block_confirm);
 
 			// Notify watching clients of InSidechainBlock
 			let block = signed_block.block();
 			rpc_author.on_block_created(block.signed_top_hashes(), block.hash());
 
 			Some(signed_block)
-		},
+		}
 		Err(e) => {
 			error!("Could not compose block confirmation: {:?}", e);
 			None
-		},
+		}
 	};
-
-	// save updated state after call executions
-	let _hash = state_handler.write(sidechain_db.ext, state_lock, &shard)?;
 
 	if block.is_none() {
 		info!("[Enclave] did not produce a block for shard {:?}", shard);
 	}
 
-	Ok((calls, block))
+	Ok((extrinsic_callbacks, block))
 }
 
 /// Execute pending trusted getters for the `shard` until `max_exec_duration` is reached.
@@ -1008,7 +975,7 @@ where
 
 	// return early if we have no trusted getters, so we don't decrypt the state unnecessarily
 	if trusted_getters.is_empty() {
-		return Ok(())
+		return Ok(());
 	}
 
 	// load state once per shard
@@ -1029,10 +996,10 @@ where
 					Ok(_) => trace!("Successfully updated client"),
 					Err(e) => error!("Could not send state to client {:?}", e),
 				}
-			},
+			}
 			Err(e) => {
 				error!("failed to get stf state, skipping trusted getter ({:?})", e);
-			},
+			}
 		};
 
 		// remove getter from pool
@@ -1044,7 +1011,7 @@ where
 
 		// Check time
 		if ends_at < duration_now() {
-			return Ok(())
+			return Ok(());
 		}
 	}
 
@@ -1061,7 +1028,7 @@ fn get_stf_state(
 ) -> Result<Option<Vec<u8>>> {
 	debug!("verifying signature of TrustedGetterSigned");
 	if let false = trusted_getter_signed.verify_signature() {
-		return Err(Error::Stf("bad signature".to_string()))
+		return Err(Error::Stf("bad signature".to_string()));
 	}
 
 	debug!("calling into STF to get state");
@@ -1069,57 +1036,67 @@ fn get_stf_state(
 }
 
 /// Composes a sidechain block of a shard
-fn compose_block_and_confirmation<PB, SB, SidechainDB>(
+fn compose_block_and_confirmation<PB, SB, StfExecutor>(
 	latest_onchain_header: &PB::Header,
 	top_call_hashes: Vec<H256>,
 	shard: ShardIdentifier,
 	state_hash_apriori: H256,
-	db: &mut SidechainDB,
+	stf_executor: &StfExecutor,
 ) -> Result<(OpaqueCall, SB)>
 where
 	PB: BlockT<Hash = H256>,
 	SB: SignedBlockT<Public = sp_core::ed25519::Public, Signature = MultiSignature>,
 	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
-	SidechainDB: LastBlockExt<SB::Block> + SidechainState<Hash = H256>,
+	StfExecutor: StfExecuteGenericUpdate<Externalities = SgxExternalities>,
 {
 	let signer_pair = Ed25519Seal::unseal()?;
-	let state_hash_new = db.state_hash();
 
-	let (block_number, parent_hash) = match db.get_last_block() {
-		Some(block) => (block.block_number() + 1, block.hash()),
-		None => {
-			info!("Seems to be first sidechain block.");
-			(1, Default::default())
-		},
-	};
+	let author_public = signer_pair.public();
+	let (block, state_hash_new) = stf_executor.execute_update(&shard, |state| {
+		let mut db = SidechainDB::<SB::Block, _>::new(state);
+		let state_hash_new = db.state_hash();
 
-	if block_number != db.get_block_number().unwrap_or(0) {
-		return Err(Error::Other("[Sidechain] BlockNumber is not LastBlock's Number + 1".into()))
-	}
+		let (block_number, parent_hash) = match db.get_last_block() {
+			Some(block) => (block.block_number() + 1, block.hash()),
+			None => {
+				info!("Seems to be first sidechain block.");
+				(1, Default::default())
+			}
+		};
 
-	// create encrypted payload
-	let mut payload: Vec<u8> =
-		StatePayload::new(state_hash_apriori, state_hash_new, db.ext().state_diff().clone())
-			.encode();
-	AesSeal::unseal().map(|key| key.encrypt(&mut payload))??;
+		if block_number != db.get_block_number().unwrap_or(0) {
+			return Err(Error::Other(
+				"[Sidechain] BlockNumber is not LastBlock's Number + 1".into(),
+			));
+		}
 
-	let block = SB::Block::new(
-		signer_pair.public(),
-		block_number,
-		parent_hash,
-		latest_onchain_header.hash(),
-		shard,
-		top_call_hashes,
-		payload,
-		now_as_u64(),
-	);
+		// create encrypted payload
+		let mut payload: Vec<u8> =
+			StatePayload::new(state_hash_apriori, state_hash_new, db.ext().state_diff().clone())
+				.encode();
+		AesSeal::unseal().map(|key| key.encrypt(&mut payload))??;
+
+		let block = SB::Block::new(
+			author_public,
+			block_number,
+			parent_hash,
+			latest_onchain_header.hash(),
+			shard,
+			top_call_hashes,
+			payload,
+			now_as_u64(),
+		);
+
+		db.set_last_block(&block);
+
+		// state diff has been written to block, clean it for the next block.
+		db.ext_mut().prune_state_diff();
+
+		Ok((db.ext, block))
+	})?;
 
 	let block_hash = block.hash();
 	debug!("Block hash {}", block_hash);
-	db.set_last_block(&block);
-
-	// state diff has been written to block, clean it for the next block.
-	db.ext_mut().prune_state_diff();
 
 	let xt_block = [TEEREX_MODULE, BLOCK_CONFIRMED];
 	let opaque_call =
@@ -1163,7 +1140,7 @@ where
 						&mut opaque_calls,
 						&decrypted_trusted_call,
 						&block.header(),
-						shard,
+						&shard,
 						StatePostProcessing::Prune, // we only want to store the state diff for direct stuff.
 					) {
 						error!("Error executing trusted call: Error: {:?}", e);
@@ -1200,8 +1177,8 @@ where
 		Ok(h) => h,
 		Err(e) => {
 			error!("Error executing shield funds. Error: {:?}", e);
-			return Ok(())
-		},
+			return Ok(());
+		}
 	};
 
 	let xt_call = [TEEREX_MODULE, CALL_CONFIRMED];
@@ -1229,60 +1206,4 @@ fn decrypt_unchecked_extrinsic(
 	let request_vec = Rsa3072Seal::unseal().map(|key| key.decrypt(&cyphertext))??;
 
 	Ok(TrustedCallSigned::decode(&mut request_vec.as_slice()).map(|call| (call, shard))?)
-}
-
-fn handle_trusted_worker_call<PB, O>(
-	calls: &mut Vec<OpaqueCall>,
-	state: &mut StfState,
-	stf_call_signed: &TrustedCallSigned,
-	header: &PB::Header,
-	shard: ShardIdentifier,
-	on_chain_ocall_api: &O,
-) -> Result<Option<(H256, H256)>>
-where
-	PB: BlockT<Hash = H256>,
-	O: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
-{
-	debug!("query mrenclave of self");
-	let mrenclave = on_chain_ocall_api.get_mrenclave_of_self()?;
-	debug!("MRENCLAVE of self is {}", mrenclave.m.to_base58());
-
-	if let false = stf_call_signed.verify_signature(&mrenclave.m, &shard) {
-		error!("TrustedCallSigned: bad signature");
-		// do not panic here or users will be able to shoot workers dead by supplying a bad signature
-		return Ok(None)
-	}
-
-	// Necessary because light client sync may not be up to date
-	// see issue #208
-	debug!("Update STF storage!");
-	let storage_hashes = Stf::get_storage_hashes_to_update(&stf_call_signed);
-	let update_map = on_chain_ocall_api
-		.get_multiple_storages_verified(storage_hashes, header)
-		.map(into_map)?;
-	Stf::update_storage(state, &update_map.into());
-
-	debug!("execute STF");
-	if let Err(e) = Stf::execute(state, stf_call_signed.clone(), calls) {
-		error!("Error performing Stf::execute. Error: {:?}", e);
-		return Ok(None)
-	}
-
-	let call_hash = blake2_256(&stf_call_signed.encode());
-	let operation = stf_call_signed.clone().into_trusted_operation(true);
-	let operation_hash = blake2_256(&operation.encode());
-	debug!("Operation hash {:?}", operation_hash);
-	debug!("Call hash {:?}", call_hash);
-
-	Ok(Some((H256::from(call_hash), H256::from(operation_hash))))
-}
-
-fn into_map(
-	storage_entries: Vec<StorageEntryVerified<Vec<u8>>>,
-) -> HashMap<Vec<u8>, Option<Vec<u8>>> {
-	storage_entries.into_iter().map(|e| e.into_tuple()).collect()
-}
-
-fn top_or_hash<H>(tcs: TrustedCallSigned, direct: bool) -> TrustedOperationOrHash<H> {
-	TrustedOperationOrHash::<H>::Operation(tcs.into_trusted_operation(direct))
 }

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -918,7 +918,8 @@ where
 	)?;
 
 	let mut extrinsic_callbacks = batch_execution_result.get_extrinsic_callbacks();
-	let call_hashes = batch_execution_result.get_executed_call_hashes().iter().copied().collect();
+	let executed_operation_hashes =
+		batch_execution_result.get_executed_operation_hashes().iter().copied().collect();
 
 	for executed_operation in batch_execution_result.executed_operations.iter() {
 		rpc_author
@@ -934,7 +935,7 @@ where
 	// create new block (side-chain)
 	let block = match compose_block_and_confirmation::<PB, SB, _>(
 		latest_onchain_header,
-		call_hashes,
+		executed_operation_hashes,
 		shard,
 		batch_execution_result.previous_state_hash,
 		stf_executor,

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -918,11 +918,7 @@ where
 	)?;
 
 	let mut extrinsic_callbacks = batch_execution_result.get_extrinsic_callbacks();
-	let call_hashes = batch_execution_result
-		.get_executed_operation_hashes()
-		.iter()
-		.map(|eh| eh.operation_hash)
-		.collect();
+	let call_hashes = batch_execution_result.get_executed_call_hashes().iter().copied().collect();
 
 	for executed_operation in batch_execution_result.executed_operations.iter() {
 		rpc_author

--- a/enclave-runtime/src/sidechain_impl.rs
+++ b/enclave-runtime/src/sidechain_impl.rs
@@ -213,7 +213,7 @@ where
 	SB: SignedBlock<Public = A::Public> + 'static,
 	SB::Block: SidechainBlockT<ShardIdentifier = H256>,
 	O: ValidateerFetch + GetStorageVerified + Send + Sync,
-	StateHandler: HandleState,
+	StateHandler: HandleState<StateT = SgxExternalities>,
 {
 	type Verifier = AuraVerifier<A, PB, SB, SidechainDB<SB::Block, SgxExternalities>, O>;
 	type SidechainState = SidechainDB<SB::Block, SgxExternalities>;

--- a/enclave-runtime/src/tests.rs
+++ b/enclave-runtime/src/tests.rs
@@ -57,7 +57,7 @@ use its_sidechain::{
 	},
 };
 use log::*;
-use sgx_externalities::SgxExternalitiesTrait;
+use sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 use sgx_tunittest::*;
 use sgx_types::size_t;
 use sp_core::{crypto::Pair, ed25519 as spEd25519, hashing::blake2_256, H256};
@@ -434,7 +434,9 @@ fn get_current_shard_index<StateHandler: QueryShardState>(
 }
 
 /// returns an empty `State` with the corresponding `ShardIdentifier`
-fn init_state<S: HandleState>(state_handler: &S) -> (State, ShardIdentifier) {
+fn init_state<S: HandleState<StateT = SgxExternalities>>(
+	state_handler: &S,
+) -> (State, ShardIdentifier) {
 	let shard = ShardIdentifier::default();
 
 	let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();

--- a/sidechain/state/src/lib.rs
+++ b/sidechain/state/src/lib.rs
@@ -49,7 +49,7 @@ use std::marker::PhantomData;
 /// Sidechain DB
 ///
 /// Todo: In the course of refactoring the STF (#269), verify if this struct is even needed.
-/// It might be that we could implement everithing directly on `[SgxExternalities]`.
+/// It might be that we could implement everything directly on `[SgxExternalities]`.
 #[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
 pub struct SidechainDB<Block, E> {
 	/// Externalities

--- a/sidechain/top-pool-rpc-author/src/author.rs
+++ b/sidechain/top-pool-rpc-author/src/author.rs
@@ -21,12 +21,11 @@ use crate::sgx_reexport_prelude::*;
 use crate::{
 	client_error::Error as ClientError,
 	error::{Error as StateRpcError, Result},
-	hash,
 	top_filter::{AllowAllTopsFilter, Filter},
 	traits::{AuthorApi, OnBlockCreated, SendState},
 };
 use codec::{Decode, Encode};
-use ita_stf::{Getter, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
+use ita_stf::{hash, Getter, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_sgx_crypto::ShieldingCrypto;
 use itp_stf_state_handler::query_shard_state::QueryShardState;
 use itp_types::{BlockHash as SidechainBlockHash, ShardIdentifier};

--- a/sidechain/top-pool-rpc-author/src/lib.rs
+++ b/sidechain/top-pool-rpc-author/src/lib.rs
@@ -37,7 +37,6 @@ pub mod author;
 pub mod author_container;
 pub mod client_error;
 pub mod error;
-pub mod hash;
 pub mod pool_types;
 pub mod top_filter;
 pub mod traits;

--- a/sidechain/top-pool-rpc-author/src/traits.rs
+++ b/sidechain/top-pool-rpc-author/src/traits.rs
@@ -18,8 +18,8 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 use crate::sgx_reexport_prelude::*;
 
-use crate::{error::Result, hash};
-use ita_stf::{TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
+use crate::error::Result;
+use ita_stf::{hash, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_types::{BlockHash as SidechainBlockHash, ShardIdentifier, H256};
 use its_top_pool::primitives::PoolFuture;
 use jsonrpc_core::Error as RpcError;


### PR DESCRIPTION
A further refactoring step towards #301 . This time I extracted code from the `enclave-runtime` that is related to executing logic on the STF. This includes:
* Trusted calls
* Trusted getters
* General state updates
* Block updates

The main motivation for separating this code to a separate crate, is that the `sidechain` components use it, and it's the reason why we still have quite a bit of `sidechain` implementation in the `enclave-runtime` instead of the `sidechain` crate.

The extracted code has not been much beautified or re-designed, it's mostly moved in its original state. I mention this, because there are certainly quite a few improvements that could be done on those parts of the code (that now reside in `stf-executor`). But in order to move along and get to the end-goal (#301), I leave it as-is for now.