### PR TITLE
Upgrade to teaclave 1.1.4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Enclave # Enclave is separate as it's not in the workspace
         run: cd enclave-runtime && cargo clippy -- -D warnings
 
-      - name: Fail-fast; cancel other jobs
-        if: failure()
-        uses: andymckay/cancel-action@0.2
+      # - name: Fail-fast; cancel other jobs
+      #   if: failure()
+      #   uses: andymckay/cancel-action@0.2
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Enclave # Enclave is separate as it's not in the workspace
         run: cd enclave-runtime && cargo clippy -- -D warnings
 
-      # - name: Fail-fast; cancel other jobs
-      #   if: failure()
-      #   uses: andymckay/cancel-action@0.2
+      - name: Fail-fast; cancel other jobs
+        if: failure()
+        uses: andymckay/cancel-action@0.2
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell 1.8.0",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "approx"
@@ -143,9 +143,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
@@ -154,8 +154,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -183,9 +183,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -264,7 +264,7 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "proc-macro2",
- "quote 1.0.9",
+ "quote 1.0.10",
  "regex 1.5.4",
  "rustc-hash",
  "shlex",
@@ -369,9 +369,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "memchr 2.4.1",
 ]
@@ -387,15 +387,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
 
 [[package]]
 name = "byte-tools"
@@ -431,6 +431,14 @@ checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
  "byteorder 1.4.3",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bytes"
