### PR TITLE
Increase sleep time for local setup after increase of block production time

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -207,7 +207,7 @@ jobs:
         run: |
           touch ${{ env.LOG_DIR}}/local-setup.log
           ./local-setup/launch.py local-setup/github-action-config.json 2>&1 | tee ${{ env.LOG_DIR}}/local-setup.log &
-          sleep 30
+          sleep 45
 
       - name: ${{ matrix.demo_name }}
         # * the change the symbolic link which points to the target/release... folder.


### PR DESCRIPTION
This should fix some CI failures we see after we increased the block production time in the node from 6s to 12s
(see https://github.com/integritee-network/integritee-node/commit/ada0c26a133e82787ff4a2028ae7f8fcb3d08510)
