### PR TITLE
[enclave-runtime] remove misleading feature imports from patches

### DIFF
--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -112,13 +112,13 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 
 [patch.crates-io]
 log = { git = "https://github.com/mesalock-linux/log-sgx" }
-env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx", default-features = false, features = ["mesalock_sgx"] }
-getrandom = { git = "https://github.com/integritee-network/getrandom-sgx", branch = "update-v2.3", features = ["mesalock_sgx"] }
+env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx" }
+getrandom = { git = "https://github.com/integritee-network/getrandom-sgx", branch = "update-v2.3"}
 
 [patch."https://github.com/paritytech/substrate"]
 log = { git = "https://github.com/mesalock-linux/log-sgx" }
-env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx", default-features = false, features = ["mesalock_sgx"] }
-sp-io = { git = "https://github.com/integritee-network/sgx-runtime", branch = "master", default-features = false, features = ["disable_oom", "disable_panic_handler", "disable_allocator", "sgx"]}
+env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx" }
+sp-io = { git = "https://github.com/integritee-network/sgx-runtime", branch = "master"}
 
 #[patch."https://github.com/integritee-network/sgx-runtime"]
 #sgx-runtime = { path = "../sgx-runtime/runtime", default-features = false}


### PR DESCRIPTION
Removes feature imports from patches as they are ignored by the compiler and are thus misleading. (And the compiler warns about them, which is not a good sign)