### PR TITLE
Remove obsolete branch from pull-request target builds

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, separate-block-production-from-state-mutation ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This was introduced for PR #541 to have a valid CI build when merging into #520. Now it has to be removed again.