+version = "0.5.4"
+source = "git+https://github.com/mesalock-linux/bytes-sgx#63d1951a35f2e888696aba3796aac45214e727ec"
+dependencies = [
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -476,14 +484,14 @@ dependencies = [
  "semver 0.11.0",
  "semver-parser 0.10.2",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 dependencies = [
  "jobserver",
 ]
@@ -544,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
 dependencies = [
  "glob",
  "libc",
@@ -589,17 +597,17 @@ dependencies = [
 
 [[package]]
 name = "common-multipart-rfc7578"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64850de981e336e6b40957ca8146256c29b250f0104245efd1b614a75c0bcb2c"
+checksum = "76d0a7a42b9c13f2b2a1a7e64b949a19bcb56a49b190076e60261001ceaa5304"
 dependencies = [
  "bytes 1.1.0",
  "futures 0.3.17",
- "http 0.2.4",
+ "http 0.2.5",
  "mime",
  "mime_guess",
  "rand 0.8.4",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -616,9 +624,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -626,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -744,9 +752,9 @@ checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.9",
+ "quote 1.0.10",
  "rustc_version 0.3.3",
- "syn 1.0.75",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -842,8 +850,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -871,7 +879,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
@@ -951,8 +959,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]
 
@@ -1114,7 +1122,7 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "serde 1.0.130",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -1134,8 +1142,8 @@ dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1146,8 +1154,8 @@ dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1156,8 +1164,8 @@ version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1321,8 +1329,8 @@ source = "git+https://github.com/mesalock-linux/futures-rs-sgx#d54882f24ddf7d613
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1334,8 +1342,8 @@ dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1408,7 +1416,7 @@ dependencies = [
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
- "slab 0.4.4",
+ "slab 0.4.5",
 ]
 
 [[package]]
@@ -1423,7 +1431,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d00328cedcac5e81c683e5620ca6a30756fc23027ebf9bff405c0e8da1fbb7e"
 dependencies = [
- "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
@@ -1432,7 +1440,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
- "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
@@ -1441,7 +1449,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
- "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
  "version_check",
 ]
 
@@ -1453,7 +1461,7 @@ checksum = "e4ac03428b3276fc7f1756eba0c76c7c0c91ef77e1c43fbdd47a460238419cb9"
 dependencies = [
  "num-traits 0.2.14",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
 ]
 
 [[package]]
@@ -1474,8 +1482,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1491,9 +1501,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
@@ -1516,18 +1526,18 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f3675cfef6a30c8031cf9e6493ebdc3bb3272a3fea3923c4210d1830e6a472"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes 1.1.0",
  "fnv 1.0.7",
  "futures-core 0.3.17",
  "futures-sink 0.3.17",
  "futures-util 0.3.17",
- "http 0.2.4",
+ "http 0.2.5",
  "indexmap",
- "slab 0.4.4",
+ "slab 0.4.5",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1575,8 +1585,8 @@ dependencies = [
 
 [[package]]
 name = "hashbrown_tstd"
-version = "0.9.0"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "0.11.2"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "heck"
@@ -1601,12 +1611,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex-literal"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e4590e13640f19f249fe3e4eca5113bc4289f2497710378190e7f4bd96f45b"
 
 [[package]]
 name = "hmac"
@@ -1652,6 +1656,17 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.2.1"
+source = "git+https://github.com/mesalock-linux/http-sgx?tag=sgx_1.1.3#62544a1833f98f1810a44877c5f1efe45f5327c0"
+dependencies = [
+ "bytes 0.5.4",
+ "fnv 1.0.6",
+ "itoa 0.4.5",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "http"
+version = "0.2.1"
 source = "git+https://github.com/integritee-network/http-sgx?branch=sgx-experimental#307b5421fb7a489a114bede0dc05c8d32b804f49"
 dependencies = [
  "bytes 1.0.1",
@@ -1662,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes 1.1.0",
  "fnv 1.0.7",
@@ -1673,12 +1688,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes 1.1.0",
- "http 0.2.4",
+ "http 0.2.5",
  "pin-project-lite",
 ]
 
@@ -1752,16 +1767,16 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.12"
+version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel 0.3.17",
  "futures-core 0.3.17",
  "futures-util 0.3.17",
  "h2",
- "http 0.2.4",
+ "http 0.2.5",
  "http-body",
  "httparse 1.5.1",
  "httpdate",
@@ -1776,14 +1791,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-multipart-rfc7578"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b747b453e4b4b43b37928c51c9b3d1c86f502dbabf9bf88f1a2e589f5a6eb"
+checksum = "3538ce6aeb81f7cd0d547a42435944d2283714a3f696630318bc47bd839fcfc9"
 dependencies = [
  "bytes 1.1.0",
  "common-multipart-rfc7578",
  "futures 0.3.17",
- "http 0.2.4",
+ "http 0.2.5",
  "hyper",
 ]
 
@@ -1820,13 +1835,13 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#30150b529af6da69d5183967261f45dbff349dcf"
 dependencies = [
  "base64 0.11.0",
  "chrono",
  "frame-support",
  "parity-scale-codec",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sp-core",
  "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=master)",
  "sp-std",
@@ -1851,7 +1866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches 0.1.9",
- "unicode-bidi 0.3.6",
+ "unicode-bidi 0.3.7",
  "unicode-normalization 0.1.19",
 ]
 
@@ -1880,8 +1895,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1896,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1947,7 +1962,7 @@ dependencies = [
  "primitive-types",
  "sc-keystore",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_crypto_helper",
  "sp-application-crypto",
  "sp-core",
@@ -1963,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "integritee-node-runtime"
 version = "0.9.3"
-source = "git+https://github.com/integritee-network/integritee-node?branch=master#cdd2ce5a3938b1a41cb0578d034f742d368bd963"
+source = "git+https://github.com/integritee-network/integritee-node?branch=master#6b3f13932775f71c414d02bed8abac808cb75f73"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1978,7 +1993,6 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-sudo",
- "pallet-teeracle",
  "pallet-teerex",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -2040,7 +2054,7 @@ dependencies = [
  "rust-crypto",
  "serde 1.0.130",
  "serde_derive 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
@@ -2050,7 +2064,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "substrate-api-client",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "tokio",
  "ws",
 ]
@@ -2082,13 +2096,13 @@ dependencies = [
  "dirs 3.0.2",
  "failure",
  "futures 0.3.17",
- "http 0.2.4",
+ "http 0.2.5",
  "hyper",
  "hyper-multipart-rfc7578",
  "hyper-tls",
  "parity-multiaddr",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "serde_urlencoded",
  "tokio",
  "tokio-util",
@@ -2138,15 +2152,15 @@ version = "0.8.0"
 dependencies = [
  "itc-tls-websocket-server",
  "itp-types",
- "jsonrpc-core 16.0.0",
  "jsonrpc-core 16.1.0",
+ "jsonrpc-core 18.0.0",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2158,7 +2172,6 @@ dependencies = [
  "finality-grandpa",
  "frame-system",
  "hash-db",
- "itp-ocall-api",
  "itp-settings",
  "itp-sgx-io",
  "itp-storage",
@@ -2172,7 +2185,7 @@ dependencies = [
  "sp-finality-grandpa",
  "sp-runtime",
  "sp-trie",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2181,16 +2194,16 @@ name = "itc-rest-client"
 version = "0.8.0"
 dependencies = [
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1",
- "http 0.2.4",
+ "http 0.2.1 (git+https://github.com/mesalock-linux/http-sgx?tag=sgx_1.1.3)",
+ "http 0.2.5",
  "http_req 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http_req 0.7.2 (git+https://github.com/mesalock-linux/http_req-sgx?tag=sgx_1.1.3)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_tstd",
  "sgx_types",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
  "url 2.1.1",
  "url 2.2.2",
@@ -2205,7 +2218,7 @@ dependencies = [
  "openssl",
  "parity-scale-codec",
  "serde_derive 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_crypto_helper",
  "url 2.2.2",
  "ws",
@@ -2223,7 +2236,7 @@ dependencies = [
  "jsonrpsee",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sp-core",
  "tokio",
 ]
@@ -2239,7 +2252,7 @@ dependencies = [
  "rustls 0.19.1",
  "sgx_tstd",
  "sgx_types",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
  "tungstenite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.14.0 (git+https://github.com/integritee-network/tungstenite-rs-sgx?branch=sgx-experimental)",
@@ -2292,14 +2305,14 @@ dependencies = [
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall",
  "parity-scale-codec",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
  "sp-core",
  "sp-finality-grandpa",
  "sp-runtime",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -2310,39 +2323,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "itp-extrinsics-factory"
-version = "0.8.0"
-dependencies = [
- "itp-nonce-cache",
- "itp-settings",
- "itp-types",
- "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec",
- "sgx_tstd",
- "sgx_types",
- "sp-core",
- "sp-runtime",
- "substrate-api-client",
- "thiserror 1.0.29",
- "thiserror 1.0.9",
-]
-
-[[package]]
-name = "itp-nonce-cache"
-version = "0.8.0"
-dependencies = [
- "lazy_static",
- "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_tstd",
- "thiserror 1.0.29",
- "thiserror 1.0.9",
-]
-
-[[package]]
 name = "itp-ocall-api"
 version = "0.8.0"
 dependencies = [
  "itp-types",
+ "its-primitives",
  "parity-scale-codec",
  "sgx_types",
  "sp-runtime",
@@ -2367,7 +2352,7 @@ dependencies = [
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
  "serde 1.0.130",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_crypto_helper",
  "sgx_rand",
  "sgx_tstd",
@@ -2380,26 +2365,6 @@ name = "itp-sgx-io"
 version = "0.8.0"
 dependencies = [
  "sgx_tstd",
-]
-
-[[package]]
-name = "itp-stf-executor"
-version = "0.8.0"
-dependencies = [
- "ita-stf",
- "itp-ocall-api",
- "itp-stf-state-handler",
- "itp-storage",
- "itp-storage-verifier",
- "itp-types",
- "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-scale-codec",
- "sgx-externalities",
- "sgx_tstd",
- "sgx_types",
- "sp-runtime",
- "thiserror 1.0.29",
- "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -2420,7 +2385,7 @@ dependencies = [
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2439,7 +2404,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-trie",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2500,7 +2465,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sgx_tstd",
  "sp-core",
  "sp-keyring",
@@ -2541,7 +2506,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sp-runtime",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2581,8 +2546,8 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-top-pool-rpc-author",
- "jsonrpc-core 16.0.0",
  "jsonrpc-core 16.1.0",
+ "jsonrpc-core 18.0.0",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2623,7 +2588,7 @@ dependencies = [
  "sp-io 4.0.0-dev (git+https://github.com/integritee-network/sgx-runtime?branch=master)",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2637,8 +2602,8 @@ dependencies = [
  "itc-direct-rpc-server",
  "itp-types",
  "its-primitives",
- "jsonrpc-core 16.0.0",
  "jsonrpc-core 16.1.0",
+ "jsonrpc-core 18.0.0",
  "linked-hash-map 0.5.2",
  "linked-hash-map 0.5.4",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2651,7 +2616,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2668,8 +2633,8 @@ dependencies = [
  "itp-test",
  "itp-types",
  "its-top-pool",
- "jsonrpc-core 16.0.0",
  "jsonrpc-core 16.1.0",
+ "jsonrpc-core 18.0.0",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "sgx_tcrypto_helper",
@@ -2677,7 +2642,7 @@ dependencies = [
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "thiserror 1.0.9",
 ]
 
@@ -2697,7 +2662,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -2711,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2726,19 +2691,6 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "jsonrpc-core"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a47c4c3ac843f9a4238943f97620619033dadef4b378cd1e8addd170de396b3"
-dependencies = [
- "futures 0.3.17",
- "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.130",
- "serde_derive 1.0.130",
- "serde_json 1.0.67",
-]
-
-[[package]]
-name = "jsonrpc-core"
 version = "16.1.0"
 source = "git+https://github.com/scs/jsonrpc?branch=no_std#694656d8153005de90c849fce2633586849846e4"
 dependencies = [
@@ -2748,6 +2700,21 @@ dependencies = [
  "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
  "sp-std",
+]
+
+[[package]]
+name = "jsonrpc-core"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
+dependencies = [
+ "futures 0.3.17",
+ "futures-executor 0.3.17",
+ "futures-util 0.3.17",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.130",
+ "serde_derive 1.0.130",
+ "serde_json 1.0.68",
 ]
 
 [[package]]
@@ -2779,8 +2746,8 @@ dependencies = [
  "jsonrpsee-utils",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.67",
- "thiserror 1.0.29",
+ "serde_json 1.0.68",
+ "thiserror 1.0.30",
  "url 2.2.2",
 ]
 
@@ -2799,9 +2766,9 @@ dependencies = [
  "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "socket2",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "tokio",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2815,8 +2782,8 @@ dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2832,9 +2799,9 @@ dependencies = [
  "hyper",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "soketto",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -2852,8 +2819,8 @@ dependencies = [
  "rand 0.8.4",
  "rustc-hash",
  "serde 1.0.130",
- "serde_json 1.0.67",
- "thiserror 1.0.29",
+ "serde_json 1.0.68",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -2871,9 +2838,9 @@ dependencies = [
  "rustls 0.19.1",
  "rustls-native-certs",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "soketto",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -2893,9 +2860,9 @@ dependencies = [
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "soketto",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2934,15 +2901,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "libloading"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2981,8 +2948,8 @@ dependencies = [
  "libsecp256k1-gen-genmult",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "sha2 0.9.6",
- "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.9.8",
+ "typenum",
 ]
 
 [[package]]
@@ -3227,15 +3194,15 @@ dependencies = [
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.2",
  "net2 0.2.37",
- "slab 0.4.4",
+ "slab 0.4.5",
  "winapi 0.2.8",
 ]
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3253,7 +3220,7 @@ dependencies = [
  "lazycell",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.23",
- "slab 0.4.4",
+ "slab 0.4.5",
 ]
 
 [[package]]
@@ -3300,8 +3267,8 @@ checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3344,8 +3311,8 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]
 
@@ -3364,7 +3331,7 @@ dependencies = [
  "rand 0.8.4",
  "rand_distr",
  "simba",
- "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum",
 ]
 
 [[package]]
@@ -3374,8 +3341,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3637,9 +3604,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr 2.4.1",
 ]
@@ -3675,9 +3642,6 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-dependencies = [
- "parking_lot 0.11.2",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -3693,9 +3657,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3713,9 +3677,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.66"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -3770,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#30150b529af6da69d5183967261f45dbff349dcf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3894,30 +3858,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-teeracle"
-version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "pallet-balances",
- "pallet-teerex",
- "pallet-timestamp",
- "parity-scale-codec",
- "sp-core",
- "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=master)",
- "sp-runtime",
- "sp-std",
- "substrate-fixed",
- "test-utils",
-]
-
-[[package]]
 name = "pallet-teerex"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#30150b529af6da69d5183967261f45dbff349dcf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3932,7 +3875,6 @@ dependencies = [
  "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=master)",
  "sp-runtime",
  "sp-std",
- "test-utils",
 ]
 
 [[package]]
@@ -3960,7 +3902,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "serde 1.0.130",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "sp-core",
  "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=master)",
  "sp-runtime",
@@ -4044,7 +3986,7 @@ version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
- "arrayvec 0.7.1",
+ "arrayvec 0.7.2",
  "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
@@ -4060,15 +4002,15 @@ checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "parity-util-mem"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad6f1acec69b95caf435bbd158d486e5a0a44fcf51531e84922c59ff09e8457"
+checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown 0.11.2",
@@ -4086,7 +4028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2",
- "syn 1.0.75",
+ "syn 1.0.81",
  "synstructure",
 ]
 
@@ -4159,7 +4101,7 @@ dependencies = [
  "cloudabi",
  "libc",
  "redox_syscall 0.1.57",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "winapi 0.3.9",
 ]
 
@@ -4173,7 +4115,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.10",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "winapi 0.3.9",
 ]
 
@@ -4253,8 +4195,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -4271,9 +4213,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
@@ -4282,9 +4224,9 @@ source = "git+https://github.com/mesalock-linux/cryptocorrosion-sgx#32d7de50b5f0
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "predicates"
@@ -4307,12 +4249,12 @@ checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd0fd014130206c9352efbdc92be592751b2b9274dff685348341082c6ea3d"
+checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
 dependencies = [
  "predicates-core",
- "treeline",
+ "termtree",
 ]
 
 [[package]]
@@ -4329,11 +4271,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "toml",
 ]
 
@@ -4345,8 +4287,8 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "version_check",
 ]
 
@@ -4357,7 +4299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
+ "quote 1.0.10",
  "version_check",
 ]
 
@@ -4375,9 +4317,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -4401,9 +4343,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -4515,7 +4457,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "ppv-lite86 0.2.10",
+ "ppv-lite86 0.2.15",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4535,7 +4477,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "ppv-lite86 0.2.10",
+ "ppv-lite86 0.2.15",
  "rand_core 0.6.3",
 ]
 
@@ -4583,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "rand_distr"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051b398806e42b9cd04ad9ec8f81e355d0a382c543ac6672c62f5a5b452ef142"
+checksum = "964d548f8e7d12e102ef183a0de7e98180c9f8729f555897a857b96e48122d2f"
 dependencies = [
  "num-traits 0.2.14",
  "rand 0.8.4",
@@ -4756,8 +4698,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5049,7 +4991,7 @@ dependencies = [
  "derive_more",
  "hex",
  "parking_lot 0.11.2",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
@@ -5077,8 +5019,8 @@ checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5267,8 +5209,8 @@ version = "1.0.118"
 source = "git+https://github.com/mesalock-linux/serde-sgx#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5278,8 +5220,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5306,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa 0.4.8",
  "ryu",
@@ -5375,13 +5317,13 @@ dependencies = [
 
 [[package]]
 name = "sgx_alloc"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_backtrace_sys"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "cc",
  "sgx_build_helper",
@@ -5390,13 +5332,13 @@ dependencies = [
 
 [[package]]
 name = "sgx_build_helper"
-version = "0.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_crypto_helper"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "itertools",
  "libc",
@@ -5414,21 +5356,21 @@ dependencies = [
 
 [[package]]
 name = "sgx_demangle"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_libc"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_types",
 ]
 
 [[package]]
 name = "sgx_rand"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_trts",
  "sgx_tstd",
@@ -5437,16 +5379,16 @@ dependencies = [
 
 [[package]]
 name = "sgx_serialize"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_tstd",
 ]
 
 [[package]]
 name = "sgx_serialize_derive"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "quote 0.3.15",
  "sgx_serialize_derive_internals",
@@ -5455,32 +5397,32 @@ dependencies = [
 
 [[package]]
 name = "sgx_serialize_derive_internals"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "syn 0.11.11",
 ]
 
 [[package]]
 name = "sgx_tcrypto"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_types",
 ]
 
 [[package]]
 name = "sgx_tcrypto_helper"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_crypto_helper",
 ]
 
 [[package]]
 name = "sgx_tprotected_fs"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_trts",
  "sgx_types",
@@ -5488,8 +5430,8 @@ dependencies = [
 
 [[package]]
 name = "sgx_trts"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_libc",
  "sgx_types",
@@ -5497,8 +5439,8 @@ dependencies = [
 
 [[package]]
 name = "sgx_tstd"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "hashbrown_tstd",
  "sgx_alloc",
@@ -5513,13 +5455,13 @@ dependencies = [
 
 [[package]]
 name = "sgx_types"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_ucrypto"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "libc",
  "rand_core 0.3.1",
@@ -5529,16 +5471,16 @@ dependencies = [
 
 [[package]]
 name = "sgx_unwind"
-version = "0.1.1"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_build_helper",
 ]
 
 [[package]]
 name = "sgx_urts"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "libc",
  "sgx_types",
@@ -5609,9 +5551,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
@@ -5622,9 +5564,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
@@ -5646,9 +5588,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "simba"
@@ -5672,9 +5614,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "slog"
@@ -5697,22 +5639,22 @@ dependencies = [
 [[package]]
 name = "smallvec"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "smallvec"
-version = "1.6.1"
 source = "git+https://github.com/mesalock-linux/rust-smallvec-sgx#b5925f10aa5bc3370a0fb339140ee063f5a888dd"
 dependencies = [
  "sgx_tstd",
 ]
 
 [[package]]
-name = "socket2"
-version = "0.4.1"
+name = "smallvec"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -5747,7 +5689,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-version",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -5758,8 +5700,8 @@ dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5828,7 +5770,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-version",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -5887,15 +5829,15 @@ dependencies = [
  "schnorrkel",
  "secrecy",
  "serde 1.0.130",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
  "sp-std",
  "sp-storage",
  "substrate-bip39",
- "thiserror 1.0.29",
- "tiny-bip39 0.8.0",
+ "thiserror 1.0.30",
+ "tiny-bip39 0.8.2",
  "tiny-keccak 2.0.2",
  "twox-hash",
  "wasmi",
@@ -5908,8 +5850,8 @@ version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -5951,7 +5893,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -6111,8 +6053,8 @@ dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -6149,13 +6091,13 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.2",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
  "sp-std",
  "sp-trie",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "tracing",
  "trie-db",
  "trie-root",
@@ -6192,7 +6134,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -6205,7 +6147,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "slog",
  "sp-std",
  "tracing",
@@ -6248,7 +6190,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -6258,8 +6200,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b829
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -6321,16 +6263,16 @@ checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "substrate-api-client"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#28c4977bcc65117a47993564996cb99da552bced"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#f9d3a773bb5c76a0c0689b012fc08599beb90ab7"
 dependencies = [
- "frame-metadata 14.0.0-dev",
+ "frame-metadata 14.0.0",
  "frame-support",
  "frame-system",
  "hex",
@@ -6340,14 +6282,14 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sp-application-crypto",
  "sp-core",
  "sp-rpc",
  "sp-runtime",
  "sp-std",
  "sp-version",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "ws",
 ]
 
@@ -6360,35 +6302,24 @@ dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
  "schnorrkel",
- "sha2 0.9.6",
+ "sha2 0.9.8",
  "zeroize",
 ]
 
 [[package]]
 name = "substrate-client-keystore"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#28c4977bcc65117a47993564996cb99da552bced"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#f9d3a773bb5c76a0c0689b012fc08599beb90ab7"
 dependencies = [
  "async-trait",
  "hex",
  "parking_lot 0.11.2",
  "sc-keystore",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",
  "sp-keystore",
-]
-
-[[package]]
-name = "substrate-fixed"
-version = "0.5.7"
-source = "git+https://github.com/encointer/substrate-fixed.git#2f353acee3c7cf7a386863a89fc6cb805048561f"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde 1.0.130",
- "typenum 1.14.0 (git+https://github.com/encointer/typenum)",
 ]
 
 [[package]]
@@ -6431,12 +6362,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
+ "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
 
@@ -6451,13 +6382,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "unicode-xid 0.2.2",
 ]
 
@@ -6499,13 +6430,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-utils"
-version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
-dependencies = [
- "hex-literal",
- "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+name = "termtree"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "textwrap"
@@ -6527,11 +6455,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
- "thiserror-impl 1.0.29",
+ "thiserror-impl 1.0.30",
 ]
 
 [[package]]
@@ -6540,19 +6468,19 @@ version = "1.0.9"
 source = "git+https://github.com/mesalock-linux/thiserror-sgx?tag=sgx_1.1.3#c2f806b88616e06aab0af770366a76885d974fdc"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -6600,9 +6528,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
+checksum = "ffc59cb9dfc85bb312c3a78fd6aa8a8582e310b0fa885d5bb877f6dcc601839d"
 dependencies = [
  "anyhow",
  "hmac 0.8.1",
@@ -6610,9 +6538,10 @@ dependencies = [
  "pbkdf2 0.4.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash",
- "sha2 0.9.6",
- "thiserror 1.0.29",
+ "sha2 0.9.8",
+ "thiserror 1.0.30",
  "unicode-normalization 0.1.19",
+ "wasm-bindgen",
  "zeroize",
 ]
 
@@ -6636,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.3.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
+checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6651,15 +6580,15 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",
  "libc",
  "memchr 2.4.1",
- "mio 0.7.13",
+ "mio 0.7.14",
  "num_cpus",
  "once_cell 1.8.0",
  "parking_lot 0.11.2",
@@ -6671,13 +6600,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -6703,9 +6632,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core 0.3.17",
  "pin-project-lite",
@@ -6714,9 +6643,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes 1.1.0",
  "futures-core 0.3.17",
@@ -6744,9 +6673,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -6756,20 +6685,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static",
 ]
@@ -6797,9 +6726,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.20"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9cbe87a2fa7e35900ce5de20220a582a9483a7063811defce79d7cbd59d4cfe"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -6807,21 +6736,15 @@ dependencies = [
  "matchers",
  "regex 1.5.4",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.68",
  "sharded-slab",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "thread_local 1.1.3",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
 ]
-
-[[package]]
-name = "treeline"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 
 [[package]]
 name = "trie-db"
@@ -6833,7 +6756,7 @@ dependencies = [
  "hashbrown 0.11.2",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
 ]
 
 [[package]]
@@ -6860,12 +6783,12 @@ dependencies = [
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.4.3",
  "bytes 1.1.0",
- "http 0.2.4",
+ "http 0.2.5",
  "httparse 1.5.1",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.8.4",
  "sha-1 0.9.8",
- "thiserror 1.0.29",
+ "thiserror 1.0.30",
  "url 2.2.2",
  "utf-8 0.7.6",
 ]
@@ -6878,7 +6801,7 @@ dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?tag=sgx_1.1.3)",
  "byteorder 1.3.4",
  "bytes 1.0.1",
- "http 0.2.1",
+ "http 0.2.1 (git+https://github.com/integritee-network/http-sgx?branch=sgx-experimental)",
  "httparse 1.4.1",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx?tag=sgx_1.1.3)",
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",
@@ -6898,20 +6821,20 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.6.5",
+ "cfg-if 0.1.10",
+ "rand 0.3.23",
  "static_assertions",
 ]
 
 [[package]]
 name = "typed-builder"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345426c7406aa355b60c5007c79a2d1f5b605540072795222f17f6443e6a9c6f"
+checksum = "a46ee5bd706ff79131be9c94e7edcb82b703c487766a114434e5790361cf08c5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -6919,14 +6842,6 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
-
-[[package]]
-name = "typenum"
-version = "1.14.0"
-source = "git+https://github.com/encointer/typenum#ec35bb80fcfb495de2e1f6966381c3f85e8a6509"
-dependencies = [
- "scale-info",
-]
 
 [[package]]
 name = "ucd-trie"
@@ -6975,16 +6890,16 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
 
 [[package]]
 name = "unicode-normalization"
 version = "0.1.12"
 source = "git+https://github.com/mesalock-linux/unicode-normalization-sgx#c1b030611969f87d75782c1df77975167cbbd509"
 dependencies = [
- "smallvec 1.6.1 (git+https://github.com/mesalock-linux/rust-smallvec-sgx)",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -7004,9 +6919,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -7128,9 +7043,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -7138,47 +7053,47 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
- "quote 1.0.9",
+ "quote 1.0.10",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.76"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "wasm-gc-api"
@@ -7193,9 +7108,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ee05bba3d1d994652079893941a2ef9324d2b58a63c31b40678fb7eddd7a5a"
+checksum = "ca00c5147c319a8ec91ec1a0edbec31e566ce2c9cc93b3f9bb86a9efd0eb795d"
 dependencies = [
  "downcast-rs",
  "libc",
@@ -7208,18 +7123,18 @@ dependencies = [
 
 [[package]]
 name = "wasmi-validation"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb8e860796d8be48efef530b60eebf84e74a88bce107374fffb0da97d504b8"
+checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
 dependencies = [
  "parity-wasm 0.42.2",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.53"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7350,7 +7265,7 @@ dependencies = [
  "openssl",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.2",
- "slab 0.4.4",
+ "slab 0.4.5",
  "url 2.2.2",
 ]
 
@@ -7378,22 +7293,22 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "approx"
@@ -484,14 +484,14 @@ dependencies = [
  "semver 0.11.0",
  "semver-parser 0.10.2",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 dependencies = [
  "jobserver",
 ]
@@ -1099,8 +1099,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/frame-metadata.git?branch=main#b5aceed422b7a361ce0bab00e18427d6c35c7607"
+version = "14.2.0"
+source = "git+https://github.com/paritytech/frame-metadata.git?branch=main#03b8afacfbdda61b2bd126dc8631a944b6a127ab"
 dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
@@ -1431,7 +1431,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d00328cedcac5e81c683e5620ca6a30756fc23027ebf9bff405c0e8da1fbb7e"
 dependencies = [
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1440,7 +1440,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1449,7 +1449,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check",
 ]
 
@@ -1461,7 +1461,7 @@ checksum = "e4ac03428b3276fc7f1756eba0c76c7c0c91ef77e1c43fbdd47a460238419cb9"
 dependencies = [
  "num-traits 0.2.14",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
 ]
 
 [[package]]
@@ -1611,6 +1611,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hmac"
@@ -1835,13 +1841,13 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#30150b529af6da69d5183967261f45dbff349dcf"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
 dependencies = [
  "base64 0.11.0",
  "chrono",
  "frame-support",
  "parity-scale-codec",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sp-core",
  "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=master)",
  "sp-std",
@@ -1881,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
  "serde 1.0.130",
 ]
@@ -1962,7 +1968,7 @@ dependencies = [
  "primitive-types",
  "sc-keystore",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_crypto_helper",
  "sp-application-crypto",
  "sp-core",
@@ -1978,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "integritee-node-runtime"
 version = "0.9.3"
-source = "git+https://github.com/integritee-network/integritee-node?branch=master#6b3f13932775f71c414d02bed8abac808cb75f73"
+source = "git+https://github.com/integritee-network/integritee-node?branch=master#cdd2ce5a3938b1a41cb0578d034f742d368bd963"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -1993,6 +1999,7 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-sudo",
+ "pallet-teeracle",
  "pallet-teerex",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -2054,7 +2061,7 @@ dependencies = [
  "rust-crypto",
  "serde 1.0.130",
  "serde_derive 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
@@ -2102,7 +2109,7 @@ dependencies = [
  "hyper-tls",
  "parity-multiaddr",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "serde_urlencoded",
  "tokio",
  "tokio-util",
@@ -2156,7 +2163,7 @@ dependencies = [
  "jsonrpc-core 18.0.0",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -2172,6 +2179,7 @@ dependencies = [
  "finality-grandpa",
  "frame-system",
  "hash-db",
+ "itp-ocall-api",
  "itp-settings",
  "itp-sgx-io",
  "itp-storage",
@@ -2200,7 +2208,7 @@ dependencies = [
  "http_req 0.7.2 (git+https://github.com/mesalock-linux/http_req-sgx?tag=sgx_1.1.3)",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_tstd",
  "sgx_types",
  "thiserror 1.0.30",
@@ -2218,7 +2226,7 @@ dependencies = [
  "openssl",
  "parity-scale-codec",
  "serde_derive 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_crypto_helper",
  "url 2.2.2",
  "ws",
@@ -2236,7 +2244,7 @@ dependencies = [
  "jsonrpsee",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sp-core",
  "tokio",
 ]
@@ -2305,7 +2313,7 @@ dependencies = [
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall",
  "parity-scale-codec",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
@@ -2323,11 +2331,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "itp-extrinsics-factory"
+version = "0.8.0"
+dependencies = [
+ "itp-nonce-cache",
+ "itp-settings",
+ "itp-types",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec",
+ "sgx_tstd",
+ "sgx_types",
+ "sp-core",
+ "sp-runtime",
+ "substrate-api-client",
+ "thiserror 1.0.30",
+ "thiserror 1.0.9",
+]
+
+[[package]]
+name = "itp-nonce-cache"
+version = "0.8.0"
+dependencies = [
+ "lazy_static",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_tstd",
+ "thiserror 1.0.30",
+ "thiserror 1.0.9",
+]
+
+[[package]]
 name = "itp-ocall-api"
 version = "0.8.0"
 dependencies = [
  "itp-types",
- "its-primitives",
  "parity-scale-codec",
  "sgx_types",
  "sp-runtime",
@@ -2352,7 +2388,7 @@ dependencies = [
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
  "serde 1.0.130",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_crypto_helper",
  "sgx_rand",
  "sgx_tstd",
@@ -2365,6 +2401,26 @@ name = "itp-sgx-io"
 version = "0.8.0"
 dependencies = [
  "sgx_tstd",
+]
+
+[[package]]
+name = "itp-stf-executor"
+version = "0.8.0"
+dependencies = [
+ "ita-stf",
+ "itp-ocall-api",
+ "itp-stf-state-handler",
+ "itp-storage",
+ "itp-storage-verifier",
+ "itp-types",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-scale-codec",
+ "sgx-externalities",
+ "sgx_tstd",
+ "sgx_types",
+ "sp-runtime",
+ "thiserror 1.0.30",
+ "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -2394,7 +2450,7 @@ name = "itp-storage"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "frame-metadata 14.0.0",
+ "frame-metadata 14.2.0",
  "frame-support",
  "hash-db",
  "parity-scale-codec",
@@ -2465,7 +2521,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sgx_tstd",
  "sp-core",
  "sp-keyring",
@@ -2714,7 +2770,7 @@ dependencies = [
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
  "serde_derive 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
 ]
 
 [[package]]
@@ -2746,7 +2802,7 @@ dependencies = [
  "jsonrpsee-utils",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "thiserror 1.0.30",
  "url 2.2.2",
 ]
@@ -2766,7 +2822,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "socket2",
  "thiserror 1.0.30",
  "tokio",
@@ -2799,7 +2855,7 @@ dependencies = [
  "hyper",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "soketto",
  "thiserror 1.0.30",
 ]
@@ -2819,7 +2875,7 @@ dependencies = [
  "rand 0.8.4",
  "rustc-hash",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "thiserror 1.0.30",
 ]
 
@@ -2838,7 +2894,7 @@ dependencies = [
  "rustls 0.19.1",
  "rustls-native-certs",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "soketto",
  "thiserror 1.0.30",
  "tokio",
@@ -2860,7 +2916,7 @@ dependencies = [
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hash",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "soketto",
  "thiserror 1.0.30",
  "tokio",
@@ -2901,15 +2957,15 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libloading"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf036d15402bea3c5d4de17b3fce76b3e4a56ebc1f577be0e7a72f7c607cf0"
+checksum = "afe203d669ec979b7128619bae5a63b7b42e9203c1b29146079ee05e2f604b52"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
@@ -2949,7 +3005,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
  "sha2 0.9.8",
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3331,7 +3387,7 @@ dependencies = [
  "rand 0.8.4",
  "rand_distr",
  "simba",
- "typenum",
+ "typenum 1.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3436,7 +3492,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.2",
+ "num-bigint 0.4.3",
  "num-complex 0.4.0",
  "num-integer 0.1.44",
  "num-iter 0.1.42",
@@ -3468,9 +3524,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer 0.1.44",
@@ -3568,7 +3624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg 1.0.1",
- "num-bigint 0.4.2",
+ "num-bigint 0.4.3",
  "num-integer 0.1.44",
  "num-traits 0.2.14",
 ]
@@ -3734,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#30150b529af6da69d5183967261f45dbff349dcf"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3858,9 +3914,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-teeracle"
+version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pallet-balances",
+ "pallet-teerex",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=master)",
+ "sp-runtime",
+ "sp-std",
+ "substrate-fixed",
+ "test-utils",
+]
+
+[[package]]
 name = "pallet-teerex"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=master#30150b529af6da69d5183967261f45dbff349dcf"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3875,6 +3952,7 @@ dependencies = [
  "sp-io 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=master)",
  "sp-runtime",
  "sp-std",
+ "test-utils",
 ]
 
 [[package]]
@@ -3976,7 +4054,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.130",
  "static_assertions",
- "unsigned-varint 0.7.0",
+ "unsigned-varint 0.7.1",
  "url 2.2.2",
 ]
 
@@ -4121,9 +4199,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pbkdf2"
@@ -4991,7 +5069,7 @@ dependencies = [
  "derive_more",
  "hex",
  "parking_lot 0.11.2",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
@@ -5248,9 +5326,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa 0.4.8",
  "ryu",
@@ -6147,7 +6225,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "slog",
  "sp-std",
  "tracing",
@@ -6272,7 +6350,7 @@ name = "substrate-api-client"
 version = "0.6.0"
 source = "git+https://github.com/scs/substrate-api-client?branch=master#f9d3a773bb5c76a0c0689b012fc08599beb90ab7"
 dependencies = [
- "frame-metadata 14.0.0",
+ "frame-metadata 14.2.0",
  "frame-support",
  "frame-system",
  "hex",
@@ -6282,7 +6360,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sp-application-crypto",
  "sp-core",
  "sp-rpc",
@@ -6315,11 +6393,22 @@ dependencies = [
  "hex",
  "parking_lot 0.11.2",
  "sc-keystore",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",
  "sp-keystore",
+]
+
+[[package]]
+name = "substrate-fixed"
+version = "0.5.7"
+source = "git+https://github.com/encointer/substrate-fixed.git#2f353acee3c7cf7a386863a89fc6cb805048561f"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.130",
+ "typenum 1.14.0 (git+https://github.com/encointer/typenum)",
 ]
 
 [[package]]
@@ -6434,6 +6523,15 @@ name = "termtree"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+
+[[package]]
+name = "test-utils"
+version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=master#2dbe761f0bb09fcb731e5ce16b25d6fff1b9e85b"
+dependencies = [
+ "hex-literal",
+ "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "textwrap"
@@ -6565,9 +6663,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6580,9 +6678,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.1.0",
@@ -6600,9 +6698,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.10",
@@ -6736,7 +6834,7 @@ dependencies = [
  "matchers",
  "regex 1.5.4",
  "serde 1.0.130",
- "serde_json 1.0.68",
+ "serde_json 1.0.70",
  "sharded-slab",
  "smallvec 1.7.0",
  "thread_local 1.1.3",
@@ -6822,7 +6920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.3.23",
+ "rand 0.6.5",
  "static_assertions",
 ]
 
@@ -6842,6 +6940,14 @@ name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
+
+[[package]]
+name = "typenum"
+version = "1.14.0"
+source = "git+https://github.com/encointer/typenum#ec35bb80fcfb495de2e1f6966381c3f85e8a6509"
+dependencies = [
+ "scale-info",
+]
 
 [[package]]
 name = "ucd-trie"
@@ -6943,9 +7049,9 @@ checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8d425fafb8cd76bc3f22aace4af471d3156301d7508f2107e98fbeae10bc7f"
+checksum = "d86a8dc7f45e4c1b0d30e43038c38f274e77af056aa5f74b93c2cf9eb3c1c836"
 
 [[package]]
 name = "untrusted"
@@ -7293,18 +7399,18 @@ checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "zeroize"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote 1.0.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ sgx_trts = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_trt
 sgx_types = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_types" }
 sgx_ucrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
 sgx_tcrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }
+sgx_tcrypto_helper = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tcrypto_helper" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,6 @@ members = [
     "sidechain/validateer-fetch",
 ]
 
-#[patch."https://github.com/integritee-network/pallet-teerex.git"]
-#pallet-teerex = { path = "../pallet-teerex" }
-
-
 #[patch."https://github.com/scs/substrate-api-client"]
 #substrate-api-client = { path = "../substrate-api-client" }
 #substrate-client-keystore = { path = "../substrate-api-client/client-keystore" }
@@ -50,3 +46,14 @@ members = [
 #sgx-runtime = { path = "../sgx-runtime/runtime", default-features = false}
 #sp-io = { path = "../sgx-runtime/substrate-sgx/sp-io", default-features = false, features = ["disable_oom", "disable_panic_handler", "disable_allocator", "sgx"]}
 #sgx-externalities = { path = "../sgx-runtime/substrate-sgx/externalities" }
+
+[patch."https://github.com/apache/teaclave-sgx-sdk.git"]
+sgx_tstd = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tstd" }
+sgx_alloc = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_alloc" }
+sgx_libc = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_libc" }
+sgx_serialize = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_serialize" }
+sgx_serialize_derive = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_serialize_derive" }
+sgx_serialize_derive_internals = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_serialize_derive_internals" }
+sgx_trts = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_trts" }
+sgx_types = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_types" }
+sgx_ucrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,4 @@ sgx_serialize_derive_internals = { version = "1.1.4", path = "../../incubator-te
 sgx_trts = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_trts" }
 sgx_types = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_types" }
 sgx_ucrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
+sgx_tcrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,15 +48,15 @@ members = [
 #sgx-externalities = { path = "../sgx-runtime/substrate-sgx/externalities" }
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
-sgx_tstd = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tstd" }
-sgx_alloc = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_alloc" }
-sgx_libc = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_libc" }
-sgx_serialize = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_serialize" }
-sgx_serialize_derive = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_serialize_derive" }
-sgx_serialize_derive_internals = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_serialize_derive_internals" }
-sgx_trts = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_trts" }
-sgx_types = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_types" }
-sgx_ucrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
-sgx_tcrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }
-sgx_tcrypto_helper = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tcrypto_helper" }
-sgx_crypto_helper = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_crypto_helper" }
+sgx_tstd = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_alloc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_libc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_serialize = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_serialize_derive = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_serialize_derive_internals = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_trts = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_types = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_ucrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_tcrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_tcrypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_crypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,4 @@ sgx_types = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_ty
 sgx_ucrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
 sgx_tcrypto = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }
 sgx_tcrypto_helper = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_tcrypto_helper" }
+sgx_crypto_helper = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_crypto_helper" }

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -43,7 +43,7 @@ base58 = { version = "0.1", optional = true }
 derive_more = { version = "0.99.5" }
 hex = { version = "0.4.2", optional = true }
 codec = { version = "2.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-sgx_tstd = { rev = "v1.1.3", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "v1.1.4-testing", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local crates
 itp-storage = { path = "../../core-primitives/storage", default-features = false }

--- a/app-libs/stf/src/cli.rs
+++ b/app-libs/stf/src/cli.rs
@@ -340,9 +340,7 @@ fn get_keystore_path(matches: &ArgMatches<'_>) -> PathBuf {
 
 pub fn get_identifiers(matches: &ArgMatches<'_>) -> ([u8; 32], ShardIdentifier) {
 	let mut mrenclave = [0u8; 32];
-	if !matches.is_present("mrenclave") {
-		panic!("--mrenclave must be provided");
-	};
+	assert!(matches.is_present("mrenclave"), "--mrenclave must be provided");
 	mrenclave.copy_from_slice(
 		&matches
 			.value_of("mrenclave")

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ geojson = "0.17"
 ws = { version = "0.9.1", features = ["ssl"] }
 serde = { version = "1.0", features = ["derive"] }
 codec = { version = "2.0.0", package = "parity-scale-codec", features = ["derive"] }
-sgx_crypto_helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # scs / integritee
 substrate-api-client = { features = ["ws-client"], git = "https://github.com/scs/substrate-api-client", branch = "master" }

--- a/core-primitives/enclave-api/Cargo.toml
+++ b/core-primitives/enclave-api/Cargo.toml
@@ -10,9 +10,9 @@ log 	    = "0.4"
 serde_json 	= "1.0"
 codec       = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 
-sgx_types           = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_urts            = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_crypto_helper 	= { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types           = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_urts            = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper 	= { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 frame-support       = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-core             = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/core-primitives/enclave-api/ffi/Cargo.toml
+++ b/core-primitives/enclave-api/ffi/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sgx_types   = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types   = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }

--- a/core-primitives/nonce-cache/src/lib.rs
+++ b/core-primitives/nonce-cache/src/lib.rs
@@ -54,15 +54,8 @@ pub mod nonce_cache;
 pub type NonceValue = u32;
 
 /// Nonce type (newtype wrapper for NonceValue)
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Default, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Nonce(pub NonceValue);
-
-impl Default for Nonce {
-	fn default() -> Self {
-		Nonce(0)
-	}
-}
-
 /// Trait to mutate a nonce.
 ///
 /// Used in a combination of loading a lock and then writing the updated

--- a/core-primitives/ocall-api/Cargo.toml
+++ b/core-primitives/ocall-api/Cargo.toml
@@ -13,7 +13,7 @@ sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://g
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
 
 # sgx-deps
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local deps
 itp-types = { path = "../types", default-features = false }

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -15,10 +15,10 @@ serde = { version = "1.0", default-features = false, features = ["alloc"] , opti
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] , optional = true }
 
 # sgx deps
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_rand = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx-crypto-helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_rand = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
 serde-sgx = { package = "serde", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx" , optional = true  }
 serde_json-sgx = { package = "serde_json", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx" , optional = true  }
 

--- a/core-primitives/sgx/io/Cargo.toml
+++ b/core-primitives/sgx/io/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 
 # sgx deps
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [features]
 default = ["std"]

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -31,10 +31,9 @@ test = []
 
 [dependencies]
 # sgx dependencies
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tcrypto = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tcrypto = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }
 itp-settings = { path = "../../core-primitives/settings", default-features = false }

--- a/core-primitives/storage-verified/Cargo.toml
+++ b/core-primitives/storage-verified/Cargo.toml
@@ -8,7 +8,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 derive_more = { version = "0.99.5" }
 
 # sgx deps
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # substrate deps
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/core-primitives/storage/Cargo.toml
+++ b/core-primitives/storage/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = { version = "1.0.26", optional = true }
 
 # sgx deps
 thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # substrate deps
 frame-metadata = { version = "14.0.0", features = ["v13"], default-features = false, git = "https://github.com/paritytech/frame-metadata.git", branch = "main" }

--- a/core-primitives/test/Cargo.toml
+++ b/core-primitives/test/Cargo.toml
@@ -8,8 +8,8 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 derive_more = { version = "0.99.5" }
 
 # sgx deps
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx-crypto-helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
 jsonrpc-core = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }

--- a/core-primitives/test/Cargo.toml
+++ b/core-primitives/test/Cargo.toml
@@ -10,7 +10,7 @@ derive_more = { version = "0.99.5" }
 # sgx deps
 sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx-crypto-helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
+sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
 jsonrpc-core = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
 

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -12,7 +12,7 @@ serde           = { version = "1.0", default-features = false, features = ["allo
 serde_json      = { version = "1.0", default-features = false, features = ["alloc"] }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master", default-features = false }
 
-sgx_tstd = { rev = "v1.1.3", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true}
+sgx_tstd = { branch = "v1.1.4-testing", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true}
 
 # local deps
 itp-storage = { path = "../storage", default-features = false }

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -25,8 +25,8 @@ std = [
 
 [dependencies]
 # sgx dependencies
-sgx_types   = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd    = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_types   = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd    = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
 
 # no-std dependencies
 codec  = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -43,5 +43,5 @@ jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jso
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
-jsonrpc-core = { version = "16", optional = true }
+jsonrpc-core = { version = "18", optional = true }
 thiserror = { version = "1.0", optional = true }

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -145,6 +145,7 @@ pub mod tests {
 		mocks::{connection_mock::ConnectionMock, updates_sink::UpdatesSink},
 		rpc_connection_registry::ConnectionRegistry,
 	};
+	use core::assert_matches::assert_matches;
 
 	type TestConnection = ConnectionMock;
 	type TestConnectionRegistry = ConnectionRegistry<String, TestConnection>;

--- a/core/direct-rpc-server/src/rpc_watch_extractor.rs
+++ b/core/direct-rpc-server/src/rpc_watch_extractor.rs
@@ -77,8 +77,8 @@ pub mod tests {
 		rpc_response_builder::RpcResponseBuilder, rpc_return_value_builder::RpcReturnValueBuilder,
 	};
 	use codec::Encode;
-	use itp_types::TrustedOperationStatus;
 	use core::assert_matches::assert_matches;
+	use itp_types::TrustedOperationStatus;
 
 	#[test]
 	fn invalid_rpc_response_returns_encoding_error() {

--- a/core/direct-rpc-server/src/rpc_watch_extractor.rs
+++ b/core/direct-rpc-server/src/rpc_watch_extractor.rs
@@ -78,6 +78,7 @@ pub mod tests {
 	};
 	use codec::Encode;
 	use itp_types::TrustedOperationStatus;
+	use core::assert_matches::assert_matches;
 
 	#[test]
 	fn invalid_rpc_response_returns_encoding_error() {

--- a/core/direct-rpc-server/src/rpc_ws_handler.rs
+++ b/core/direct-rpc-server/src/rpc_ws_handler.rs
@@ -103,6 +103,7 @@ pub mod tests {
 	use itp_types::{DirectRequestStatus, RpcReturnValue};
 	use jsonrpc_core::Params;
 	use serde_json::json;
+	use core::assert_matches::assert_matches;
 
 	type TestConnection = ConnectionMock;
 	type TestConnectionRegistry = ConnectionRegistry<String, TestConnection>;

--- a/core/direct-rpc-server/src/rpc_ws_handler.rs
+++ b/core/direct-rpc-server/src/rpc_ws_handler.rs
@@ -100,10 +100,10 @@ pub mod tests {
 		rpc_connection_registry::ConnectionRegistry,
 	};
 	use codec::Encode;
+	use core::assert_matches::assert_matches;
 	use itp_types::{DirectRequestStatus, RpcReturnValue};
 	use jsonrpc_core::Params;
 	use serde_json::json;
-	use core::assert_matches::assert_matches;
 
 	type TestConnection = ConnectionMock;
 	type TestConnectionRegistry = ConnectionRegistry<String, TestConnection>;

--- a/core/light-client/Cargo.toml
+++ b/core/light-client/Cargo.toml
@@ -44,8 +44,8 @@ num = { package = "num-traits", version = "0.2", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
 
 # sgx-deps
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs"], optional = true}
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs"], optional = true}
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # local deps

--- a/core/light-client/src/lib.rs
+++ b/core/light-client/src/lib.rs
@@ -134,7 +134,7 @@ impl<Block: BlockT> LightValidation<Block> {
 	}
 
 	fn schedule_validator_set_change(relay: &mut RelayState<Block>, header: &Block::Header) {
-		if let Some(log) = pending_change::<Block>(&header.digest()) {
+		if let Some(log) = pending_change::<Block>(header.digest()) {
 			if relay.scheduled_change.is_some() {
 				error!(
 					"Tried to scheduled authorities change even though one is already scheduled!!"
@@ -301,7 +301,7 @@ where
 			},
 		}
 
-		Self::schedule_validator_set_change(&mut relay, &header);
+		Self::schedule_validator_set_change(relay, &header);
 
 		// a valid grandpa proof proofs finalization of all previous unjustified blocks
 		relay.header_hashes.append(&mut relay.unjustified_headers);
@@ -323,14 +323,14 @@ where
 		header: Block::Header,
 		justifications: Option<Justifications>,
 	) -> Result<(), Error> {
-		let mut relay = self.tracked_relays.get_mut(&relay_id).ok_or(Error::NoSuchRelayExists)?;
+		let relay = self.tracked_relays.get_mut(&relay_id).ok_or(Error::NoSuchRelayExists)?;
 
 		if relay.last_finalized_block_header.hash() != *header.parent_hash() {
 			return Err(Error::HeaderAncestryMismatch)
 		}
 		let ancestry_proof = vec![];
 
-		Self::apply_validator_set_change(&mut relay, &header);
+		Self::apply_validator_set_change(relay, &header);
 
 		let validator_set = relay.current_validator_set.clone();
 		let validator_set_id = relay.current_validator_set_id;

--- a/core/rest-client/Cargo.toml
+++ b/core/rest-client/Cargo.toml
@@ -33,9 +33,9 @@ url = { version = "2.0.0", optional = true }
 
 # sgx dependencies
 http_req-sgx = { package = "http_req", git = "https://github.com/mesalock-linux/http_req-sgx", tag = "sgx_1.1.3", optional = true }
-http-sgx = { package = "http", git = "https://github.com/integritee-network/http-sgx", branch = "sgx-experimental", optional = true }
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+http-sgx = { package = "http", git = "https://github.com/mesalock-linux/http-sgx", tag = "sgx_1.1.3", optional = true }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 url_sgx = { package = "url", git = "https://github.com/mesalock-linux/rust-url-sgx", tag = "sgx_1.1.3", optional = true }
 

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -11,7 +11,7 @@ url = { version = "2.0.0" }
 log = "0.4"
 serde_json = "1.0"
 serde_derive = "1.0"
-sgx_crypto_helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 
 [dependencies.itp-types]

--- a/core/rpc-client/src/direct_client.rs
+++ b/core/rpc-client/src/direct_client.rs
@@ -158,7 +158,7 @@ impl DirectApi for DirectClient {
 		let method = "author_getShieldingKey".to_owned();
 		let jsonrpc_call: String = RpcRequest::compose_jsonrpc_call(method, vec![]);
 
-		let response_str = match Self::get(&self, jsonrpc_call) {
+		let response_str = match Self::get(self, jsonrpc_call) {
 			Ok(resp) => resp,
 			Err(err_msg) =>
 				return Err(format! {"Could not retrieve shielding pubkey: {:?}", err_msg}),

--- a/core/tls-websocket-server/Cargo.toml
+++ b/core/tls-websocket-server/Cargo.toml
@@ -28,8 +28,8 @@ std = [
 
 [dependencies]
 # sgx dependencies
-sgx_types   = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd    = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_types   = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd    = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
 
 # sgx enabled external libraries
 mio_sgx         = { package = "mio",            git = "https://github.com/mesalock-linux/mio-sgx",                  tag = "sgx_1.1.3",              optional = true }

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -13,6 +13,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ac-primitives"
+version = "0.1.0"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#2edd060c0a515718d62f3a78008b4123a5acefeb"
+dependencies = [
+ "parity-scale-codec",
+ "sp-core",
+]
+
+[[package]]
 name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell 1.8.0",
@@ -95,9 +104,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "autocfg"
@@ -115,6 +124,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 name = "base-x"
 version = "0.2.6"
 source = "git+https://github.com/whalelephant/base-x-rs?branch=no_std#906c9ac59282ff5a2eec86efd25d50ad9927b147"
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
@@ -235,9 +250,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
 
 [[package]]
 name = "byte-tools"
@@ -269,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -353,12 +368,12 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
- "generic-array 0.12.4",
- "subtle 1.0.0",
+ "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -370,7 +385,7 @@ dependencies = [
  "byteorder 1.4.3",
  "digest 0.8.1",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -383,7 +398,7 @@ dependencies = [
  "byteorder 1.4.3",
  "digest 0.9.0",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -401,9 +416,9 @@ checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.9",
+ "quote 1.0.10",
  "rustc_version 0.3.3",
- "syn 1.0.75",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -456,7 +471,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 name = "enclave-runtime"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.1",
+ "arrayvec 0.7.2",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "bit-vec",
  "byteorder 1.4.3",
@@ -498,6 +513,7 @@ dependencies = [
  "retain_mut",
  "rust-base58",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3)",
+ "sc-utils",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
  "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
@@ -519,7 +535,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "sp-utils",
  "sp-version",
  "substrate-api-client",
  "tiny-keccak",
@@ -591,7 +606,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -606,7 +621,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "14.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -615,8 +630,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/frame-metadata.git?branch=main#b5aceed422b7a361ce0bab00e18427d6c35c7607"
+version = "14.2.0"
+source = "git+https://github.com/paritytech/frame-metadata.git?branch=main#03b8afacfbdda61b2bd126dc8631a944b6a127ab"
 dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
@@ -625,7 +640,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "bitflags",
  "frame-metadata 14.0.0-dev",
@@ -634,7 +649,7 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "paste",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -648,44 +663,43 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
- "impl-trait-for-tuples",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "sp-core",
@@ -698,7 +712,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -817,8 +831,8 @@ source = "git+https://github.com/mesalock-linux/futures-rs-sgx#d54882f24ddf7d613
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -830,8 +844,8 @@ dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -904,7 +918,7 @@ dependencies = [
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
- "slab 0.4.4",
+ "slab 0.4.5",
 ]
 
 [[package]]
@@ -980,8 +994,8 @@ dependencies = [
 
 [[package]]
 name = "hashbrown_tstd"
-version = "0.9.0"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "0.11.2"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "hex"
@@ -991,22 +1005,22 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac",
- "digest 0.8.1",
+ "digest 0.9.0",
 ]
 
 [[package]]
 name = "hmac-drbg"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
 dependencies = [
- "digest 0.8.1",
- "generic-array 0.12.4",
+ "digest 0.9.0",
+ "generic-array 0.14.4",
  "hmac",
 ]
 
@@ -1060,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
 dependencies = [
  "serde 1.0.130",
 ]
@@ -1074,15 +1088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1150,7 +1164,7 @@ dependencies = [
  "jsonrpc-core",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
- "serde_json 1.0.67",
+ "serde_json 1.0.70",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -1332,7 +1346,7 @@ name = "itp-storage"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "frame-metadata 14.0.0",
+ "frame-metadata 14.2.0",
  "frame-support",
  "hash-db",
  "parity-scale-codec",
@@ -1401,7 +1415,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde 1.0.130",
- "serde_json 1.0.67",
+ "serde_json 1.0.70",
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
@@ -1579,7 +1593,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.28",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -1612,24 +1626,56 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libsecp256k1"
-version = "0.3.5"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1e2c808481a63dc6da2074752fdd4336a3c8fcc68b83db6f1fd5224ae7962"
+checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
 dependencies = [
  "arrayref",
- "crunchy",
- "digest 0.8.1",
+ "base64 0.12.3",
+ "digest 0.9.0",
  "hmac-drbg",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.2",
- "subtle 2.4.1",
+ "serde 1.0.130",
+ "sha2 0.9.8",
  "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -1897,11 +1943,10 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
- "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
  "sp-application-crypto",
@@ -1913,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1927,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1940,7 +1985,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1961,7 +2006,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1974,7 +2019,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1993,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2006,11 +2051,10 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "sp-inherents",
@@ -2022,12 +2066,12 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -2037,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -2047,11 +2091,11 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
- "arrayvec 0.7.1",
+ "arrayvec 0.7.2",
  "bitvec",
  "byte-slice-cast",
  "impl-trait-for-tuples",
@@ -2061,21 +2105,21 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "parity-util-mem"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad6f1acec69b95caf435bbd158d486e5a0a44fcf51531e84922c59ff09e8457"
+checksum = "6f4cb4e169446179cbc6b8b6320cc9fca49bd2e94e8db25f25f200a8ea774770"
 dependencies = [
  "cfg-if 1.0.0",
  "hashbrown 0.11.2",
@@ -2092,7 +2136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
  "proc-macro2",
- "syn 1.0.75",
+ "syn 1.0.81",
  "synstructure",
 ]
 
@@ -2117,15 +2161,15 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
  "winapi",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "percent-encoding"
@@ -2160,9 +2204,9 @@ source = "git+https://github.com/mesalock-linux/cryptocorrosion-sgx#32d7de50b5f0
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "primitive-types"
@@ -2178,11 +2222,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
- "thiserror 1.0.28",
+ "thiserror 1.0.30",
  "toml",
 ]
 
@@ -2200,9 +2244,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -2218,7 +2262,7 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "regex 1.5.4",
- "thiserror 1.0.28",
+ "thiserror 1.0.30",
 ]
 
 [[package]]
@@ -2243,9 +2287,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -2284,7 +2328,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "ppv-lite86 0.2.10",
+ "ppv-lite86 0.2.15",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2347,8 +2391,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c38e3aecd2b21cb3959637b883bb3714bc7e43f0268b9a29d3743ee3e55cdd2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2390,9 +2434,9 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "retain_mut"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c17925a9027d298a4603d286befe3f9dc0e8ed02523141914eb628798d6e5b"
+checksum = "448296241d034b96c11173591deaa1302f2c17b56092106c1f92c1bc0183a8c9"
 
 [[package]]
 name = "ring"
@@ -2487,6 +2531,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-utils"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
+dependencies = [
+ "futures 0.3.17",
+ "futures-timer",
+ "lazy_static",
+ "prometheus",
+]
+
+[[package]]
 name = "scale-info"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,8 +2561,8 @@ checksum = "baeb2780690380592f86205aa4ee49815feb2acad8c2f59e6dd207148c3f1fcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2522,7 +2577,7 @@ dependencies = [
  "merlin",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.2",
- "subtle 2.4.1",
+ "subtle",
  "zeroize",
 ]
 
@@ -2625,8 +2680,8 @@ version = "1.0.118"
 source = "git+https://github.com/mesalock-linux/serde-sgx#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2636,8 +2691,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2664,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa 0.4.8",
  "ryu",
@@ -2721,13 +2776,13 @@ dependencies = [
 
 [[package]]
 name = "sgx_alloc"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_backtrace_sys"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "cc",
  "sgx_build_helper",
@@ -2736,13 +2791,13 @@ dependencies = [
 
 [[package]]
 name = "sgx_build_helper"
-version = "0.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_crypto_helper"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "itertools",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
@@ -2755,21 +2810,21 @@ dependencies = [
 
 [[package]]
 name = "sgx_demangle"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_libc"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_types",
 ]
 
 [[package]]
 name = "sgx_rand"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_trts",
  "sgx_tstd",
@@ -2778,16 +2833,16 @@ dependencies = [
 
 [[package]]
 name = "sgx_serialize"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_tstd",
 ]
 
 [[package]]
 name = "sgx_serialize_derive"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "quote 0.3.15",
  "sgx_serialize_derive_internals",
@@ -2796,32 +2851,32 @@ dependencies = [
 
 [[package]]
 name = "sgx_serialize_derive_internals"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "syn 0.11.11",
 ]
 
 [[package]]
 name = "sgx_tcrypto"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_types",
 ]
 
 [[package]]
 name = "sgx_tcrypto_helper"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_crypto_helper",
 ]
 
 [[package]]
 name = "sgx_tprotected_fs"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_trts",
  "sgx_types",
@@ -2829,8 +2884,8 @@ dependencies = [
 
 [[package]]
 name = "sgx_trts"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_libc",
  "sgx_types",
@@ -2838,16 +2893,16 @@ dependencies = [
 
 [[package]]
 name = "sgx_tse"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_types",
 ]
 
 [[package]]
 name = "sgx_tseal"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_tcrypto",
  "sgx_trts",
@@ -2857,8 +2912,8 @@ dependencies = [
 
 [[package]]
 name = "sgx_tstd"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "hashbrown_tstd",
  "sgx_alloc",
@@ -2873,21 +2928,21 @@ dependencies = [
 
 [[package]]
 name = "sgx_tunittest"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_tstd",
 ]
 
 [[package]]
 name = "sgx_types"
-version = "1.1.3"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 
 [[package]]
 name = "sgx_unwind"
-version = "0.1.1"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?rev=v1.1.3#6cf73140d5e9b05366a2ae4f8fe8141449e7204f"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
 dependencies = [
  "sgx_build_helper",
 ]
@@ -2952,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
+checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
 
 [[package]]
 name = "slab"
@@ -2966,15 +3021,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
-
-[[package]]
-name = "smallvec"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
@@ -2985,9 +3034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
@@ -3001,19 +3056,19 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -3024,7 +3079,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.14",
@@ -3037,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -3048,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3060,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3075,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -3085,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "blake2-rfc",
  "byteorder 1.4.3",
@@ -3115,17 +3170,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "finality-grandpa",
  "parity-scale-codec",
@@ -3139,7 +3194,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3171,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -3181,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -3200,7 +3255,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3216,19 +3271,19 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3240,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -3250,12 +3305,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 
 [[package]]
 name = "sp-storage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "ref-cast",
@@ -3266,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3278,7 +3333,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -3289,7 +3344,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -3298,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -3310,21 +3365,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-utils"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
-dependencies = [
- "futures 0.3.17",
- "futures-core 0.3.17",
- "futures-timer",
- "lazy_static",
- "prometheus",
-]
-
-[[package]]
 name = "sp-version"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -3335,19 +3378,18 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "parity-scale-codec",
- "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#f651d45ce5742bc60fe8ae518c035d1638ae83d2"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#b391b82954ad95a927a921035e3017c4a0aad516"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3369,9 +3411,10 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "substrate-api-client"
 version = "0.6.0"
-source = "git+https://github.com/scs/substrate-api-client?branch=master#28c4977bcc65117a47993564996cb99da552bced"
+source = "git+https://github.com/scs/substrate-api-client?branch=master#2edd060c0a515718d62f3a78008b4123a5acefeb"
 dependencies = [
- "frame-metadata 14.0.0-dev",
+ "ac-primitives",
+ "frame-metadata 14.2.0",
  "frame-support",
  "hex",
  "parity-scale-codec",
@@ -3380,12 +3423,6 @@ dependencies = [
  "sp-runtime",
  "sp-std",
 ]
-
-[[package]]
-name = "subtle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
@@ -3406,12 +3443,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.75"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
+ "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
 
@@ -3426,13 +3463,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "unicode-xid 0.2.2",
 ]
 
@@ -3461,11 +3498,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
 dependencies = [
- "thiserror-impl 1.0.28",
+ "thiserror-impl 1.0.30",
 ]
 
 [[package]]
@@ -3474,19 +3511,19 @@ version = "1.0.9"
 source = "git+https://github.com/mesalock-linux/thiserror-sgx?tag=sgx_1.1.3#c2f806b88616e06aab0af770366a76885d974fdc"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3518,9 +3555,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.26"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -3529,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 
 [[package]]
 name = "trie-db"
@@ -3542,7 +3579,7 @@ dependencies = [
  "hash-db",
  "hashbrown 0.11.2",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
- "smallvec 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.7.0",
 ]
 
 [[package]]
@@ -3624,7 +3661,7 @@ name = "unicode-normalization"
 version = "0.1.12"
 source = "git+https://github.com/mesalock-linux/unicode-normalization-sgx#c1b030611969f87d75782c1df77975167cbbd509"
 dependencies = [
- "smallvec 1.6.1 (git+https://github.com/mesalock-linux/rust-smallvec-sgx)",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -3745,21 +3782,26 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
- "quote 1.0.9",
- "syn 1.0.75",
+ "quote 1.0.10",
+ "syn 1.0.81",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "sgx_ucrypto"
+version = "1.1.4"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -3800,8 +3800,3 @@ dependencies = [
  "syn 1.0.81",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "sgx_ucrypto"
-version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -136,3 +136,4 @@ sgx_trts = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_
 sgx_types = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_types" }
 sgx_ucrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
 sgx_tcrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }
+sgx_tcrypto_helper = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto_helper" }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -24,17 +24,17 @@ test = [
 ]
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
-sgx_tse = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs","net","backtrace"] }
-sgx_rand = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_trts = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tseal = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tcrypto = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_serialize = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_serialize_derive = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tunittest = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx-crypto-helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper" }
+sgx_tse = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs","net","backtrace"] }
+sgx_rand = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_trts = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tseal = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tcrypto = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_serialize = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_serialize_derive = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tunittest = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper" }
 
 [dependencies]
 codec  = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
@@ -124,3 +124,14 @@ sp-io = { git = "https://github.com/integritee-network/sgx-runtime", branch = "m
 #sgx-runtime = { path = "../sgx-runtime/runtime", default-features = false}
 #sp-io = { path = "../sgx-runtime/substrate-sgx/sp-io", default-features = false, features = ["disable_oom", "disable_panic_handler", "disable_allocator", "sgx"]}
 #sgx-externalities = { path = "../../sgx-runtime/substrate-sgx/externalities"}
+
+[patch."https://github.com/apache/teaclave-sgx-sdk.git"]
+sgx_tstd = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tstd" }
+sgx_alloc = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_alloc" }
+sgx_libc = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_libc" }
+sgx_serialize = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_serialize" }
+sgx_serialize_derive = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_serialize_derive" }
+sgx_serialize_derive_internals = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_serialize_derive_internals" }
+sgx_trts = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_trts" }
+sgx_types = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_types" }
+sgx_ucrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -137,3 +137,4 @@ sgx_types = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx
 sgx_ucrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
 sgx_tcrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }
 sgx_tcrypto_helper = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto_helper" }
+sgx_crypto_helper = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_crypto_helper" }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -137,4 +137,4 @@ sgx_types = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx
 sgx_ucrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
 sgx_tcrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }
 sgx_tcrypto_helper = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto_helper" }
-sgx_crypto_helper = { version = "1.1.4", path = "../../incubator-teaclave-sgx-sdk/sgx_crypto_helper" }
+sgx_crypto_helper = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_crypto_helper" }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -103,7 +103,7 @@ sp-core = { version = "4.0.0-dev", default-features = false, features = ["full_c
 sp-finality-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
-sp-utils = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
+sc-utils = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-version = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-application-crypto = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 #beefy-merkle-tree = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", features = "keccak" }
@@ -135,3 +135,4 @@ sgx_serialize_derive_internals = { version = "1.1.4", path = "../../../incubator
 sgx_trts = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_trts" }
 sgx_types = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_types" }
 sgx_ucrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
+sgx_tcrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -134,7 +134,6 @@ sgx_serialize_derive = { version = "1.1.4", git = "https://github.com/haerdib/in
 sgx_serialize_derive_internals = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
 sgx_trts = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
 sgx_types = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_ucrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
 sgx_tcrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
 sgx_tcrypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
 sgx_crypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -126,15 +126,15 @@ sp-io = { git = "https://github.com/integritee-network/sgx-runtime", branch = "m
 #sgx-externalities = { path = "../../sgx-runtime/substrate-sgx/externalities"}
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
-sgx_tstd = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tstd" }
-sgx_alloc = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_alloc" }
-sgx_libc = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_libc" }
-sgx_serialize = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_serialize" }
-sgx_serialize_derive = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_serialize_derive" }
-sgx_serialize_derive_internals = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_serialize_derive_internals" }
-sgx_trts = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_trts" }
-sgx_types = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_types" }
-sgx_ucrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_ucrypto" }
-sgx_tcrypto = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto" }
-sgx_tcrypto_helper = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_tcrypto_helper" }
-sgx_crypto_helper = { version = "1.1.4", path = "../../../incubator-teaclave-sgx-sdk/sgx_crypto_helper" }
+sgx_tstd = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_alloc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_libc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_serialize = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_serialize_derive = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_serialize_derive_internals = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_trts = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_types = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_ucrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_tcrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_tcrypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_crypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}

--- a/enclave-runtime/rust-toolchain.toml
+++ b/enclave-runtime/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-01"
+channel = "nightly-2021-10-16"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/enclave-runtime/rust-toolchain.toml
+++ b/enclave-runtime/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-23"
+channel = "nightly-2021-10-01"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/enclave-runtime/rust-toolchain.toml
+++ b/enclave-runtime/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-01"
+channel = "nightly-2021-10-23"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/enclave-runtime/rust-toolchain.toml
+++ b/enclave-runtime/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-05-11"
+channel = "nightly-2021-10-01"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/enclave-runtime/src/cert.rs
+++ b/enclave-runtime/src/cert.rs
@@ -69,7 +69,7 @@ pub fn gen_ecc_cert(
 					writer.next().write_set(|writer| {
 						writer.next().write_sequence(|writer| {
 							writer.next().write_oid(&ObjectIdentifier::from_slice(&[2, 5, 4, 3]));
-							writer.next().write_utf8_string(&ISSUER);
+							writer.next().write_utf8_string(ISSUER);
 						});
 					});
 				});
@@ -87,7 +87,7 @@ pub fn gen_ecc_cert(
 					writer.next().write_set(|writer| {
 						writer.next().write_sequence(|writer| {
 							writer.next().write_oid(&ObjectIdentifier::from_slice(&[2, 5, 4, 3]));
-							writer.next().write_utf8_string(&SUBJECT);
+							writer.next().write_utf8_string(SUBJECT);
 						});
 					});
 				});
@@ -127,7 +127,7 @@ pub fn gen_ecc_cert(
 			// Signature
 			let sig = {
 				let tbs = &writer.buf[4..];
-				ecc_handle.ecdsa_sign_slice(tbs, &prv_k).unwrap()
+				ecc_handle.ecdsa_sign_slice(tbs, prv_k).unwrap()
 			};
 			let sig_der = yasna::construct_der(|writer| {
 				writer.write_sequence(|writer| {
@@ -274,7 +274,7 @@ where
 	}
 
 	// Verify the signature against the signing cert
-	match sig_cert.verify_signature(&webpki::RSA_PKCS1_2048_8192_SHA256, &attn_report_raw, &sig) {
+	match sig_cert.verify_signature(&webpki::RSA_PKCS1_2048_8192_SHA256, attn_report_raw, &sig) {
 		Ok(_) => info!("Signature good"),
 		Err(e) => {
 			error!("Signature verification error {:?}", e);

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -551,7 +551,7 @@ where
 			return Err(e.into())
 		}
 
-		if let Err(e) = stf_executor.update_states::<PB>(&block.header()) {
+		if let Err(e) = stf_executor.update_states::<PB>(block.header()) {
 			error!("Error performing state updates upon block import");
 			return Err(e.into())
 		}
@@ -624,7 +624,7 @@ where
 					if let Err(e) = stf_executor.execute_trusted_call::<PB>(
 						&mut opaque_calls,
 						&decrypted_trusted_call,
-						&block.header(),
+						block.header(),
 						&shard,
 						StatePostProcessing::Prune, // we only want to store the state diff for direct stuff.
 					) {
@@ -654,7 +654,7 @@ where
     );
 
 	debug!("decrypt the call");
-	let account_vec = Rsa3072Seal::unseal().map(|key| key.decrypt(&account_encrypted))??;
+	let account_vec = Rsa3072Seal::unseal().map(|key| key.decrypt(account_encrypted))??;
 
 	let account = AccountId::decode(&mut account_vec.as_slice())
 		.sgx_error_with_log("[ShieldFunds] Could not decode account")?;

--- a/enclave-runtime/src/tls_ra.rs
+++ b/enclave-runtime/src/tls_ra.rs
@@ -192,7 +192,7 @@ fn send_files(
 	aes: &Aes,
 ) -> SgxResult<()> {
 	tls.write(&rsa_pair.len().to_le_bytes()).sgx_error()?;
-	tls.write(&rsa_pair).sgx_error()?;
+	tls.write(rsa_pair).sgx_error()?;
 	tls.write(&aes.key[..]).sgx_error()?;
 	tls.write(&aes.init_vec[..]).sgx_error()?;
 	Ok(())

--- a/enclave-runtime/src/top_pool_operation_executor.rs
+++ b/enclave-runtime/src/top_pool_operation_executor.rs
@@ -114,7 +114,7 @@ where
 		self.stf_executor
 			.execute_timed_getters_batch(
 				&trusted_getters,
-				&shard,
+				shard,
 				max_exec_duration,
 				|trusted_getter_signed: &TrustedGetterSigned,
 				 state_result: StfExecutorResult<Option<Vec<u8>>>| {

--- a/enclave-runtime/src/utils.rs
+++ b/enclave-runtime/src/utils.rs
@@ -28,9 +28,7 @@ pub fn hash_from_slice(hash_slize: &[u8]) -> Hash {
 }
 
 pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) {
-	if data.len() > writable.len() {
-		panic!("not enough bytes in output buffer for return value");
-	}
+	assert!(!data.len() > writable.len(), "Not enough bytes in output buffer for return value");
 	let (left, right) = writable.split_at_mut(data.len());
 	left.clone_from_slice(&data);
 	// fill the right side with whitespace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-01"
+channel = "nightly-2021-10-16"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-23"
+channel = "nightly-2021-10-01"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-10-01"
+channel = "nightly-2021-10-23"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-05-11"
+channel = "nightly-2021-10-01"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -36,9 +36,9 @@ sha2 = { version = "0.7", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.10.1", default-features = false, features = ["codec"] }
 
-sgx_urts = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_crypto_helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_urts = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local
 itp-settings = { path = "../core-primitives/settings" }

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -6,7 +6,7 @@ pub enum Error {
 	#[error("{0}")]
 	Codec(#[from] CodecError),
 	#[error("{0}")]
-	ApiClientError(#[from] ApiClientError),
+	ApiClient(#[from] ApiClientError),
 	#[error("Node API terminated subscription unexpectedly: {0}")]
 	ApiSubscriptionDisconnected(#[from] std::sync::mpsc::RecvError),
 	#[error("{0}")]
@@ -14,9 +14,9 @@ pub enum Error {
 	#[error("{0}")]
 	Serialization(#[from] serde_json::Error),
 	#[error("{0}")]
-	FromUtf8Error(#[from] std::string::FromUtf8Error),
+	FromUtf8(#[from] std::string::FromUtf8Error),
 	#[error("Application setup error!")]
-	ApplicationSetupError,
+	ApplicationSetup,
 	#[error("Custom Error: {0}")]
 	Custom(Box<dyn std::error::Error>),
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
 	)));
 
 	if let Some(smatches) = matches.subcommand_matches("run") {
-		let shard = extract_shard(&smatches, enclave.as_ref());
+		let shard = extract_shard(smatches, enclave.as_ref());
 
 		// Todo: Is this deprecated?? It is only used in remote attestation.
 		config.set_ext_api_url(
@@ -168,7 +168,7 @@ fn main() {
 			tokio_handle,
 		);
 	} else if let Some(smatches) = matches.subcommand_matches("request-keys") {
-		let shard = extract_shard(&smatches, enclave.as_ref());
+		let shard = extract_shard(smatches, enclave.as_ref());
 		let provider_url = smatches.value_of("provider").expect("provider must be specified");
 		request_keys(provider_url, &shard, enclave.as_ref(), smatches.is_present("skip-ra"));
 	} else if matches.is_present("shielding-key") {
@@ -201,7 +201,7 @@ fn main() {
 	} else if matches.is_present("mrenclave") {
 		println!("{}", enclave.get_mrenclave().unwrap().encode().to_base58());
 	} else if let Some(_matches) = matches.subcommand_matches("init-shard") {
-		let shard = extract_shard(&_matches, enclave.as_ref());
+		let shard = extract_shard(_matches, enclave.as_ref());
 		init_shard(&shard);
 	} else if let Some(_matches) = matches.subcommand_matches("test") {
 		if _matches.is_present("provisioning-server") {
@@ -487,7 +487,7 @@ fn request_keys<E: TlsRemoteAttestation>(
 	enclave_request_key_provisioning(
 		enclave_api,
 		sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
-		&provider_url,
+		provider_url,
 		skip_ra,
 	)
 	.unwrap();
@@ -526,7 +526,7 @@ fn print_events(events: Events, _sender: Sender<String>) {
 					my_node_runtime::pallet_teerex::RawEvent::AddedEnclave(sender, worker_url) => {
 						println!("[+] Received AddedEnclave event");
 						println!("    Sender (Worker):  {:?}", sender);
-						println!("    Registered URL: {:?}", str::from_utf8(&worker_url).unwrap());
+						println!("    Registered URL: {:?}", str::from_utf8(worker_url).unwrap());
 					},
 					my_node_runtime::pallet_teerex::RawEvent::Forwarded(shard) => {
 						println!(
@@ -611,7 +611,7 @@ fn subscribe_to_parentchain_new_headers<E: EnclaveBase + Sidechain>(
 	mut last_synced_header: Header,
 ) -> Result<(), Error> {
 	let (sender, receiver) = channel();
-	api.subscribe_finalized_heads(sender).map_err(Error::ApiClientError)?;
+	api.subscribe_finalized_heads(sender).map_err(Error::ApiClient)?;
 
 	loop {
 		let new_header: Header = match receiver.recv() {
@@ -755,7 +755,7 @@ fn ensure_account_has_funds(api: &mut Api<sr25519::Pair, WsRpcClient>, accountid
 	info!("    Alice's Account Nonce is {}", nonce);
 
 	// check account balance
-	let free = api.get_free_balance(&accountid).unwrap();
+	let free = api.get_free_balance(accountid).unwrap();
 	info!("TEE's free balance = {:?}", free);
 
 	let existential_deposit = api.get_existential_deposit().unwrap();
@@ -779,7 +779,7 @@ fn ensure_account_has_funds(api: &mut Api<sr25519::Pair, WsRpcClient>, accountid
 		info!("[<] Extrinsic got finalized. Hash: {:?}\n", xt_hash);
 
 		//verify funds have arrived
-		let free = api.get_free_balance(&accountid);
+		let free = api.get_free_balance(accountid);
 		info!("TEE's NEW free balance = {:?}", free);
 
 		api.signer = signer_orig;

--- a/service/src/sidechain_storage/db.rs
+++ b/service/src/sidechain_storage/db.rs
@@ -42,7 +42,7 @@ impl SidechainDB {
 
 	/// writes a batch to the DB
 	pub fn write(&mut self, batch: WriteBatch) -> Result<()> {
-		self.db.write(batch).map_err(Error::OperationalError)
+		self.db.write(batch).map_err(Error::Operational)
 	}
 
 	/// adds a given key value pair to the batch
@@ -58,6 +58,6 @@ impl SidechainDB {
 	/// add an entry to the DB
 	#[cfg(test)]
 	pub fn put<K: Encode, V: Encode>(&mut self, key: K, value: V) -> Result<()> {
-		self.db.put(key.encode(), value.encode()).map_err(Error::OperationalError)
+		self.db.put(key.encode(), value.encode()).map_err(Error::Operational)
 	}
 }

--- a/service/src/sidechain_storage/error.rs
+++ b/service/src/sidechain_storage/error.rs
@@ -18,11 +18,11 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub enum Error {
 	/// File access error
 	#[error("Could not interact with file storage: {0:?}")]
-	OperationalError(#[from] rocksdb::Error),
+	Operational(#[from] rocksdb::Error),
 	/// Last block of shard not found
 	#[error("Last Block of shard: {0} not found")]
 	LastBlockNotFound(String),
 	/// Decoding Error
 	#[error("Could not decode: {0:?}")]
-	DecodeError(#[from] codec::Error),
+	Decode(#[from] codec::Error),
 }

--- a/service/src/sidechain_storage/storage.rs
+++ b/service/src/sidechain_storage/storage.rs
@@ -152,7 +152,7 @@ impl<SignedBlock: SignedBlockT> SidechainStorage<SignedBlock> {
 			let mut batch = WriteBatch::default();
 			let mut current_block_number = block_number;
 			// Remove blocks from db until no block anymore
-			while let Some(block_hash) = self.get_block_hash(&shard, current_block_number)? {
+			while let Some(block_hash) = self.get_block_hash(shard, current_block_number)? {
 				self.delete_block(&mut batch, &block_hash, &current_block_number, shard);
 				current_block_number -= 1;
 			}

--- a/service/src/sync_block_gossiper.rs
+++ b/service/src/sync_block_gossiper.rs
@@ -60,7 +60,7 @@ where
 			},
 			None => {
 				error!("Failed to get worker instance");
-				Err(Error::ApplicationSetupError)
+				Err(Error::ApplicationSetup)
 			},
 		}
 	}

--- a/service/src/utils.rs
+++ b/service/src/utils.rs
@@ -46,9 +46,7 @@ pub fn hex_encode(data: Vec<u8>) -> String {
 }
 
 pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) {
-	if data.len() > writable.len() {
-		panic!("not enough bytes in output buffer for return value");
-	}
+	assert!(!data.len() > writable.len(), "Not enough bytes in output buffer for return value");
 	let (left, right) = writable.split_at_mut(data.len());
 	left.clone_from_slice(&data);
 	// fill the right side with whitespace
@@ -63,8 +61,6 @@ pub fn check_files() {
 	let files =
 		vec![ENCLAVE_FILE, SHIELDING_KEY_FILE, SIGNING_KEY_FILE, RA_SPID_FILE, RA_API_KEY_FILE];
 	for f in files.iter() {
-		if !Path::new(f).exists() {
-			panic!("file doesn't exist: {}", f);
-		}
+		assert!(Path::new(f).exists(), "File doesn't exist: {}", f);
 	}
 }

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 log = { version = "0.4.14", default-features = false }
 
 # sgx deps
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # substrate deps
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/sidechain/consensus/aura/src/verifier.rs
+++ b/sidechain/consensus/aura/src/verifier.rs
@@ -171,12 +171,12 @@ mod tests {
 	use crate::mock::{
 		default_header, validateer, StateMock, TestAuraVerifier, TestBlockBuilder, SLOT_DURATION,
 	};
+	use core::assert_matches::assert_matches;
 	use frame_support::assert_ok;
 	use itp_test::mock::onchain_mock::OnchainMock;
 	use its_primitives::traits::SignBlock;
 	use sp_keyring::ed25519::Keyring;
 	use sp_runtime::{app_crypto::ed25519, testing::H256};
-	use core::assert_matches::assert_matches;
 
 	fn assert_bad_sidechain_block_err<T: Debug>(result: Result<T, ConsensusError>, msg: &str) {
 		assert_matches!(result.unwrap_err(),ConsensusError::BadSidechainBlock(

--- a/sidechain/consensus/aura/src/verifier.rs
+++ b/sidechain/consensus/aura/src/verifier.rs
@@ -176,6 +176,7 @@ mod tests {
 	use its_primitives::traits::SignBlock;
 	use sp_keyring::ed25519::Keyring;
 	use sp_runtime::{app_crypto::ed25519, testing::H256};
+	use core::assert_matches::assert_matches;
 
 	fn assert_bad_sidechain_block_err<T: Debug>(result: Result<T, ConsensusError>, msg: &str) {
 		assert_matches!(result.unwrap_err(),ConsensusError::BadSidechainBlock(

--- a/sidechain/consensus/aura/src/verifier.rs
+++ b/sidechain/consensus/aura/src/verifier.rs
@@ -119,7 +119,7 @@ where
 		)
 	);
 
-	let authorities = authorities::<_, AuthorityPair, PB>(ctx, &parentchain_head)?;
+	let authorities = authorities::<_, AuthorityPair, PB>(ctx, parentchain_head)?;
 
 	let expected_author = slot_author::<AuthorityPair>(*slot, &authorities)
 		.ok_or_else(|| ConsensusError::CouldNotGetAuthorities("No authorities found".into()))?;

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -33,7 +33,7 @@ itp-sgx-crypto = { path = "../../../core-primitives/sgx/crypto", default-feature
 itp-types = { path = "../../../core-primitives/types", default-features = false }
 
 # sgx deps
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -12,7 +12,7 @@ derive_more = "0.99.16"
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 
 # sgx deps
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 
 # substrate deps
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -194,6 +194,7 @@ mod tests {
 	use sp_keyring::ed25519::Keyring;
 	use sp_runtime::{testing::H256, traits::Header as HeaderT};
 	use std::fmt::Debug;
+	use core::assert_matches::assert_matches;
 
 	const SLOT_DURATION: Duration = Duration::from_millis(1000);
 

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -185,6 +185,7 @@ pub mod sgx {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use core::assert_matches::assert_matches;
 	use itp_sgx_io::SealedIO;
 	use itp_types::{Block as ParentchainBlock, Header as ParentchainHeader};
 	use its_primitives::{
@@ -194,7 +195,6 @@ mod tests {
 	use sp_keyring::ed25519::Keyring;
 	use sp_runtime::{testing::H256, traits::Header as HeaderT};
 	use std::fmt::Debug;
-	use core::assert_matches::assert_matches;
 
 	const SLOT_DURATION: Duration = Duration::from_millis(1000);
 

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -26,8 +26,8 @@ sgx = [
 
 [dependencies]
 # sgx dependencies
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 itp-types = { path = "../../core-primitives/types", default-features = false }

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -40,7 +40,7 @@ jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jso
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
 rust-base58 = { package = "rust-base58", version = "0.0.4", optional = true }
-jsonrpc-core = { version = "16", optional = true }
+jsonrpc-core = { version = "18", optional = true }
 
 # no-std compatible libraries
 codec  = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/sidechain/state/Cargo.toml
+++ b/sidechain/state/Cargo.toml
@@ -54,7 +54,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 thiserror = { version = "1.0.9", optional = true }
 
 # sgx deps
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # sgx forks
 thiserror_sgx = { package = "thiserror", version = "1.0.9", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/sidechain/top-pool-rpc-author/Cargo.toml
+++ b/sidechain/top-pool-rpc-author/Cargo.toml
@@ -38,9 +38,9 @@ test = [ "itp-test/sgx" ]
 
 [dependencies]
 # sgx dependencies
-sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx-crypto-helper = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
+sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }
@@ -57,7 +57,7 @@ jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jso
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
-jsonrpc-core = { version = "16", optional = true }
+jsonrpc-core = { version = "18", optional = true }
 thiserror = { version = "1.0", optional = true }
 
 # no-std compatible libraries

--- a/sidechain/top-pool-rpc-author/src/author.rs
+++ b/sidechain/top-pool-rpc-author/src/author.rs
@@ -115,7 +115,7 @@ where
 		}
 
 		// decrypt call
-		let request_vec = match self.encryption_key.decrypt(&ext.as_slice()) {
+		let request_vec = match self.encryption_key.decrypt(ext.as_slice()) {
 			Ok(req) => req,
 			Err(_) => return Box::pin(ready(Err(ClientError::BadFormatDecipher.into()))),
 		};

--- a/sidechain/top-pool/Cargo.toml
+++ b/sidechain/top-pool/Cargo.toml
@@ -37,7 +37,7 @@ std = [
 [dependencies]
 # sgx dependencies
 sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread", "untrusted_time"] }
+sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread", "untrusted_time"] }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }
@@ -51,7 +51,7 @@ linked-hash-map_sgx = { package = "linked-hash-map", git = "https://github.com/m
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
-jsonrpc-core = { version = "16", optional = true }
+jsonrpc-core = { version = "18", optional = true }
 linked-hash-map = { version = "0.5.2", optional = true }
 thiserror = { version = "1.0", optional = true }
 

--- a/sidechain/top-pool/src/future.rs
+++ b/sidechain/top-pool/src/future.rs
@@ -45,7 +45,7 @@ impl<Hash: fmt::Debug, Ex: fmt::Debug> fmt::Debug for WaitingTrustedOperations<H
 		//write!(fmt, "imported_at: {:?}, ", self.imported_at)?;
 		write!(fmt, "operation: {:?}, ", self.operation)?;
 		write!(fmt, "missing_tags: {{")?;
-		let mut it = self.missing_tags.iter().map(|tag| HexDisplay::from(tag));
+		let mut it = self.missing_tags.iter().map(HexDisplay::from);
 		if let Some(tag) = it.next() {
 			write!(fmt, "{}", tag)?;
 		}

--- a/sidechain/top-pool/src/pool.rs
+++ b/sidechain/top-pool/src/pool.rs
@@ -359,7 +359,7 @@ where
 		// And finally - submit reverified operations back to the pool
 
 		self.validated_pool.resubmit_pruned(
-			&at,
+			at,
 			known_imported_hashes,
 			pruned_hashes,
 			reverified_transactions.into_iter().map(|(_, xt)| xt).collect(),

--- a/sidechain/top-pool/src/ready.rs
+++ b/sidechain/top-pool/src/ready.rs
@@ -135,7 +135,7 @@ impl<Hash: hash::Hash + Member + Ord, Ex> ReadyOperations<Hash, Ex> {
 	/// Borrows a map of tags that are provided by operations in this queue.
 	pub fn provided_tags(&self, shard: ShardIdentifier) -> Option<&HashMap<Tag, Hash>> {
 		if let Some(tag_pool) = &self.provided_tags.get(&shard) {
-			return Some(&tag_pool)
+			return Some(tag_pool)
 		}
 		None
 	}
@@ -352,7 +352,7 @@ impl<Hash: hash::Hash + Member + Ord, Ex> ReadyOperations<Hash, Ex> {
 					for tag in &tx.operation.operation.requires {
 						if let Some(hash) = self.provided_tags.get(&shard).unwrap().get(tag) {
 							if let Some(tx) = ready.get_mut(hash) {
-								remove_item(&mut tx.unlocks, &hash);
+								remove_item(&mut tx.unlocks, hash);
 							}
 						}
 					}
@@ -411,7 +411,7 @@ impl<Hash: hash::Hash + Member + Ord, Ex> ReadyOperations<Hash, Ex> {
 						let mut find_previous = |tag| -> Option<Vec<Tag>> {
 							let prev_hash = self.provided_tags.get(&shard).unwrap().get(tag)?;
 							let mut ready = self.ready.get_mut(&shard).unwrap().write();
-							let tx2 = ready.get_mut(&prev_hash)?;
+							let tx2 = ready.get_mut(prev_hash)?;
 							remove_item(&mut tx2.unlocks, hash);
 							// We eagerly prune previous operations as well.
 							// But it might not always be good.

--- a/sidechain/top-pool/src/validated_pool.rs
+++ b/sidechain/top-pool/src/validated_pool.rs
@@ -443,7 +443,7 @@ where
 		self.pool
 			.read()
 			.unwrap()
-			.by_hashes(&hashes, shard)
+			.by_hashes(hashes, shard)
 			.into_iter()
 			.map(|existing_in_pool| existing_in_pool.map(|operation| operation.provides.to_vec()))
 			.collect()
@@ -557,7 +557,7 @@ where
 		let now = Instant::now();
 		let to_remove = {
 			self.ready(shard)
-				.filter(|tx| self.rotator.ban_if_stale(&now, block_number, &tx))
+				.filter(|tx| self.rotator.ban_if_stale(&now, block_number, tx))
 				.map(|tx| tx.hash)
 				.collect::<Vec<_>>()
 		};
@@ -565,7 +565,7 @@ where
 			let p = self.pool.read().unwrap();
 			let mut hashes = Vec::new();
 			for tx in p.futures(shard) {
-				if self.rotator.ban_if_stale(&now, block_number, &tx) {
+				if self.rotator.ban_if_stale(&now, block_number, tx) {
 					hashes.push(tx.hash);
 				}
 			}


### PR DESCRIPTION
This PR introduces the following changes:
- update all teaclave libraries to v1.1.4-testing
- patches all mesalock libraries to use v1.1.4 teaclave
- rust toolchain update to most recent one that is possible (30.10 and later not possible: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/360#issuecomment-970252525)
- removes cargo clippy issues emerged due to rust toolchain update