### PR TITLE
Refactor locking mechanism of light client to ensure granular exclusive access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,6 +2183,8 @@ dependencies = [
  "itp-settings",
  "itp-sgx-io",
  "itp-storage",
+ "itp-types",
+ "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.14",
  "parity-scale-codec",

--- a/core/light-client/Cargo.toml
+++ b/core/light-client/Cargo.toml
@@ -39,6 +39,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 derive_more = { version = "0.99.5" }
 finality-grandpa = { version = "0.14.3", default-features = false, features = ["derive-codec"] }
 hash-db = { version = "0.15.2", default-features = false }
+lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 log = { version = "0.4.14", default-features = false }
 num = { package = "num-traits", version = "0.2", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
@@ -61,3 +62,6 @@ sp-application-crypto = { version = "4.0.0-dev", default-features = false, featu
 sp-finality-grandpa = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-trie = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master" }
+
+[dev-dependencies]
+itp-types = { path = "../../core-primitives/types" }

--- a/core/light-client/src/concurrent_access.rs
+++ b/core/light-client/src/concurrent_access.rs
@@ -53,12 +53,12 @@ where
 {
 	type ValidatorType: Validator<PB> + LightClientState<PB>;
 
-	/// Execute a non-mutating function on the validator
+	/// Execute a non-mutating function on the validator.
 	fn execute_on_validator<F, R>(&self, getter_function: F) -> Result<R>
 	where
 		F: FnOnce(&Self::ValidatorType) -> Result<R>;
 
-	/// Execute a mutating function on the validator
+	/// Execute a mutating function on the validator.
 	fn execute_mut_on_validator<F, R>(&self, mutating_function: F) -> Result<R>
 	where
 		F: FnOnce(&mut Self::ValidatorType) -> Result<R>;

--- a/core/light-client/src/concurrent_access.rs
+++ b/core/light-client/src/concurrent_access.rs
@@ -15,6 +15,9 @@
 
 */
 
+//! Concurrent access mechanisms that ensure mutually exclusive read/write access
+//! to the light-client (validator) by employing RwLocks under the hood.
+
 #[cfg(feature = "sgx")]
 use std::sync::SgxRwLock as RwLock;
 
@@ -32,8 +35,8 @@ use sp_runtime::traits::{Block as BlockT, NumberFor};
 use std::marker::PhantomData;
 
 lazy_static! {
-	// as long as we have a file backend, we use this 'dummy' lock,
-	// which guards against concurrent read/write access
+	// As long as we have a file backend, we use this 'dummy' lock,
+	// which guards against concurrent read/write access.
 	pub static ref VALIDATOR_LOCK: RwLock<()> = Default::default();
 }
 

--- a/core/light-client/src/concurrent_access.rs
+++ b/core/light-client/src/concurrent_access.rs
@@ -1,0 +1,142 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(feature = "sgx")]
+use std::sync::SgxRwLock as RwLock;
+
+#[cfg(feature = "std")]
+use std::sync::RwLock;
+
+use crate::{
+	error::{Error, Result},
+	LightClientState, Validator,
+};
+use finality_grandpa::BlockNumberOps;
+use itp_sgx_io::SealedIO;
+use lazy_static::lazy_static;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::marker::PhantomData;
+
+lazy_static! {
+	// as long as we have a file backend, we use this 'dummy' lock,
+	// which guards against concurrent read/write access
+	pub static ref VALIDATOR_LOCK: RwLock<()> = Default::default();
+}
+
+/// Retrieve an exclusive lock on a validator for either read or write access.
+///
+/// In order to hide the whole locks mechanics, we provide an interface that allows executing
+/// either a mutating, or a non-mutating function on the validator.
+/// The reason we have this additional wrapper around `SealedIO`, is that we need
+/// to guard against concurrent access by using RWLocks (which `SealedIO` does not do).
+pub trait ValidatorAccess<PB>
+where
+	PB: BlockT,
+	NumberFor<PB>: BlockNumberOps,
+{
+	type ValidatorType: Validator<PB> + LightClientState<PB>;
+
+	fn execute_on_validator<F, R>(&self, getter_function: F) -> Result<R>
+	where
+		F: FnOnce(&Self::ValidatorType) -> Result<R>;
+
+	fn execute_mut_on_validator<F, R>(&self, mutating_function: F) -> Result<R>
+	where
+		F: FnOnce(&mut Self::ValidatorType) -> Result<R>;
+}
+
+/// Implementation of a validator access based on a global lock and corresponding file.
+#[derive(Clone, Debug)]
+pub struct GlobalValidatorAccessor<ValidatorT, PB, Seal>
+where
+	ValidatorT: Validator<PB> + LightClientState<PB>,
+	Seal: SealedIO<Error = Error, Unsealed = ValidatorT>,
+	PB: BlockT,
+	NumberFor<PB>: BlockNumberOps,
+{
+	_phantom: PhantomData<(Seal, ValidatorT, PB)>,
+}
+
+impl<ValidatorT, PB, Seal> Default for GlobalValidatorAccessor<ValidatorT, PB, Seal>
+where
+	ValidatorT: Validator<PB> + LightClientState<PB>,
+	Seal: SealedIO<Error = Error, Unsealed = ValidatorT>,
+	PB: BlockT,
+	NumberFor<PB>: BlockNumberOps,
+{
+	fn default() -> Self {
+		GlobalValidatorAccessor { _phantom: Default::default() }
+	}
+}
+
+impl<ValidatorT, PB, Seal> GlobalValidatorAccessor<ValidatorT, PB, Seal>
+where
+	ValidatorT: Validator<PB> + LightClientState<PB>,
+	Seal: SealedIO<Error = Error, Unsealed = ValidatorT>,
+	PB: BlockT,
+	NumberFor<PB>: BlockNumberOps,
+{
+	pub fn new() -> Self {
+		GlobalValidatorAccessor { _phantom: Default::default() }
+	}
+}
+
+impl<ValidatorT, PB, Seal> ValidatorAccess<PB> for GlobalValidatorAccessor<ValidatorT, PB, Seal>
+where
+	ValidatorT: Validator<PB> + LightClientState<PB>,
+	Seal: SealedIO<Error = Error, Unsealed = ValidatorT>,
+	PB: BlockT,
+	NumberFor<PB>: BlockNumberOps,
+{
+	type ValidatorType = ValidatorT;
+
+	fn execute_on_validator<F, R>(&self, getter_function: F) -> Result<R>
+	where
+		F: FnOnce(&Self::ValidatorType) -> Result<R>,
+	{
+		let _read_lock = VALIDATOR_LOCK.read().map_err(|_| Error::PoisonedLock)?;
+		let validator = Seal::unseal()?;
+		getter_function(&validator)
+	}
+
+	fn execute_mut_on_validator<F, R>(&self, mutating_function: F) -> Result<R>
+	where
+		F: FnOnce(&mut Self::ValidatorType) -> Result<R>,
+	{
+		let _write_lock = VALIDATOR_LOCK.write().map_err(|_| Error::PoisonedLock)?;
+		let mut validator = Seal::unseal()?;
+		let result = mutating_function(&mut validator);
+		Seal::seal(validator)?;
+		result
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::mocks::{validator_mock::ValidatorMock, validator_mock_seal::ValidatorMockSeal};
+	use itp_types::Block;
+
+	type TestAccessor = GlobalValidatorAccessor<ValidatorMock, Block, ValidatorMockSeal>;
+
+	#[test]
+	fn execute_with_and_without_mut_in_single_thread_works() {
+		let accessor = TestAccessor::default();
+		let _read_result = accessor.execute_on_validator(|_v| Ok(())).unwrap();
+		let _write_result = accessor.execute_mut_on_validator(|_v| Ok(())).unwrap();
+	}
+}

--- a/core/light-client/src/concurrent_access.rs
+++ b/core/light-client/src/concurrent_access.rs
@@ -53,10 +53,12 @@ where
 {
 	type ValidatorType: Validator<PB> + LightClientState<PB>;
 
+	/// Execute a non-mutating function on the validator
 	fn execute_on_validator<F, R>(&self, getter_function: F) -> Result<R>
 	where
 		F: FnOnce(&Self::ValidatorType) -> Result<R>;
 
+	/// Execute a mutating function on the validator
 	fn execute_mut_on_validator<F, R>(&self, mutating_function: F) -> Result<R>
 	where
 		F: FnOnce(&mut Self::ValidatorType) -> Result<R>;

--- a/core/light-client/src/error.rs
+++ b/core/light-client/src/error.rs
@@ -49,6 +49,8 @@ pub enum Error {
 	InvalidFinalityProof(#[from] JustificationError),
 	#[error("Header ancestry mismatch")]
 	HeaderAncestryMismatch,
+	#[error("Poisoned validator lock")]
+	PoisonedLock,
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/core/light-client/src/lib.rs
+++ b/core/light-client/src/lib.rs
@@ -116,7 +116,7 @@ where
 		extrinsic: OpaqueExtrinsic,
 	) -> Result<(), Error>;
 
-	/// Sends encoded extrinsics to the parentchain.
+	/// Sends encoded extrinsics to the parentchain and cache them internally for later confirmation.
 	fn send_extrinsics<OCallApi: EnclaveOnChainOCallApi>(
 		&mut self,
 		ocall_api: &OCallApi,

--- a/core/light-client/src/mocks/mod.rs
+++ b/core/light-client/src/mocks/mod.rs
@@ -1,0 +1,19 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+pub mod validator_mock;
+pub mod validator_mock_seal;

--- a/core/light-client/src/mocks/validator_mock.rs
+++ b/core/light-client/src/mocks/validator_mock.rs
@@ -1,0 +1,103 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{error::Result, AuthorityList, HashFor, LightClientState, RelayId, SetId, Validator};
+use itp_ocall_api::EnclaveOnChainOCallApi;
+use itp_storage::StorageProof;
+use itp_types::Block;
+use sp_runtime::{traits::Block as BlockT, Justifications, OpaqueExtrinsic};
+use std::vec::Vec;
+
+type Header = <Block as BlockT>::Header;
+
+/// Validator mock to be used in tests.
+#[derive(Clone, Copy, Debug)]
+pub struct ValidatorMock;
+
+impl Validator<Block> for ValidatorMock {
+	fn initialize_relay(
+		&mut self,
+		_block_header: Header,
+		_validator_set: AuthorityList,
+		_validator_set_proof: StorageProof,
+	) -> Result<RelayId> {
+		todo!()
+	}
+
+	fn submit_finalized_headers(
+		&mut self,
+		_relay_id: RelayId,
+		_header: Header,
+		_ancestry_proof: Vec<Header>,
+		_validator_set: AuthorityList,
+		_validator_set_id: SetId,
+		_justifications: Option<Justifications>,
+	) -> Result<()> {
+		todo!()
+	}
+
+	fn submit_simple_header(
+		&mut self,
+		_relay_id: RelayId,
+		_header: Header,
+		_justifications: Option<Justifications>,
+	) -> Result<()> {
+		todo!()
+	}
+
+	fn submit_xt_to_be_included(
+		&mut self,
+		_relay_id: RelayId,
+		_extrinsic: OpaqueExtrinsic,
+	) -> Result<()> {
+		todo!()
+	}
+
+	fn send_extrinsics<OCallApi: EnclaveOnChainOCallApi>(
+		&mut self,
+		_ocall_api: &OCallApi,
+		_extrinsics: Vec<OpaqueExtrinsic>,
+	) -> Result<()> {
+		todo!()
+	}
+
+	fn check_xt_inclusion(&mut self, _relay_id: RelayId, _block: &Block) -> Result<()> {
+		todo!()
+	}
+}
+
+impl LightClientState<Block> for ValidatorMock {
+	fn num_xt_to_be_included(&mut self, _relay_id: RelayId) -> Result<usize> {
+		todo!()
+	}
+
+	fn genesis_hash(&self, _relay_id: RelayId) -> Result<HashFor<Block>> {
+		todo!()
+	}
+
+	fn latest_finalized_header(&self, _relay_id: RelayId) -> Result<Header> {
+		todo!()
+	}
+
+	fn penultimate_finalized_block_header(&self, _relay_id: RelayId) -> Result<Header> {
+		todo!()
+	}
+
+	fn num_relays(&self) -> RelayId {
+		todo!()
+	}
+}

--- a/core/light-client/src/mocks/validator_mock_seal.rs
+++ b/core/light-client/src/mocks/validator_mock_seal.rs
@@ -18,7 +18,7 @@
 use crate::{error::Error, mocks::validator_mock::ValidatorMock};
 use itp_sgx_io::SealedIO;
 
-/// A seal that return a mock validator.
+/// A seal that returns a mock validator.
 #[derive(Clone)]
 pub struct ValidatorMockSeal;
 

--- a/core/light-client/src/mocks/validator_mock_seal.rs
+++ b/core/light-client/src/mocks/validator_mock_seal.rs
@@ -1,0 +1,36 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{error::Error, mocks::validator_mock::ValidatorMock};
+use itp_sgx_io::SealedIO;
+
+/// A seal that return a mock validator.
+#[derive(Clone)]
+pub struct ValidatorMockSeal;
+
+impl SealedIO for ValidatorMockSeal {
+	type Error = Error;
+	type Unsealed = ValidatorMock;
+
+	fn unseal() -> Result<Self::Unsealed, Self::Error> {
+		Ok(ValidatorMock)
+	}
+
+	fn seal(_unsealed: Self::Unsealed) -> Result<(), Self::Error> {
+		Ok(())
+	}
+}

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "itp-settings",
  "itp-sgx-io",
  "itp-storage",
+ "lazy_static",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "num-traits 0.2.14",
  "parity-scale-codec",

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -36,7 +36,6 @@ use crate::{
 	error::{Error, Result},
 	ocall::OcallApi,
 	rpc::worker_api_direct::{public_api_rpc_handler, side_chain_io_handler},
-	sync::{EnclaveLock, LightClientRwLock},
 	utils::{
 		hash_from_slice, utf8_str_from_raw, write_slice_and_whitespace_pad, DecodeRaw,
 		UnwrapOrSgxErrorUnexpected,
@@ -51,7 +50,8 @@ use itc_direct_rpc_server::{
 	rpc_ws_handler::RpcWsHandler,
 };
 use itc_light_client::{
-	io::LightClientSeal, BlockNumberOps, LightClientState, NumberFor, Validator,
+	concurrent_access::ValidatorAccess, BlockNumberOps, LightClientState, NumberFor, Validator,
+	ValidatorAccessor,
 };
 use itc_tls_websocket_server::{connection::TungsteniteWsConnection, run_ws_server};
 use itp_extrinsics_factory::{CreateExtrinsics, ExtrinsicsFactory};
@@ -491,34 +491,28 @@ where
 	PB: BlockT<Hash = H256>,
 	NumberFor<PB>: BlockNumberOps,
 {
-	// we acquire lock explicitly (variable binding), since '_' will drop the lock after the statement
-	// see https://medium.com/codechain/rust-underscore-does-not-bind-fec6a18115a8
-	let _light_client_lock = EnclaveLock::write_light_client_db()?;
+	let validator_access = ValidatorAccessor::<PB>::default();
+	let genesis_hash = validator_access.execute_on_validator(|v| v.genesis_hash(v.num_relays()))?;
 
-	let mut validator = LightClientSeal::<PB>::unseal()?;
 	let signer = Ed25519Seal::unseal()?;
 	let stf_executor = StfExecutor::new(Arc::new(OcallApi), Arc::new(GlobalFileStateHandler));
-	let genesis_hash = validator.genesis_hash(validator.num_relays())?;
 	let extrinsics_factory =
 		ExtrinsicsFactory::new(genesis_hash, signer, GLOBAL_NONCE_CACHE.clone());
 
 	sync_blocks_on_light_client(
 		blocks_to_sync,
-		&mut validator,
+		&validator_access,
 		&extrinsics_factory,
 		&OcallApi,
 		&stf_executor,
 	)?;
 
-	// store updated state in light client in case we fail afterwards.
-	LightClientSeal::seal(validator)?;
-
 	Ok(())
 }
 
-fn sync_blocks_on_light_client<PB, V, OCallApi, StfExecutor, ExtrinsicsFactory>(
+fn sync_blocks_on_light_client<PB, ValidatorAccessor, OCallApi, StfExecutor, ExtrinsicsFactory>(
 	blocks_to_sync: Vec<SignedBlockG<PB>>,
-	validator: &mut V,
+	validator_access: &ValidatorAccessor,
 	extrinsics_factory: &ExtrinsicsFactory,
 	on_chain_ocall_api: &OCallApi,
 	stf_executor: &StfExecutor,
@@ -526,7 +520,7 @@ fn sync_blocks_on_light_client<PB, V, OCallApi, StfExecutor, ExtrinsicsFactory>(
 where
 	PB: BlockT<Hash = H256>,
 	NumberFor<PB>: BlockNumberOps,
-	V: Validator<PB> + LightClientState<PB>,
+	ValidatorAccessor: ValidatorAccess<PB>,
 	OCallApi: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
 	StfExecutor: StfUpdateState + StfExecuteTrustedCall + StfExecuteShieldFunds,
 	ExtrinsicsFactory: CreateExtrinsics,
@@ -536,13 +530,13 @@ where
 	debug!("Syncing light client!");
 	for signed_block in blocks_to_sync.into_iter() {
 		let block = signed_block.block;
-		validator.check_xt_inclusion(validator.num_relays(), &block).unwrap(); // panic can only happen if relay_id does not exist
+		let justifications = signed_block.justifications.clone();
 
-		if let Err(e) = validator.submit_simple_header(
-			validator.num_relays(),
-			block.header().clone(),
-			signed_block.justifications.clone(),
-		) {
+		if let Err(e) = validator_access.execute_mut_on_validator(|v| {
+			v.check_xt_inclusion(v.num_relays(), &block)?;
+
+			v.submit_simple_header(v.num_relays(), block.header().clone(), justifications)
+		}) {
 			error!("Block verification failed. Error : {:?}", e);
 			return Err(e.into())
 		}
@@ -569,7 +563,7 @@ where
 
 	let xts = extrinsics_factory.create_extrinsics(calls.as_slice())?;
 
-	validator.send_extrinsics(on_chain_ocall_api, xts)?;
+	validator_access.execute_mut_on_validator(|v| v.send_extrinsics(on_chain_ocall_api, xts))?;
 
 	Ok(())
 }

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -563,6 +563,7 @@ where
 
 	let xts = extrinsics_factory.create_extrinsics(calls.as_slice())?;
 
+	// Sending the extrinsic requires mut access because the validator caches the sent extrinsics internally.
 	validator_access.execute_mut_on_validator(|v| v.send_extrinsics(on_chain_ocall_api, xts))?;
 
 	Ok(())

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -546,7 +546,7 @@ where
 			return Err(e.into())
 		}
 
-		// execute indirect calls, incl. shielding and unshielding
+		// Execute indirect calls, incl. shielding and unshielding.
 		match scan_block_for_relevant_xt(&block, stf_executor) {
 			Ok((unshielding_call_confirmations, executed_shielding_calls)) => {
 				// Include all unshieldung confirmations that need to be executed on the parentchain.


### PR DESCRIPTION
Before we acquired a (write) lock for an entire e-call, and it had to be done explicitly and thus could be forgotten. Now we acquire the lock implicitly when we read or write from/to the light client and on a per-operation basis.

This is a preparation for #423, where we will need to modify the block import behavior and need granular locking to prevent deadlocks.