### PR TITLE
Extract the top pool operation execution into separate modules

### DIFF
--- a/enclave-runtime/src/sidechain_block_composer.rs
+++ b/enclave-runtime/src/sidechain_block_composer.rs
@@ -1,0 +1,186 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	error::{Error, Result},
+	utils::now_as_u64,
+};
+use codec::Encode;
+use ita_stf::StatePayload;
+use itp_settings::node::{PROPOSED_SIDECHAIN_BLOCK, TEEREX_MODULE};
+use itp_sgx_crypto::StateCrypto;
+use itp_stf_executor::traits::StfExecuteGenericUpdate;
+use itp_types::{OpaqueCall, ShardIdentifier, H256};
+use its_sidechain::{
+	primitives::traits::{Block as SidechainBlockT, SignBlock, SignedBlock as SignedBlockT},
+	state::{LastBlockExt, SidechainDB, SidechainState, SidechainSystemExt, StateHash},
+	top_pool_rpc_author::traits::{AuthorApi, OnBlockCreated, SendState},
+};
+use log::*;
+use sgx_externalities::SgxExternalitiesTrait;
+use sp_core::Pair;
+use sp_runtime::{
+	traits::{Block as BlockT, Header},
+	MultiSignature,
+};
+use std::{format, marker::PhantomData, sync::Arc, vec::Vec};
+
+/// Compose a sidechain block and corresponding confirmation extrinsic for the parentchain
+///
+pub trait ComposeBlockAndConfirmation {
+	type SidechainBlockT: SignedBlockT;
+	type ParentchainBlockT: BlockT;
+
+	fn compose_block_and_confirmation(
+		&self,
+		latest_onchain_header: &<Self::ParentchainBlockT as BlockT>::Header,
+		top_call_hashes: Vec<H256>,
+		shard: ShardIdentifier,
+		state_hash_apriori: H256,
+	) -> Result<(OpaqueCall, Self::SidechainBlockT)>;
+}
+
+/// Block composer implementation for the sidechain
+pub struct BlockComposer<PB, SB, Signer, StateKey, RpcAuthor, StfExecutor> {
+	signer: Signer,
+	state_key: StateKey,
+	rpc_author: Arc<RpcAuthor>,
+	stf_executor: Arc<StfExecutor>,
+	_phantom: PhantomData<(PB, SB)>,
+}
+
+impl<PB, SB, Signer, StateKey, RpcAuthor, StfExecutor>
+	BlockComposer<PB, SB, Signer, StateKey, RpcAuthor, StfExecutor>
+where
+	PB: BlockT<Hash = H256>,
+	SB: SignedBlockT<Public = Signer::Public, Signature = MultiSignature>,
+	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
+	SB::Signature: From<Signer::Signature>,
+	RpcAuthor:
+		AuthorApi<H256, PB::Hash> + OnBlockCreated<Hash = PB::Hash> + SendState<Hash = PB::Hash>,
+	StfExecutor: StfExecuteGenericUpdate,
+	<StfExecutor as StfExecuteGenericUpdate>::Externalities:
+		SgxExternalitiesTrait + SidechainState + SidechainSystemExt + StateHash,
+	Signer: Pair<Public = sp_core::ed25519::Public>,
+	Signer::Public: Encode,
+	StateKey: StateCrypto,
+{
+	pub fn new(
+		signer: Signer,
+		state_key: StateKey,
+		rpc_author: Arc<RpcAuthor>,
+		stf_executor: Arc<StfExecutor>,
+	) -> Self {
+		BlockComposer { signer, state_key, rpc_author, stf_executor, _phantom: Default::default() }
+	}
+}
+
+impl<PB, SB, Signer, StateKey, RpcAuthor, StfExecutor> ComposeBlockAndConfirmation
+	for BlockComposer<PB, SB, Signer, StateKey, RpcAuthor, StfExecutor>
+where
+	PB: BlockT<Hash = H256>,
+	SB: SignedBlockT<Public = Signer::Public, Signature = MultiSignature>,
+	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
+	SB::Signature: From<Signer::Signature>,
+	RpcAuthor:
+		AuthorApi<H256, PB::Hash> + OnBlockCreated<Hash = PB::Hash> + SendState<Hash = PB::Hash>,
+	StfExecutor: StfExecuteGenericUpdate,
+	<StfExecutor as StfExecuteGenericUpdate>::Externalities:
+		SgxExternalitiesTrait + SidechainState + SidechainSystemExt + StateHash,
+	Signer: Pair<Public = sp_core::ed25519::Public>,
+	Signer::Public: Encode,
+	StateKey: StateCrypto,
+{
+	type SidechainBlockT = SB;
+	type ParentchainBlockT = PB;
+
+	fn compose_block_and_confirmation(
+		&self,
+		latest_onchain_header: &PB::Header,
+		top_call_hashes: Vec<H256>,
+		shard: ShardIdentifier,
+		state_hash_apriori: H256,
+	) -> Result<(OpaqueCall, Self::SidechainBlockT)> {
+		let author_public = self.signer.public();
+		let (block, _) = self.stf_executor.execute_update(&shard, |state| {
+			let mut db = SidechainDB::<
+				SB::Block,
+				<StfExecutor as StfExecuteGenericUpdate>::Externalities,
+			>::new(state);
+			let state_hash_new = db.state_hash();
+
+			let (block_number, parent_hash) = match db.get_last_block() {
+				Some(block) => (block.block_number() + 1, block.hash()),
+				None => {
+					info!("Seems to be first sidechain block.");
+					(1, Default::default())
+				},
+			};
+
+			if block_number != db.get_block_number().unwrap_or(0) {
+				return Err(Error::Other(
+					"[Sidechain] BlockNumber is not LastBlock's Number + 1".into(),
+				))
+			}
+
+			// create encrypted payload
+			let mut payload: Vec<u8> = StatePayload::new(
+				state_hash_apriori,
+				state_hash_new,
+				db.ext().state_diff().clone(),
+			)
+			.encode();
+
+			self.state_key.encrypt(&mut payload).map_err(|e| {
+				Error::Other(format!("Failed to encrypt state payload: {:?}", e).into())
+			})?;
+
+			let block = SB::Block::new(
+				author_public,
+				block_number,
+				parent_hash,
+				latest_onchain_header.hash(),
+				shard,
+				top_call_hashes,
+				payload,
+				now_as_u64(),
+			);
+
+			db.set_last_block(&block);
+
+			// state diff has been written to block, clean it for the next block.
+			db.ext_mut().prune_state_diff();
+
+			Ok((db.ext, block))
+		})?;
+
+		let block_hash = block.hash();
+		debug!("Block hash {}", block_hash);
+
+		let opaque_call = create_proposed_sidechain_block_call(shard, block_hash);
+
+		self.rpc_author.on_block_created(block.signed_top_hashes(), block.hash());
+		let signed_block = block.sign_block(&self.signer);
+
+		Ok((opaque_call, signed_block))
+	}
+}
+
+/// Creates a proposed_sidechain_block extrinsic for a given shard id and sidechain block hash.
+fn create_proposed_sidechain_block_call(shard_id: ShardIdentifier, block_hash: H256) -> OpaqueCall {
+	OpaqueCall::from_tuple(&([TEEREX_MODULE, PROPOSED_SIDECHAIN_BLOCK], shard_id, block_hash))
+}

