### PR TITLE
Use the same version of http and httparse in the enclave dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,14 +578,6 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
-source = "git+https://github.com/mesalock-linux/bytes-sgx#63d1951a35f2e888696aba3796aac45214e727ec"
-dependencies = [
- "sgx_tstd",
-]
-
-[[package]]
-name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
@@ -1892,17 +1884,6 @@ dependencies = [
 [[package]]
 name = "http"
 version = "0.2.1"
-source = "git+https://github.com/mesalock-linux/http-sgx?tag=sgx_1.1.3#62544a1833f98f1810a44877c5f1efe45f5327c0"
-dependencies = [
- "bytes 0.5.4",
- "fnv 1.0.6",
- "itoa 0.4.5",
- "sgx_tstd",
-]
-
-[[package]]
-name = "http"
-version = "0.2.1"
 source = "git+https://github.com/integritee-network/http-sgx?branch=sgx-experimental#307b5421fb7a489a114bede0dc05c8d32b804f49"
 dependencies = [
  "bytes 1.0.1",
@@ -2462,7 +2443,7 @@ name = "itc-rest-client"
 version = "0.8.0"
 dependencies = [
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.2.1 (git+https://github.com/mesalock-linux/http-sgx?tag=sgx_1.1.3)",
+ "http 0.2.1",
  "http 0.2.4",
  "http_req 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "http_req 0.7.2 (git+https://github.com/mesalock-linux/http_req-sgx?tag=sgx_1.1.3)",
@@ -7098,7 +7079,7 @@ dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?tag=sgx_1.1.3)",
  "byteorder 1.3.4",
  "bytes 1.0.1",
- "http 0.2.1 (git+https://github.com/integritee-network/http-sgx?branch=sgx-experimental)",
+ "http 0.2.1",
  "httparse 1.4.1",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx?tag=sgx_1.1.3)",
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",

--- a/core/rest-client/Cargo.toml
+++ b/core/rest-client/Cargo.toml
@@ -33,9 +33,9 @@ url = { version = "2.0.0", optional = true }
 
 # sgx dependencies
 http_req-sgx = { package = "http_req", git = "https://github.com/mesalock-linux/http_req-sgx", tag = "sgx_1.1.3", optional = true }
-http-sgx = { package = "http", git = "https://github.com/mesalock-linux/http-sgx", tag = "sgx_1.1.3", optional = true }
+http-sgx = { package = "http", git = "https://github.com/integritee-network/http-sgx", branch = "sgx-experimental", optional = true }
 sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 url_sgx = { package = "url", git = "https://github.com/mesalock-linux/rust-url-sgx", tag = "sgx_1.1.3", optional = true }
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
  "env_logger",
  "frame-support",
  "hex",
- "httparse 1.5.1",
+ "httparse",
  "ipfs-unixfs",
  "ita-stf",
  "itc-direct-rpc-server",
@@ -1025,12 +1025,6 @@ source = "git+https://github.com/integritee-network/httparse-sgx?branch=sgx-expe
 dependencies = [
  "sgx_tstd",
 ]
-
-[[package]]
-name = "httparse"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "humantime"
@@ -3539,7 +3533,7 @@ dependencies = [
  "byteorder 1.3.4",
  "bytes",
  "http",
- "httparse 1.4.1",
+ "httparse",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx?tag=sgx_1.1.3)",
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?tag=sgx_1.1.3)",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -69,7 +69,7 @@ chrono = { git = "https://github.com/mesalock-linux/chrono-sgx" }
 base64 = { rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/rust-base64-sgx" }
 num-bigint = { git = "https://github.com/mesalock-linux/num-bigint-sgx" }
 serde_derive = { git = "https://github.com/mesalock-linux/serde-sgx" }
-httparse = { version = "1.3",  default-features = false }
+httparse = { git = "https://github.com/integritee-network/httparse-sgx", branch = "sgx-experimental", features = ["mesalock_sgx"], default-features = false }
 itertools = { version = "0.10.1",  default-features = false, features = []}
 bit-vec = { version = "0.6",    default-features = false }
 base58 = { rev = "sgx_1.1.3", package="rust-base58", git = "https://github.com/mesalock-linux/rust-base58-sgx", default-features = false, features=["mesalock_sgx"] }


### PR DESCRIPTION
We have our own forks of http and httparse (for now). With this change we make sure that we use those consistently.