### PR TITLE
[sidechain] loop function without drift. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,7 +2765,7 @@ name = "its-consensus-slots"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "futures 0.3.17",
+ "futures 0.3.18",
  "futures-timer",
  "itp-sgx-io",
  "itp-time-utils",
@@ -2779,6 +2779,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-keyring",
  "sp-runtime",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2106,6 +2106,7 @@ dependencies = [
  "itp-enclave-api",
  "itp-settings",
  "itp-types",
+ "its-consensus-slots",
  "its-primitives",
  "its-storage",
  "jsonrpsee",
@@ -2764,6 +2765,8 @@ name = "its-consensus-slots"
 version = "0.8.0"
 dependencies = [
  "derive_more",
+ "futures 0.3.17",
+ "futures-timer",
  "itp-sgx-io",
  "itp-time-utils",
  "itp-types",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,7 +12,7 @@ log = "0.4"
 env_logger = "0.7"
 base58 = "0.1"
 rust-crypto = "0.2"
-clap = { version = "2.33", features = [ "yaml" ] }
+clap = { version = "2.33", features = ["yaml"] }
 lazy_static = "1.4.0"
 parking_lot = "0.11.1"
 thiserror = "1.0"
@@ -21,7 +21,7 @@ dirs = "1.0.2"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-jsonrpsee = { version = "0.2.0", features = ["client", "ws-server", "macros"]}
+jsonrpsee = { version = "0.2.0", features = ["client", "ws-server", "macros"] }
 async-trait = "0.1.50"
 tokio = { version = "1.6.1", features = ["full"] }
 
@@ -46,7 +46,7 @@ itp-api-client-extensions = { path = "../core-primitives/api-client-extensions" 
 itc-rpc-client = { path = "../core/rpc-client" }
 itc-rpc-server = { path = "../core/rpc-server" }
 itp-enclave-api = { path = "../core-primitives/enclave-api" }
-its-consensus-slots = { path = "../sidechain/consensus/slots"}
+its-consensus-slots = { path = "../sidechain/consensus/slots" }
 its-primitives = { path = "../sidechain/primitives"}
 its-storage = { path = "../sidechain/storage" }
 ita-stf = { path = "../app-libs/stf" }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -46,6 +46,7 @@ itp-api-client-extensions = { path = "../core-primitives/api-client-extensions" 
 itc-rpc-client = { path = "../core/rpc-client" }
 itc-rpc-server = { path = "../core/rpc-server" }
 itp-enclave-api = { path = "../core-primitives/enclave-api" }
+its-consensus-slots = { path = "../sidechain/consensus/slots"}
 its-primitives = { path = "../sidechain/primitives"}
 its-storage = { path = "../sidechain/storage" }
 ita-stf = { path = "../app-libs/stf" }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -55,7 +55,7 @@ use itp_settings::{
 	worker::MIN_FUND_INCREASE_FACTOR,
 };
 use itp_types::SignedBlock;
-use its_consensus_slots::start_interval_block_production;
+use its_consensus_slots::start_slot_worker;
 use its_primitives::types::SignedBlock as SignedSidechainBlock;
 use its_storage::{start_sidechain_pruning_loop, BlockPruner, SidechainStorageLock};
 use log::*;
@@ -348,7 +348,7 @@ fn start_worker<E, T, D>(
 	thread::Builder::new()
 		.name("interval_block_production_timer".to_owned())
 		.spawn(move || {
-			let future = start_interval_block_production(
+			let future = start_slot_worker(
 				|| execute_trusted_calls(side_chain_enclave_api.as_ref()),
 				SLOT_DURATION,
 			);

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -51,6 +51,7 @@ use itp_settings::{
 		ENCRYPTED_STATE_FILE, SHARDS_PATH, SHIELDING_KEY_FILE, SIDECHAIN_PURGE_INTERVAL,
 		SIDECHAIN_PURGE_LIMIT, SIDECHAIN_STORAGE_PATH, SIGNING_KEY_FILE,
 	},
+	sidechain::SLOT_DURATION,
 	worker::MIN_FUND_INCREASE_FACTOR,
 };
 use itp_types::SignedBlock;
@@ -344,7 +345,6 @@ fn start_worker<E, T, D>(
 	// ------------------------------------------------------------------------
 	// start interval block production (execution of trusted calls, sidechain block production)
 	let side_chain_enclave_api = enclave.clone();
-	use itp_settings::sidechain::SLOT_DURATION;
 	thread::Builder::new()
 		.name("interval_block_production_timer".to_owned())
 		.spawn(move || {

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -40,14 +40,16 @@ default = ["std"]
 std = [
     "codec/std",
     "log/std",
+    # only for slot-stream
+    "futures",
+    "futures-timer",
+    # local deps
     "sp-consensus-slots/std",
     "sp-runtime/std",
     "its-primitives/std",
     "its-consensus-common/std",
     "itp-time-utils/std",
     "itp-sgx-io/std",
-    "futures",
-    "futures-timer",
 ]
 sgx = [
     "sgx_tstd",

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -11,6 +11,10 @@ codec = { package = "parity-scale-codec", version = "2.2.0", default-features = 
 derive_more = "0.99.16"
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 
+# only for slot-stream
+futures = { version = "0.3.9", optional = true }
+futures-timer = { version = "3.0.1", optional = true }
+
 # sgx deps
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 
@@ -41,6 +45,8 @@ std = [
     "its-consensus-common/std",
     "itp-time-utils/std",
     "itp-sgx-io/std",
+    "futures",
+    "futures-timer",
 ]
 sgx = [
     "sgx_tstd",

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -32,6 +32,7 @@ itp-types = { path = "../../../core-primitives/types", default-features = false 
 [dev-dependencies]
 itp-types = { path = "../../../core-primitives/types" }
 sp-keyring = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master" }
+tokio = "*"
 
 
 [features]

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -42,8 +42,12 @@ pub use slots::*;
 use sp_runtime::traits::{Block as ParentchainBlock, Header};
 use std::{fmt::Debug, time::Duration, vec::Vec};
 
+#[cfg(feature = "std")]
+mod slot_stream;
 mod slots;
 
+#[cfg(feature = "std")]
+pub use slot_stream::*;
 pub use slots::*;
 
 /// The result of [`SlotWorker::on_slot`].

--- a/sidechain/consensus/slots/src/slot_stream.rs
+++ b/sidechain/consensus/slots/src/slot_stream.rs
@@ -1,0 +1,50 @@
+use crate::time_until_next_slot;
+use futures_timer::Delay;
+use std::time::Duration;
+
+/// Triggers the enclave to produce a block based on a fixed time schedule.
+pub async fn start_interval_block_production<F>(trusted_call: F, slot_duration: Duration)
+where
+	F: Fn() -> (),
+{
+	let mut slot_stream = SlotStream::new(slot_duration);
+
+	loop {
+		slot_stream.next_slot().await;
+		trusted_call();
+	}
+}
+
+pub struct SlotStream {
+	slot_duration: Duration,
+	inner_delay: Option<Delay>,
+}
+
+impl SlotStream {
+	pub fn new(slot_duration: Duration) -> Self {
+		SlotStream { slot_duration, inner_delay: None }
+	}
+}
+
+impl SlotStream {
+	pub async fn next_slot(&mut self) {
+		self.inner_delay = match self.inner_delay.take() {
+			None => {
+				// schedule wait.
+				let wait_dur = time_until_next_slot(self.slot_duration);
+				Some(Delay::new(wait_dur))
+			},
+			Some(d) => Some(d),
+		};
+
+		if let Some(inner_delay) = self.inner_delay.take() {
+			inner_delay.await;
+		}
+		// timeout has fired.
+
+		let ends_in = time_until_next_slot(self.slot_duration);
+
+		// reschedule delay for next slot.
+		self.inner_delay = Some(Delay::new(ends_in));
+	}
+}

--- a/sidechain/consensus/slots/src/slot_stream.rs
+++ b/sidechain/consensus/slots/src/slot_stream.rs
@@ -11,7 +11,11 @@
 	limitations under the License.
 */
 
-//! Implementation of schedule of the slots to time so that trusted calls can be aligned.
+//! Slots functionality for Substrate.
+//!
+//! Some consensus algorithms have a concept of *slots*, which are intervals in
+//! time during which certain events can and/or must occur.  This crate
+//! provides generic functionality for slots.
 
 use crate::time_until_next_slot;
 use futures_timer::Delay;
@@ -57,7 +61,8 @@ impl SlotStream {
 		if let Some(inner_delay) = self.inner_delay.take() {
 			inner_delay.await;
 		}
-		// timeout has fired.
+		// Waits for the duration of `inner_delay`.
+		// Upon timeout, `inner_delay` is reset according to the time left until next slot.
 
 		let ends_in = time_until_next_slot(self.slot_duration);
 

--- a/sidechain/consensus/slots/src/slot_stream.rs
+++ b/sidechain/consensus/slots/src/slot_stream.rs
@@ -81,11 +81,12 @@ mod tests {
 	const SLOT_TOLERANCE: Duration = Duration::from_millis(10);
 
 	#[tokio::test]
-	async fn slot_stream_call_one_block() {
+	async fn short_task_execution_does_not_influence_next_slot() {
 		let mut slot_stream = SlotStream::new(SLOT_DURATION);
 
 		slot_stream.next_slot().await;
 		let now = Instant::now();
+		// task execution shorter than slot duration
 		thread::sleep(Duration::from_millis(200));
 		slot_stream.next_slot().await;
 
@@ -95,11 +96,12 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn slot_stream_long_call() {
+	async fn long_task_execution_does_not_cause_drift() {
 		let mut slot_stream = SlotStream::new(SLOT_DURATION);
 
 		slot_stream.next_slot().await;
 		let now = Instant::now();
+		// task execution is longer than slot duration
 		thread::sleep(Duration::from_millis(500));
 		slot_stream.next_slot().await;
 		slot_stream.next_slot().await;

--- a/sidechain/consensus/slots/src/slot_stream.rs
+++ b/sidechain/consensus/slots/src/slot_stream.rs
@@ -46,6 +46,8 @@ impl SlotStream {
 	}
 }
 
+/// Waits for the duration of `inner_delay`.
+/// Upon timeout, `inner_delay` is reset according to the time left until next slot.
 impl SlotStream {
 	pub async fn next_slot(&mut self) {
 		self.inner_delay = match self.inner_delay.take() {
@@ -61,8 +63,6 @@ impl SlotStream {
 		if let Some(inner_delay) = self.inner_delay.take() {
 			inner_delay.await;
 		}
-		// Waits for the duration of `inner_delay`.
-		// Upon timeout, `inner_delay` is reset according to the time left until next slot.
 
 		let ends_in = time_until_next_slot(self.slot_duration);
 

--- a/sidechain/consensus/slots/src/slot_stream.rs
+++ b/sidechain/consensus/slots/src/slot_stream.rs
@@ -1,14 +1,18 @@
 /*
 	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
+
 		http://www.apache.org/licenses/LICENSE-2.0
+
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 	See the License for the specific language governing permissions and
 	limitations under the License.
+
 */
 
 //! Slots functionality for Substrate.
@@ -46,9 +50,9 @@ impl SlotStream {
 	}
 }
 
-/// Waits for the duration of `inner_delay`.
-/// Upon timeout, `inner_delay` is reset according to the time left until next slot.
 impl SlotStream {
+	/// Waits for the duration of `inner_delay`.
+	/// Upon timeout, `inner_delay` is reset according to the time left until next slot.
 	pub async fn next_slot(&mut self) {
 		self.inner_delay = match self.inner_delay.take() {
 			None => {
@@ -66,7 +70,7 @@ impl SlotStream {
 
 		let ends_in = time_until_next_slot(self.slot_duration);
 
-		// reschedule delay for next slot.
+		// Re-schedule delay for next slot.
 		self.inner_delay = Some(Delay::new(ends_in));
 	}
 }
@@ -86,7 +90,7 @@ mod tests {
 
 		slot_stream.next_slot().await;
 		let now = Instant::now();
-		// task execution shorter than slot duration
+		// Task execution is shorter than slot duration.
 		thread::sleep(Duration::from_millis(200));
 		slot_stream.next_slot().await;
 
@@ -101,7 +105,7 @@ mod tests {
 
 		slot_stream.next_slot().await;
 		let now = Instant::now();
-		// task execution is longer than slot duration
+		// Task execution is longer than slot duration.
 		thread::sleep(Duration::from_millis(500));
 		slot_stream.next_slot().await;
 		slot_stream.next_slot().await;

--- a/sidechain/consensus/slots/src/slot_stream.rs
+++ b/sidechain/consensus/slots/src/slot_stream.rs
@@ -1,3 +1,18 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+//! Implementation of schedule of the slots to time so that trusted calls can be aligned.
+
 use crate::time_until_next_slot;
 use futures_timer::Delay;
 use std::time::Duration;
@@ -15,6 +30,7 @@ where
 	}
 }
 
+/// Stream to calculate the slot schedule with
 pub struct SlotStream {
 	slot_duration: Duration,
 	inner_delay: Option<Delay>,
@@ -30,7 +46,8 @@ impl SlotStream {
 	pub async fn next_slot(&mut self) {
 		self.inner_delay = match self.inner_delay.take() {
 			None => {
-				// schedule wait.
+				// Delay is not initializes in this case,
+				// so we have to initialize with the time until the next slot.
 				let wait_dur = time_until_next_slot(self.slot_duration);
 				Some(Delay::new(wait_dur))
 			},

--- a/sidechain/consensus/slots/src/slot_stream.rs
+++ b/sidechain/consensus/slots/src/slot_stream.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 /// Triggers the enclave to produce a block based on a fixed time schedule.
 pub async fn start_interval_block_production<F>(trusted_call: F, slot_duration: Duration)
 where
-	F: Fn() -> (),
+	F: Fn(),
 {
 	let mut slot_stream = SlotStream::new(slot_duration);
 


### PR DESCRIPTION
When a trusted call takes longer than the slot duration the wait time until the next slot is adapted to avoid drifts.

Closes #504