### PR TITLE
Specify 'untrusted_time' feature explicitely in crates with sgx_tstd

### DIFF
--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -32,7 +32,7 @@ test = []
 [dependencies]
 # sgx dependencies
 sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
 
 # local dependencies

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -15,12 +15,6 @@
 
 */
 
-// #[cfg(all(not(feature = "std"), feature = "sgx"))]
-// use crate::sgx_reexport_prelude::*;
-
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-use std::untrusted::time::SystemTimeEx;
-
 use crate::{
 	error::{Error, Result},
 	traits::{

--- a/enclave-runtime/src/cert.rs
+++ b/enclave-runtime/src/cert.rs
@@ -10,7 +10,7 @@ use num_bigint::BigUint;
 use serde_json::Value;
 use sgx_tcrypto::*;
 use sgx_types::*;
-use std::{io::BufReader, prelude::v1::*, ptr, str, time::*, untrusted::time::SystemTimeEx};
+use std::{io::BufReader, prelude::v1::*, ptr, str, time::*};
 use yasna::models::ObjectIdentifier;
 
 type SignatureAlgorithms = &'static [&'static webpki::SignatureAlgorithm];

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -12,7 +12,7 @@ derive_more = "0.99.16"
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 
 # sgx deps
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 
 # substrate deps
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -27,9 +27,6 @@ use std::time::{Duration, SystemTime};
 
 pub use sp_consensus_slots::Slot;
 
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-use std::untrusted::time::SystemTimeEx;
-
 /// Returns current duration since unix epoch.
 pub fn duration_now() -> Duration {
 	let now = SystemTime::now();

--- a/sidechain/top-pool/Cargo.toml
+++ b/sidechain/top-pool/Cargo.toml
@@ -37,7 +37,7 @@ std = [
 [dependencies]
 # sgx dependencies
 sgx_types = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_tstd = { rev = "v1.1.3", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread", "untrusted_time"] }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }

--- a/sidechain/top-pool/src/future.rs
+++ b/sidechain/top-pool/src/future.rs
@@ -18,9 +18,6 @@
 
 pub extern crate alloc;
 
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-use std::untrusted::time::InstantEx;
-
 use crate::base_pool::TrustedOperation;
 use alloc::{boxed::Box, fmt, sync::Arc, vec, vec::Vec};
 use core::hash;

--- a/sidechain/top-pool/src/pool.rs
+++ b/sidechain/top-pool/src/pool.rs
@@ -19,9 +19,6 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 use crate::sgx_reexport_prelude::*;
 
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-use std::untrusted::time::InstantEx;
-
 use crate::{
 	base_pool as base, error,
 	primitives::TrustedOperationSource,

--- a/sidechain/top-pool/src/validated_pool.rs
+++ b/sidechain/top-pool/src/validated_pool.rs
@@ -29,9 +29,6 @@ use std::sync::Mutex;
 #[cfg(feature = "std")]
 use std::sync::RwLock;
 
-#[cfg(all(not(feature = "std"), feature = "sgx"))]
-use std::untrusted::time::InstantEx;
-
 use crate::{
 	base_pool as base,
 	base_pool::PruneStatus,


### PR DESCRIPTION
This renders the `use std::untrusted::time::*` imports obsolete.
We do this because in a feature branch we encountered clippy issues about these imports being unused (in #442 ). It is still not entirely clear why these clippy warnings appear on that specific branch.
One suspicion is, that somehow a new/changed dependency now enables the `sgx_tstd/untrusted_time` feature which wasn't the case before.