--- a/enclave-runtime/src/sync.rs
+++ b/enclave-runtime/src/sync.rs
@@ -1,3 +1,19 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
 //! Primitives to handle multithreaded state access in the enclave.
 //!
 //! Note: In general the design should try to minimize usage of these, as potential deadlocks can

--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -1,0 +1,180 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	error::{Error, Result},
+	ocall::OcallApi,
+	sidechain_block_composer::BlockComposer,
+	sidechain_impl::{exec_aura_on_slot, ProposerFactory},
+	sync::{EnclaveLock, EnclaveStateRWLock},
+	top_pool_operation_executor::{ExecuteGettersOnTopPool, TopPoolOperationExecutor},
+};
+use itc_light_client::{io::LightClientSeal, BlockNumberOps, LightClientState, NumberFor};
+use itp_extrinsics_factory::ExtrinsicsFactory;
+use itp_nonce_cache::GLOBAL_NONCE_CACHE;
+use itp_settings::sidechain::SLOT_DURATION;
+use itp_sgx_crypto::{AesSeal, Ed25519Seal};
+use itp_sgx_io::SealedIO;
+use itp_stf_executor::executor::StfExecutor;
+use itp_stf_state_handler::{query_shard_state::QueryShardState, GlobalFileStateHandler};
+use itp_types::{Block, H256};
+use its_sidechain::{
+	primitives::types::block::SignedBlock as SignedSidechainBlock,
+	slots::{duration_now, remaining_time, sgx::LastSlotSeal, yield_next_slot},
+	top_pool_rpc_author::{global_author_container::GlobalAuthorContainer, traits::GetAuthor},
+};
+use log::*;
+use sgx_types::sgx_status_t;
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+
+#[no_mangle]
+pub unsafe extern "C" fn execute_trusted_getters() -> sgx_status_t {
+	if let Err(e) = execute_top_pool_trusted_getters_on_all_shards() {
+		return e.into()
+	}
+
+	sgx_status_t::SGX_SUCCESS
+}
+
+/// Internal [`execute_trusted_getters`] function to be able to use the `?` operator.
+///
+/// Executes trusted getters for a scheduled amount of time (defined by settings).
+fn execute_top_pool_trusted_getters_on_all_shards() -> Result<()> {
+	use itp_settings::enclave::MAX_TRUSTED_GETTERS_EXEC_DURATION;
+
+	let rpc_author = GlobalAuthorContainer.get().ok_or_else(|| {
+		error!("Failed to retrieve author mutex. It might not be initialized?");
+		Error::MutexAccess
+	})?;
+
+	let state_handler = Arc::new(GlobalFileStateHandler);
+	let stf_executor = Arc::new(StfExecutor::new(Arc::new(OcallApi), state_handler.clone()));
+
+	let shards = state_handler.list_shards()?;
+	let mut remaining_shards = shards.len() as u32;
+	let ends_at = duration_now() + MAX_TRUSTED_GETTERS_EXEC_DURATION;
+
+	let top_pool_executor = TopPoolOperationExecutor::<Block, SignedSidechainBlock, _, _>::new(
+		rpc_author,
+		stf_executor,
+	);
+
+	// Execute trusted getters for each shard. Each shard gets equal amount of time to execute
+	// getters.
+	for shard in shards.into_iter() {
+		let shard_exec_time = match remaining_time(ends_at)
+			.map(|r| r.checked_div(remaining_shards))
+			.flatten()
+		{
+			Some(t) => t,
+			None => {
+				info!("[Enclave] Could not execute trusted operations for all shards. Remaining number of shards: {}.", remaining_shards);
+				break
+			},
+		};
+
+		match top_pool_executor.execute_trusted_getters_on_shard(&shard, shard_exec_time) {
+			Ok(()) => {},
+			Err(e) => error!("Error in trusted getter execution for shard {:?}: {:?}", shard, e),
+		}
+
+		remaining_shards -= 1;
+	}
+
+	Ok(())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn execute_trusted_calls() -> sgx_status_t {
+	if let Err(e) = execute_top_pool_trusted_calls_internal::<Block>() {
+		return e.into()
+	}
+
+	sgx_status_t::SGX_SUCCESS
+}
+
+/// Internal [`execute_trusted_calls`] function to be able to use the `?` operator.
+///
+/// Executes `Aura::on_slot() for `slot` if it is this enclave's `Slot`.
+///
+/// This function makes an ocall that does the following:
+///
+/// *   sends sidechain `confirm_block` xt's with the produced sidechain blocks
+/// *   gossip produced sidechain blocks to peer validateers.
+fn execute_top_pool_trusted_calls_internal<PB>() -> Result<()>
+where
+	PB: BlockT<Hash = H256>,
+	NumberFor<PB>: BlockNumberOps,
+{
+	// we acquire lock explicitly (variable binding), since '_' will drop the lock after the statement
+	// see https://medium.com/codechain/rust-underscore-does-not-bind-fec6a18115a8
+	let (_light_client_lock, _side_chain_lock) = EnclaveLock::write_all()?;
+
+	let mut validator = LightClientSeal::<PB>::unseal()?;
+
+	let authority = Ed25519Seal::unseal()?;
+	let state_key = AesSeal::unseal()?;
+
+	let rpc_author = GlobalAuthorContainer.get().ok_or_else(|| {
+		error!("Failed to retrieve author mutex. Maybe it's not initialized?");
+		Error::MutexAccess
+	})?;
+
+	let state_handler = Arc::new(GlobalFileStateHandler);
+	let stf_executor = Arc::new(StfExecutor::new(Arc::new(OcallApi), state_handler.clone()));
+
+	let latest_onchain_header = validator.latest_finalized_header(validator.num_relays()).unwrap();
+	let genesis_hash = validator.genesis_hash(validator.num_relays())?;
+	let extrinsics_factory =
+		ExtrinsicsFactory::new(genesis_hash, authority.clone(), GLOBAL_NONCE_CACHE.clone());
+
+	let top_pool_executor =
+		Arc::new(TopPoolOperationExecutor::<PB, SignedSidechainBlock, _, _>::new(
+			rpc_author.clone(),
+			stf_executor.clone(),
+		));
+
+	let block_composer =
+		Arc::new(BlockComposer::new(authority.clone(), state_key, rpc_author, stf_executor));
+
+	match yield_next_slot(duration_now(), SLOT_DURATION, latest_onchain_header, &mut LastSlotSeal)?
+	{
+		Some(slot) => {
+			let shards = state_handler.list_shards()?;
+			let env = ProposerFactory::new(top_pool_executor, block_composer);
+
+			exec_aura_on_slot::<_, _, SignedSidechainBlock, _, _, _, _>(
+				slot,
+				authority,
+				&mut validator,
+				&extrinsics_factory,
+				OcallApi,
+				env,
+				shards,
+			)?
+		},
+		None => {
+			debug!("No slot yielded. Skipping block production.");
+			return Ok(())
+		},
+	};
+
+	LightClientSeal::seal(validator)?;
+
+	Ok(())
+}

--- a/enclave-runtime/src/top_pool_operation_executor.rs
+++ b/enclave-runtime/src/top_pool_operation_executor.rs
@@ -1,0 +1,219 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	error::{Error, Result},
+	utils::now_as_u64,
+};
+use codec::Encode;
+use ita_stf::{hash::TrustedOperationOrHash, TrustedGetterSigned};
+use itp_stf_executor::{
+	traits::{StfExecuteTimedCallsBatch, StfExecuteTimedGettersBatch},
+	BatchExecutionResult,
+};
+use itp_types::{ShardIdentifier, H256};
+use its_sidechain::{
+	primitives::traits::{Block as SidechainBlockT, SignedBlock as SignedBlockT},
+	state::{SidechainDB, SidechainState, SidechainSystemExt, StateHash},
+	top_pool_rpc_author::traits::{AuthorApi, OnBlockCreated, SendState},
+};
+use log::*;
+use sgx_externalities::SgxExternalitiesTrait;
+use sp_runtime::{traits::Block as BlockT, MultiSignature};
+use std::{marker::PhantomData, sync::Arc, time::Duration, vec::Vec};
+
+/// Trait to execute trusted calls from the top pool
+///
+/// Loads trusted calls from the top pool for a given shard
+/// and executes them until either all calls are executed or `max_exec_duration` is reached.
+pub trait ExecuteCallsOnTopPool {
+	type ParentchainBlockT: BlockT;
+
+	fn execute_trusted_calls(
+		&self,
+		latest_onchain_header: &<Self::ParentchainBlockT as BlockT>::Header,
+		shard: H256,
+		max_exec_duration: Duration,
+	) -> Result<BatchExecutionResult>;
+}
+
+/// Trait to execute trusted getters from the top pool
+///
+/// Loads trusted getters from the top pool for a given shard
+/// and executes them until either all calls are executed or `max_exec_duration` is reached.
+pub trait ExecuteGettersOnTopPool {
+	fn execute_trusted_getters_on_shard(
+		&self,
+		shard: &ShardIdentifier,
+		max_exec_duration: Duration,
+	) -> Result<()>;
+}
+
+/// Executes operations on the top pool
+///
+/// Operations can either be Getters or Calls
+pub struct TopPoolOperationExecutor<PB, SB, RpcAuthor, StfExecutor> {
+	rpc_author: Arc<RpcAuthor>,
+	stf_executor: Arc<StfExecutor>,
+	_phantom: PhantomData<(PB, SB)>,
+}
+
+impl<PB, SB, RpcAuthor, StfExecutor> TopPoolOperationExecutor<PB, SB, RpcAuthor, StfExecutor>
+where
+	PB: BlockT<Hash = H256>,
+	SB: SignedBlockT<Public = sp_core::ed25519::Public, Signature = MultiSignature>,
+	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
+	RpcAuthor:
+		AuthorApi<H256, PB::Hash> + OnBlockCreated<Hash = PB::Hash> + SendState<Hash = PB::Hash>,
+	StfExecutor: StfExecuteTimedCallsBatch + StfExecuteTimedGettersBatch,
+	<StfExecutor as StfExecuteTimedCallsBatch>::Externalities:
+		SgxExternalitiesTrait + SidechainState + SidechainSystemExt + StateHash,
+{
+	pub fn new(rpc_author: Arc<RpcAuthor>, stf_executor: Arc<StfExecutor>) -> Self {
+		TopPoolOperationExecutor { rpc_author, stf_executor, _phantom: Default::default() }
+	}
+}
+
+impl<PB, SB, RpcAuthor, StfExecutor> ExecuteGettersOnTopPool
+	for TopPoolOperationExecutor<PB, SB, RpcAuthor, StfExecutor>
+where
+	PB: BlockT<Hash = H256>,
+	SB: SignedBlockT<Public = sp_core::ed25519::Public, Signature = MultiSignature>,
+	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
+	RpcAuthor:
+		AuthorApi<H256, PB::Hash> + OnBlockCreated<Hash = PB::Hash> + SendState<Hash = PB::Hash>,
+	StfExecutor: StfExecuteTimedCallsBatch + StfExecuteTimedGettersBatch,
+	<StfExecutor as StfExecuteTimedCallsBatch>::Externalities:
+		SgxExternalitiesTrait + SidechainState + SidechainSystemExt + StateHash,
+{
+	/// Execute pending trusted getters for the `shard` until `max_exec_duration` is reached.
+	fn execute_trusted_getters_on_shard(
+		&self,
+		shard: &ShardIdentifier,
+		max_exec_duration: Duration,
+	) -> Result<()> {
+		// retrieve trusted operations from pool
+		let trusted_getters = self.rpc_author.get_pending_tops_separated(*shard)?.1;
+
+		type StfExecutorResult<T> = itp_stf_executor::error::Result<T>;
+
+		self.stf_executor
+			.execute_timed_getters_batch(
+				&trusted_getters,
+				&shard,
+				max_exec_duration,
+				|trusted_getter_signed: &TrustedGetterSigned,
+				 state_result: StfExecutorResult<Option<Vec<u8>>>| {
+					let hash_of_getter =
+						self.rpc_author.hash_of(&trusted_getter_signed.clone().into());
+
+					match state_result {
+						Ok(r) => {
+							// let client know of current state
+							trace!("Updating client");
+							match self.rpc_author.send_state(hash_of_getter, r.encode()) {
+								Ok(_) => trace!("Successfully updated client"),
+								Err(e) => error!("Could not send state to client {:?}", e),
+							}
+						},
+						Err(e) => {
+							error!("failed to get stf state, skipping trusted getter ({:?})", e);
+						},
+					};
+
+					// remove getter from pool
+					if let Err(e) = self.rpc_author.remove_top(
+						vec![TrustedOperationOrHash::Hash(hash_of_getter)],
+						*shard,
+						false,
+					) {
+						error!("Error removing trusted operation from top pool: Error: {:?}", e);
+					}
+				},
+			)
+			.map_err(Error::StfExecution)
+	}
+}
+
+impl<PB, SB, RpcAuthor, StfExecutor> ExecuteCallsOnTopPool
+	for TopPoolOperationExecutor<PB, SB, RpcAuthor, StfExecutor>
+where
+	PB: BlockT<Hash = H256>,
+	SB: SignedBlockT<Public = sp_core::ed25519::Public, Signature = MultiSignature>,
+	SB::Block: SidechainBlockT<ShardIdentifier = H256, Public = sp_core::ed25519::Public>,
+	RpcAuthor:
+		AuthorApi<H256, PB::Hash> + OnBlockCreated<Hash = PB::Hash> + SendState<Hash = PB::Hash>,
+	StfExecutor: StfExecuteTimedCallsBatch + StfExecuteTimedGettersBatch,
+	<StfExecutor as StfExecuteTimedCallsBatch>::Externalities:
+		SgxExternalitiesTrait + SidechainState + SidechainSystemExt + StateHash,
+{
+	type ParentchainBlockT = PB;
+
+	fn execute_trusted_calls(
+		&self,
+		latest_onchain_header: &PB::Header,
+		shard: H256,
+		max_exec_duration: Duration,
+	) -> Result<BatchExecutionResult> {
+		// retrieve trusted operations from pool
+		let trusted_calls = self.rpc_author.get_pending_tops_separated(shard)?.0;
+
+		// Todo: remove when we have proper on-boarding of new workers #273.
+		if trusted_calls.is_empty() {
+			info!("No trusted calls in top for shard: {:?}", shard);
+		// we return here when we actually import sidechain blocks because we currently have no
+		// means of worker on-boarding. Without on-boarding we have can't get a working multi
+		// worker-setup.
+		//
+		// But if we use this trick (only produce a sidechain block if there are trusted_calls), we
+		// we can simply wait with the submission of trusted calls until all workers are ready. Then
+		// we don't need to exchange any state and can have a functional multi-worker setup.
+		// return Ok(Default::default())
+		} else {
+			debug!("Got following trusted calls from pool: {:?}", trusted_calls);
+		}
+
+		let batch_execution_result = self.stf_executor.execute_timed_calls_batch::<PB, _>(
+			&trusted_calls,
+			latest_onchain_header,
+			&shard,
+			max_exec_duration,
+			|s| {
+				let mut sidechain_db = SidechainDB::<
+					SB::Block,
+					<StfExecutor as StfExecuteTimedCallsBatch>::Externalities,
+				>::new(s);
+				sidechain_db
+					.set_block_number(&sidechain_db.get_block_number().map_or(1, |n| n + 1));
+				sidechain_db.set_timestamp(&now_as_u64());
+				sidechain_db.ext
+			},
+		)?;
+
+		for executed_operation in batch_execution_result.executed_operations.iter() {
+			self.rpc_author
+				.remove_top(
+					vec![executed_operation.trusted_operation_or_hash.clone()],
+					shard,
+					executed_operation.is_success(),
+				)
+				.map_err(|e| Error::Other(e.into()))?;
+		}
+
+		Ok(batch_execution_result)
+	}
+}

