### PR TITLE
Update teaclave sgx libraries 1.1.4 from testing branch to master branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1586,7 +1586,7 @@ dependencies = [
 [[package]]
 name = "hashbrown_tstd"
 version = "0.11.2"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "heck"
@@ -5597,12 +5597,12 @@ dependencies = [
 [[package]]
 name = "sgx_alloc"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_backtrace_sys"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "cc",
  "sgx_build_helper",
@@ -5612,12 +5612,12 @@ dependencies = [
 [[package]]
 name = "sgx_build_helper"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_crypto_helper"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "itertools",
  "libc",
@@ -5636,12 +5636,12 @@ dependencies = [
 [[package]]
 name = "sgx_demangle"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_libc"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_types",
 ]
@@ -5649,7 +5649,7 @@ dependencies = [
 [[package]]
 name = "sgx_rand"
 version = "1.1.4"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_trts",
  "sgx_tstd",
@@ -5659,7 +5659,7 @@ dependencies = [
 [[package]]
 name = "sgx_tcrypto"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_types",
 ]
@@ -5667,7 +5667,7 @@ dependencies = [
 [[package]]
 name = "sgx_tcrypto_helper"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_crypto_helper",
 ]
@@ -5675,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "sgx_tprotected_fs"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_trts",
  "sgx_types",
@@ -5684,7 +5684,7 @@ dependencies = [
 [[package]]
 name = "sgx_trts"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_libc",
  "sgx_types",
@@ -5693,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "sgx_tstd"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "hashbrown_tstd",
  "sgx_alloc",
@@ -5709,12 +5709,12 @@ dependencies = [
 [[package]]
 name = "sgx_types"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_ucrypto"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "libc",
  "rand_core 0.3.1",
@@ -5725,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "sgx_unwind"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_build_helper",
 ]
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "sgx_urts"
 version = "1.1.4"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "libc",
  "sgx_types",
@@ -7606,14 +7606,14 @@ dependencies = [
 [[patch.unused]]
 name = "sgx_serialize"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[patch.unused]]
 name = "sgx_serialize_derive"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[patch.unused]]
 name = "sgx_serialize_derive_internals"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,15 +48,15 @@ members = [
 ]
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
-sgx_tstd = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_alloc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_libc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_serialize = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_serialize_derive = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_serialize_derive_internals = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_trts = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_types = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_ucrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_tcrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_tcrypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_crypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_tstd = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_alloc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_libc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_serialize = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_serialize_derive = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_serialize_derive_internals = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_trts = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_types = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_ucrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_tcrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_tcrypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_crypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -45,7 +45,7 @@ base58 = { version = "0.1", optional = true }
 derive_more = { version = "0.99.5" }
 hex = { version = "0.4.2", optional = true }
 codec = { version = "2.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-sgx_tstd = { branch = "v1.1.4-testing", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local crates
 itp-storage = { path = "../../core-primitives/storage", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,7 +22,7 @@ geojson = "0.17"
 ws = { version = "0.9.1", features = ["ssl"] }
 serde = { version = "1.0", features = ["derive"] }
 codec = { version = "2.0.0", package = "parity-scale-codec", features = ["derive"] }
-sgx_crypto_helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # scs / integritee
 substrate-api-client = { features = ["ws-client"], git = "https://github.com/scs/substrate-api-client", branch = "master" }

--- a/core-primitives/component-container/Cargo.toml
+++ b/core-primitives/component-container/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [dependencies]
 # sgx dependencies
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [features]
 default = ["std"]

--- a/core-primitives/enclave-api/Cargo.toml
+++ b/core-primitives/enclave-api/Cargo.toml
@@ -10,9 +10,9 @@ log 	    = "0.4"
 serde_json 	= "1.0"
 codec       = { package = "parity-scale-codec", version = "2.0.0", features = ["derive"] }
 
-sgx_types           = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_urts            = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_crypto_helper 	= { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types           = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_urts            = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper 	= { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 frame-support       = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }
 sp-core             = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }

--- a/core-primitives/enclave-api/ffi/Cargo.toml
+++ b/core-primitives/enclave-api/ffi/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sgx_types   = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types   = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }

--- a/core-primitives/extrinsics-factory/Cargo.toml
+++ b/core-primitives/extrinsics-factory/Cargo.toml
@@ -24,8 +24,8 @@ sgx = [
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 substrate-api-client = { default-features = false, git = "https://github.com/scs/substrate-api-client", branch = "master" }
 
 # local dependencies

--- a/core-primitives/nonce-cache/Cargo.toml
+++ b/core-primitives/nonce-cache/Cargo.toml
@@ -20,7 +20,7 @@ sgx = [
 
 [dependencies]
 # sgx dependencies
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 

--- a/core-primitives/ocall-api/Cargo.toml
+++ b/core-primitives/ocall-api/Cargo.toml
@@ -13,7 +13,7 @@ sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://g
 sp-std = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}
 
 # sgx-deps
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local deps
 itp-types = { path = "../types", default-features = false }

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -15,10 +15,10 @@ serde = { version = "1.0", default-features = false, features = ["alloc"] , opti
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] , optional = true }
 
 # sgx deps
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_rand = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_rand = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
 serde-sgx = { package = "serde", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx" , optional = true  }
 serde_json-sgx = { package = "serde_json", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx" , optional = true  }
 

--- a/core-primitives/sgx/io/Cargo.toml
+++ b/core-primitives/sgx/io/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 
 # sgx deps
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [features]
 default = ["std"]

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -31,8 +31,8 @@ test = []
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
 
 # local dependencies

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -32,9 +32,9 @@ test = []
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tcrypto = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tcrypto = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }
 itp-settings = { path = "../../core-primitives/settings" }

--- a/core-primitives/storage-verified/Cargo.toml
+++ b/core-primitives/storage-verified/Cargo.toml
@@ -8,7 +8,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 derive_more = { version = "0.99.5" }
 
 # sgx deps
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # substrate deps
 sp-core = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/core-primitives/storage/Cargo.toml
+++ b/core-primitives/storage/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = { version = "1.0.26", optional = true }
 
 # sgx deps
 thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # substrate deps
 frame-metadata = { version = "14.0.0", features = ["v13"], default-features = false, git = "https://github.com/paritytech/frame-metadata.git", branch = "main" }

--- a/core-primitives/test/Cargo.toml
+++ b/core-primitives/test/Cargo.toml
@@ -8,9 +8,9 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 derive_more = { version = "0.99.5" }
 
 # sgx deps
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
 jsonrpc-core = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
 

--- a/core-primitives/time-utils/Cargo.toml
+++ b/core-primitives/time-utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 [features]
 default = ["std"]

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -12,7 +12,7 @@ serde           = { version = "1.0", default-features = false, features = ["allo
 serde_json      = { version = "1.0", default-features = false, features = ["alloc"] }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master", default-features = false }
 
-sgx_tstd = { branch = "v1.1.4-testing", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true}
+sgx_tstd = { branch = "master", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true}
 
 # local deps
 itp-storage = { path = "../storage", default-features = false }

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -25,8 +25,8 @@ std = [
 
 [dependencies]
 # sgx dependencies
-sgx_types   = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd    = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_types   = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd    = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
 
 # no-std dependencies
 codec  = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }

--- a/core/parentchain/block-import-dispatcher/Cargo.toml
+++ b/core/parentchain/block-import-dispatcher/Cargo.toml
@@ -7,8 +7,8 @@ resolver = "2"
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 itc-parentchain-block-import-queue = { path = "../block-import-queue", default-features = false }

--- a/core/parentchain/block-import-queue/Cargo.toml
+++ b/core/parentchain/block-import-queue/Cargo.toml
@@ -7,8 +7,8 @@ resolver = "2"
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/core/parentchain/block-importer/Cargo.toml
+++ b/core/parentchain/block-importer/Cargo.toml
@@ -7,8 +7,8 @@ resolver = "2"
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 ita-stf = { path = "../../../app-libs/stf", default-features = false }

--- a/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -7,8 +7,8 @@ resolver = "2"
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 ita-stf = { path = "../../../app-libs/stf", default-features = false }

--- a/core/parentchain/light-client/Cargo.toml
+++ b/core/parentchain/light-client/Cargo.toml
@@ -45,8 +45,8 @@ num = { package = "num-traits", version = "0.2", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
 
 # sgx-deps
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs"], optional = true}
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs"], optional = true}
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # local deps

--- a/core/rest-client/Cargo.toml
+++ b/core/rest-client/Cargo.toml
@@ -34,8 +34,8 @@ url = { version = "2.0.0", optional = true }
 # sgx dependencies
 http_req-sgx = { package = "http_req", git = "https://github.com/mesalock-linux/http_req-sgx", tag = "sgx_1.1.3", optional = true }
 http-sgx = { package = "http", git = "https://github.com/mesalock-linux/http-sgx", tag = "sgx_1.1.3", optional = true }
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 url_sgx = { package = "url", git = "https://github.com/mesalock-linux/rust-url-sgx", tag = "sgx_1.1.3", optional = true }
 

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -11,7 +11,7 @@ url = { version = "2.0.0" }
 log = "0.4"
 serde_json = "1.0"
 serde_derive = "1.0"
-sgx_crypto_helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 
 [dependencies.itp-types]

--- a/core/tls-websocket-server/Cargo.toml
+++ b/core/tls-websocket-server/Cargo.toml
@@ -28,8 +28,8 @@ std = [
 
 [dependencies]
 # sgx dependencies
-sgx_types   = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd    = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_types   = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd    = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
 
 # sgx enabled external libraries
 mio_sgx         = { package = "mio",            git = "https://github.com/mesalock-linux/mio-sgx",                  tag = "sgx_1.1.3",              optional = true }

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1002,7 +1002,7 @@ dependencies = [
 [[package]]
 name = "hashbrown_tstd"
 version = "0.11.2"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "hex"
@@ -2967,12 +2967,12 @@ dependencies = [
 [[package]]
 name = "sgx_alloc"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_backtrace_sys"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "cc",
  "sgx_build_helper",
@@ -2982,12 +2982,12 @@ dependencies = [
 [[package]]
 name = "sgx_build_helper"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_crypto_helper"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "itertools",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
@@ -3001,12 +3001,12 @@ dependencies = [
 [[package]]
 name = "sgx_demangle"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_libc"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_types",
 ]
@@ -3014,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "sgx_rand"
 version = "1.1.4"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_trts",
  "sgx_tstd",
@@ -3024,7 +3024,7 @@ dependencies = [
 [[package]]
 name = "sgx_serialize"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_tstd",
 ]
@@ -3032,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "sgx_serialize_derive"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "quote 0.3.15",
  "sgx_serialize_derive_internals",
@@ -3042,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "sgx_serialize_derive_internals"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "syn 0.11.11",
 ]
@@ -3050,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "sgx_tcrypto"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_types",
 ]
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "sgx_tcrypto_helper"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_crypto_helper",
 ]
@@ -3066,7 +3066,7 @@ dependencies = [
 [[package]]
 name = "sgx_tprotected_fs"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_trts",
  "sgx_types",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "sgx_trts"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_libc",
  "sgx_types",
@@ -3084,7 +3084,7 @@ dependencies = [
 [[package]]
 name = "sgx_tse"
 version = "1.1.4"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_types",
 ]
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "sgx_tseal"
 version = "1.1.4"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_tcrypto",
  "sgx_trts",
@@ -3103,7 +3103,7 @@ dependencies = [
 [[package]]
 name = "sgx_tstd"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "hashbrown_tstd",
  "sgx_alloc",
@@ -3119,7 +3119,7 @@ dependencies = [
 [[package]]
 name = "sgx_tunittest"
 version = "1.1.4"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_tstd",
 ]
@@ -3127,12 +3127,12 @@ dependencies = [
 [[package]]
 name = "sgx_types"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 
 [[package]]
 name = "sgx_unwind"
 version = "1.1.4"
-source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=v1.1.4-testing#19355dc16d347331eb9949aec83ffe7103d9da94"
+source = "git+https://github.com/haerdib/incubator-teaclave-sgx-sdk?branch=master#863378876c55025084572e22554bbedd57eead97"
 dependencies = [
  "sgx_build_helper",
 ]

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -24,17 +24,17 @@ test = [
 ]
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
-sgx_tse = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs","net","backtrace"] }
-sgx_rand = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_trts = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tseal = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tcrypto = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_serialize = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_serialize_derive = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tunittest = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper" }
+sgx_tse = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs","net","backtrace"] }
+sgx_rand = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_trts = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tseal = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tcrypto = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_serialize = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_serialize_derive = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tunittest = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper" }
 
 [dependencies]
 codec  = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
@@ -125,14 +125,14 @@ sp-io = { git = "https://github.com/integritee-network/sgx-runtime", branch = "m
 #sgx-externalities = { path = "../../sgx-runtime/substrate-sgx/externalities"}
 
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
-sgx_tstd = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_alloc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_libc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_serialize = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_serialize_derive = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_serialize_derive_internals = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_trts = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_types = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_tcrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_tcrypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
-sgx_crypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "v1.1.4-testing"}
+sgx_tstd = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_alloc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_libc = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_serialize = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_serialize_derive = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_serialize_derive_internals = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_trts = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_types = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_tcrypto = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_tcrypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}
+sgx_crypto_helper = { version = "1.1.4", git = "https://github.com/haerdib/incubator-teaclave-sgx-sdk", branch = "master"}

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -35,9 +35,9 @@ sha2 = { version = "0.7", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.10.1", default-features = false, features = ["codec"] }
 
-sgx_urts = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_crypto_helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_urts = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local
 itp-settings = { path = "../core-primitives/settings" }

--- a/sidechain/block-composer/Cargo.toml
+++ b/sidechain/block-composer/Cargo.toml
@@ -7,8 +7,8 @@ resolver = "2"
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -10,7 +10,7 @@ finality-grandpa = { version = "0.14.3", default-features = false, features = ["
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
 
 # sgx deps
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # substrate deps
 frame-support = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -33,7 +33,7 @@ itp-sgx-crypto = { path = "../../../core-primitives/sgx/crypto", default-feature
 itp-types = { path = "../../../core-primitives/types", default-features = false }
 
 # sgx deps
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 sp-runtime = { version = "4.0.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -12,7 +12,7 @@ derive_more = "0.99.16"
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 
 # sgx deps
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 
 # substrate deps
 sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master"}

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -26,8 +26,8 @@ sgx = [
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 itp-types = { path = "../../core-primitives/types", default-features = false }

--- a/sidechain/state/Cargo.toml
+++ b/sidechain/state/Cargo.toml
@@ -53,7 +53,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 thiserror = { version = "1.0.9", optional = true }
 
 # sgx deps
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # sgx forks
 thiserror_sgx = { package = "thiserror", version = "1.0.9", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/sidechain/top-pool-executor/Cargo.toml
+++ b/sidechain/top-pool-executor/Cargo.toml
@@ -7,8 +7,8 @@ resolver = "2"
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }

--- a/sidechain/top-pool-rpc-author/Cargo.toml
+++ b/sidechain/top-pool-rpc-author/Cargo.toml
@@ -40,9 +40,9 @@ test = [ "itp-test/sgx" ]
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx-crypto-helper = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_tcrypto_helper", optional = true }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }

--- a/sidechain/top-pool/Cargo.toml
+++ b/sidechain/top-pool/Cargo.toml
@@ -36,8 +36,8 @@ std = [
 
 [dependencies]
 # sgx dependencies
-sgx_types = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd = { branch = "v1.1.4-testing", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread", "untrusted_time"] }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread", "untrusted_time"] }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }


### PR DESCRIPTION
We were using the teaclave sgx library versions 1.1.4 from their 'testing' branch. Now they've deleted that branch and moved everything to master. So we change all the references to that testing branch to `master`. 
This was noticed by @haerdib - thanks ☺️ 

This is related to issue #509 - although we cannot remove the patches yet, since mesalock have not updated their sgx ported libraries yet.