--- a/enclave-runtime/src/utils.rs
+++ b/enclave-runtime/src/utils.rs
@@ -19,7 +19,7 @@ use codec::{Decode, Error, Input};
 use its_sidechain::slots::duration_now;
 use log::*;
 use sgx_types::sgx_status_t;
-use std::{slice, time::Duration, vec::Vec};
+use std::{slice, vec::Vec};
 
 pub fn hash_from_slice(hash_slize: &[u8]) -> Hash {
 	let mut g = [0; 32];
@@ -70,11 +70,6 @@ pub unsafe fn utf8_str_from_raw<'a>(
 	let bytes = slice::from_raw_parts(data, len);
 
 	std::str::from_utf8(bytes)
-}
-
-/// calculates the remaining time `until`.
-pub fn remaining_time(until: Duration) -> Option<Duration> {
-	until.checked_sub(duration_now())
 }
 
 /// returns current duration since unix epoch in millis as u64

--- a/sidechain/consensus/common/src/block_import.rs
+++ b/sidechain/consensus/common/src/block_import.rs
@@ -57,7 +57,7 @@ where
 		F: FnOnce(Self::SidechainState) -> Result<Self::SidechainState, Error>;
 
 	/// key that is used for state encryption
-	fn state_key() -> Result<Self::StateCrypto, Error>;
+	fn state_key(&self) -> Self::StateCrypto;
 
 	/// import the block
 	fn import_block(
@@ -75,7 +75,7 @@ where
 
 			let update = state_update_from_encrypted(
 				block_import_params.block().state_payload(),
-				Self::state_key()?,
+				self.state_key(),
 			)?;
 
 			state.apply_state_update(&update).map_err(|e| Error::Other(e.into()))?;

--- a/sidechain/top-pool-rpc-author/src/author_tests.rs
+++ b/sidechain/top-pool-rpc-author/src/author_tests.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	author::Author,
-	test_utils::submit_and_execute_top,
+	test_utils::submit_operation_to_top_pool,
 	top_filter::{AllowAllTopsFilter, Filter, GettersOnlyFilter},
 };
 use codec::{Decode, Encode};
@@ -67,7 +67,7 @@ pub fn submitting_to_author_inserts_in_pool() {
 	let top = TrustedOperation::from(trusted_getter_signed());
 
 	let submit_response: H256 =
-		submit_and_execute_top(&author, &top, &shielding_key, shard_id()).unwrap();
+		submit_operation_to_top_pool(&author, &top, &shielding_key, shard_id()).unwrap();
 
 	assert!(!submit_response.is_zero());
 
@@ -79,7 +79,7 @@ pub fn submitting_call_to_author_when_top_is_filtered_returns_error() {
 	let (author, top_pool, shielding_key) = create_author_with_filter(GettersOnlyFilter);
 	let top = TrustedOperation::from(trusted_call_signed());
 
-	let submit_response = submit_and_execute_top(&author, &top, &shielding_key, shard_id());
+	let submit_response = submit_operation_to_top_pool(&author, &top, &shielding_key, shard_id());
 
 	assert!(submit_response.is_err());
 	assert!(top_pool.get_last_submitted_transactions().is_empty());
@@ -90,7 +90,7 @@ pub fn submitting_getter_to_author_when_top_is_filtered_inserts_in_pool() {
 	let top = TrustedOperation::from(trusted_getter_signed());
 
 	let submit_response =
-		submit_and_execute_top(&author, &top, &shielding_key, shard_id()).unwrap();
+		submit_operation_to_top_pool(&author, &top, &shielding_key, shard_id()).unwrap();
 
 	assert!(!submit_response.is_zero());
 	assert_eq!(1, top_pool.get_last_submitted_transactions().len());

--- a/sidechain/top-pool-rpc-author/src/test_utils.rs
+++ b/sidechain/top-pool-rpc-author/src/test_utils.rs
@@ -26,10 +26,8 @@ use jsonrpc_core::futures::executor;
 use sp_core::H256;
 use std::{fmt::Debug, vec::Vec};
 
-/// Test utility function to submit and execute a trusted operation on an RPC author
-///
-/// The trusted operation will be executed in a blocking (i.e. synchronous) fashion
-pub fn submit_and_execute_top<R, S>(
+/// Test utility function to submit a trusted operation on an RPC author
+pub fn submit_operation_to_top_pool<R, S>(
 	author: &R,
 	top: &TrustedOperation,
 	shielding_key: &S,
@@ -46,8 +44,6 @@ where
 }
 
 /// Get all pending trusted operations, grouped into calls and getters
-///
-///
 pub fn get_pending_tops_separated<R>(
 	rpc_author: &R,
 	shard: ShardIdentifier,


### PR DESCRIPTION
Created new traits/components that execute the trusted operations from the top pool.
Also separated the execution and block/confirmation composition.

The is in preparation for moving these parts into the sidechain crate.

- [x] Merge #498 first, then rebase this onto master