### PR TITLE
Move sidechain block builder to separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,6 +2744,7 @@ dependencies = [
  "its-consensus-slots",
  "its-primitives",
  "its-state",
+ "its-test",
  "its-top-pool-executor",
  "its-validateer-fetch",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ dependencies = [
  "its-consensus-slots",
  "its-primitives",
  "its-storage",
+ "its-test",
  "jsonrpsee",
  "lazy_static",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2386,6 +2387,7 @@ dependencies = [
  "itp-enclave-api",
  "itp-types",
  "its-primitives",
+ "its-test",
  "jsonrpsee",
  "log 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
@@ -2876,6 +2878,17 @@ dependencies = [
  "rocksdb",
  "sp-core",
  "thiserror 1.0.30",
+]
+
+[[package]]
+name = "its-test"
+version = "0.8.0"
+dependencies = [
+ "itp-time-utils",
+ "itp-types",
+ "its-primitives",
+ "sgx_tstd",
+ "sp-core",
 ]
 
 [[package]]

--- a/core/rpc-server/Cargo.toml
+++ b/core/rpc-server/Cargo.toml
@@ -17,6 +17,7 @@ itp-enclave-api = { path = "../../core-primitives/enclave-api" }
 its-primitives = { path = "../../sidechain/primitives" }
 itp-types = { path = "../../core-primitives/types" }
 
+
 [features]
 default = ["std"]
 std = []
@@ -24,3 +25,4 @@ std = []
 [dev-dependencies]
 env_logger = { version = "*" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "master" }
+its-test = { path = "../../sidechain/test" }

--- a/core/rpc-server/src/mock.rs
+++ b/core/rpc-server/src/mock.rs
@@ -1,11 +1,7 @@
 use parity_scale_codec::Encode;
 
 use itp_enclave_api::{direct_request::DirectRequest, EnclaveResult};
-use itp_types::{RpcResponse, ShardIdentifier};
-use its_primitives::{
-	traits::{Block as BlockT, SignBlock},
-	types::{Block, SignedBlock},
-};
+use itp_types::RpcResponse;
 
 pub struct TestEnclave;
 
@@ -13,32 +9,4 @@ impl DirectRequest for TestEnclave {
 	fn rpc(&self, _request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
 		Ok(RpcResponse { jsonrpc: "mock_response".into(), result: "null".encode(), id: 1 }.encode())
 	}
-}
-
-// todo: this is a duplicate that is also defined in the worker. We should extract an independent
-// itp-test crate because here we don't want to depend on the worker itself.
-pub fn test_sidechain_block() -> SignedBlock {
-	use sp_core::{Pair, H256};
-
-	let signer_pair = sp_core::ed25519::Pair::from_string("//Alice", None).unwrap();
-	let author = signer_pair.public();
-	let block_number: u64 = 0;
-	let parent_hash = H256::random();
-	let layer_one_head = H256::random();
-	let signed_top_hashes = vec![];
-	let encrypted_payload: Vec<u8> = vec![];
-	let shard = ShardIdentifier::default();
-
-	// when
-	let block = Block::new(
-		author,
-		block_number,
-		parent_hash.clone(),
-		layer_one_head.clone(),
-		shard.clone(),
-		signed_top_hashes.clone(),
-		encrypted_payload.clone(),
-		10000,
-	);
-	block.sign_block(&signer_pair)
 }

--- a/core/rpc-server/src/tests.rs
+++ b/core/rpc-server/src/tests.rs
@@ -26,7 +26,8 @@ async fn test_client_calls() {
 	let response: Vec<u8> = client
 		.request(
 			"sidechain_importBlock",
-			vec![to_json_value(vec![SidechainBlockBuilder::default().build()]).unwrap()].into(),
+			vec![to_json_value(vec![SidechainBlockBuilder::default().build_signed()]).unwrap()]
+				.into(),
 		)
 		.await
 		.unwrap();

--- a/core/rpc-server/src/tests.rs
+++ b/core/rpc-server/src/tests.rs
@@ -8,7 +8,8 @@ use jsonrpsee::{
 use parity_scale_codec::Decode;
 
 use itp_types::RpcResponse;
-use mock::{test_sidechain_block, TestEnclave};
+use its_test::sidechain_block_builder::SidechainBlockBuilder;
+use mock::TestEnclave;
 
 fn init() {
 	let _ = env_logger::builder().is_test(true).try_init();
@@ -25,7 +26,7 @@ async fn test_client_calls() {
 	let response: Vec<u8> = client
 		.request(
 			"sidechain_importBlock",
-			vec![to_json_value(vec![test_sidechain_block()]).unwrap()].into(),
+			vec![to_json_value(vec![SidechainBlockBuilder::default().build()]).unwrap()].into(),
 		)
 		.await
 		.unwrap();

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -40,16 +40,16 @@ sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-s
 sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local
-itp-settings = { path = "../core-primitives/settings" }
-itp-types = { path = "../core-primitives/types" }
-itp-api-client-extensions = { path = "../core-primitives/api-client-extensions" }
+ita-stf = { path = "../app-libs/stf" }
 itc-rpc-client = { path = "../core/rpc-client" }
 itc-rpc-server = { path = "../core/rpc-server" }
+itp-api-client-extensions = { path = "../core-primitives/api-client-extensions" }
 itp-enclave-api = { path = "../core-primitives/enclave-api" }
+itp-settings = { path = "../core-primitives/settings" }
+itp-types = { path = "../core-primitives/types" }
 its-consensus-slots = { path = "../sidechain/consensus/slots" }
 its-primitives = { path = "../sidechain/primitives"}
 its-storage = { path = "../sidechain/storage" }
-ita-stf = { path = "../app-libs/stf" }
 
 # scs / integritee
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "master" }
@@ -72,4 +72,5 @@ production = ['itp-settings/production']
 
 [dev-dependencies]
 anyhow = "1.0.40"
+its-test = { path = "../sidechain/test" }
 mockall = "0.10.1"

--- a/service/src/tests/commons.rs
+++ b/service/src/tests/commons.rs
@@ -31,11 +31,6 @@ use substrate_api_client::{rpc::WsRpcClient, Api};
 
 #[cfg(test)]
 use crate::config::Config;
-#[cfg(test)]
-use its_primitives::{
-	traits::{Block as BlockT, SignBlock},
-	types::{Block, SignedBlock},
-};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Message {
@@ -142,33 +137,6 @@ pub fn get_nonce(api: &Api<sr25519::Pair, WsRpcClient>, who: &AccountId32) -> u3
 	} else {
 		0
 	}
-}
-
-#[cfg(test)]
-pub fn test_sidechain_block() -> SignedBlock {
-	use sp_core::{Pair, H256};
-
-	let signer_pair = sp_core::ed25519::Pair::from_string("//Alice", None).unwrap();
-	let author = signer_pair.public();
-	let block_number: u64 = 0;
-	let parent_hash = H256::random();
-	let layer_one_head = H256::random();
-	let signed_top_hashes = vec![];
-	let encrypted_payload: Vec<u8> = vec![];
-	let shard = ShardIdentifier::default();
-
-	// when
-	let block = Block::new(
-		author,
-		block_number,
-		parent_hash.clone(),
-		layer_one_head.clone(),
-		shard.clone(),
-		signed_top_hashes.clone(),
-		encrypted_payload.clone(),
-		1000,
-	);
-	block.sign_block(&signer_pair)
 }
 
 /// Local Worker config. Fields are the default values except for

--- a/service/src/worker.rs
+++ b/service/src/worker.rs
@@ -120,6 +120,7 @@ pub fn worker_url_into_async_rpc_url(url: &str) -> WorkerResult<String> {
 mod tests {
 	use frame_support::assert_ok;
 	use its_primitives::types::SignedBlock as SignedSidechainBlock;
+	use its_test::sidechain_block_builder::SidechainBlockBuilder;
 	use jsonrpsee::{ws_server::WsServerBuilder, RpcModule};
 	use log::debug;
 	use std::net::SocketAddr;
@@ -127,7 +128,7 @@ mod tests {
 
 	use crate::{
 		tests::{
-			commons::{local_worker_config, test_sidechain_block},
+			commons::local_worker_config,
 			mock::{TestNodeApi, W1_URL, W2_URL},
 		},
 		worker::{worker_url_into_async_rpc_url, Worker, WorkerT},
@@ -163,7 +164,7 @@ mod tests {
 
 		let worker = Worker::new(local_worker_config(W1_URL.into()), TestNodeApi, Arc::new(()), ());
 
-		let resp = worker.gossip_blocks(vec![test_sidechain_block()]).await;
+		let resp = worker.gossip_blocks(vec![SidechainBlockBuilder::default().build()]).await;
 		assert_ok!(resp);
 	}
 }

--- a/service/src/worker.rs
+++ b/service/src/worker.rs
@@ -164,7 +164,9 @@ mod tests {
 
 		let worker = Worker::new(local_worker_config(W1_URL.into()), TestNodeApi, Arc::new(()), ());
 
-		let resp = worker.gossip_blocks(vec![SidechainBlockBuilder::default().build()]).await;
+		let resp = worker
+			.gossip_blocks(vec![SidechainBlockBuilder::default().build_signed()])
+			.await;
 		assert_ok!(resp);
 	}
 }

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -42,6 +42,7 @@ env_logger = "0.9.0"
 itc-parentchain-block-import-dispatcher = { path = "../../../core/parentchain/block-import-dispatcher", features = ["mocks"] }
 itp-storage = { path = "../../../core-primitives/storage" }
 itp-test = { path = "../../../core-primitives/test" }
+its-test = { path = "../../test" }
 its-top-pool-executor = { path = "../../top-pool-executor", features = ["mocks"] }
 sp-keyring = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master"}
 

--- a/sidechain/consensus/aura/src/lib.rs
+++ b/sidechain/consensus/aura/src/lib.rs
@@ -331,10 +331,10 @@ mod tests {
 		header: ParentchainHeader,
 	) -> Arc<TriggerParentchainBlockImportMock<SignedParentchainBlock>> {
 		let latest_parentchain_block =
-			ParentchainBlockBuilder::default().with_header(header.clone()).build_signed();
+			ParentchainBlockBuilder::default().with_header(header).build_signed();
 		Arc::new(
 			TriggerParentchainBlockImportMock::default()
-				.with_latest_imported(Some(latest_parentchain_block.clone())),
+				.with_latest_imported(Some(latest_parentchain_block)),
 		)
 	}
 
@@ -451,7 +451,7 @@ mod tests {
 		let _ = env_logger::builder().is_test(true).try_init();
 		let latest_parentchain_header = ParentchainHeaderBuilder::default().with_number(84).build();
 		let parentchain_block_import_trigger =
-			create_import_trigger_with_header(latest_parentchain_header.clone());
+			create_import_trigger_with_header(latest_parentchain_header);
 
 		let mut aura = get_aura(
 			onchain_mock_with_default_authorities(),

--- a/sidechain/consensus/aura/src/mock.rs
+++ b/sidechain/consensus/aura/src/mock.rs
@@ -26,7 +26,7 @@ use its_primitives::{
 };
 use its_state::LastBlockExt;
 use its_test::sidechain_block_builder::SidechainBlockBuilder;
-use sp_runtime::{app_crypto::ed25519, traits::Header as HeaderT};
+use sp_runtime::{app_crypto::ed25519, generic::SignedBlock, traits::Header as HeaderT};
 use std::time::Duration;
 
 pub const SLOT_DURATION: Duration = Duration::from_millis(300);
@@ -79,7 +79,10 @@ impl Proposer<ParentchainBlock, SignedSidechainBlock> for ProposerMock {
 		_max_duration: Duration,
 	) -> Result<Proposal<SignedSidechainBlock>, ConsensusError> {
 		Ok(Proposal {
-			block: SidechainBlockBuilder::random().build_signed(),
+			block: SidechainBlockBuilder::random()
+				.with_parentchain_block_hash(self.parentchain_header.hash())
+				.build_signed(),
+
 			parentchain_effects: Default::default(),
 		})
 	}

--- a/sidechain/consensus/aura/src/mock.rs
+++ b/sidechain/consensus/aura/src/mock.rs
@@ -18,19 +18,15 @@
 use crate::{verifier::AuraVerifier, Aura};
 use itc_parentchain_block_import_dispatcher::trigger_parentchain_block_import_mock::TriggerParentchainBlockImportMock;
 use itp_test::mock::onchain_mock::OnchainMock;
-use itp_time_utils::duration_now;
 use itp_types::{AccountId, Block as ParentchainBlock, Enclave, Header};
 use its_consensus_common::{Environment, Error as ConsensusError, Proposal, Proposer};
 use its_primitives::{
-	traits::{Block as SidechainBlockT, SignBlock as SignBlockT, SignedBlock as SignedBlockT},
+	traits::{Block as SidechainBlockT, SignedBlock as SignedBlockT},
 	types::block::{Block as SidechainBlock, SignedBlock as SignedSidechainBlock},
 };
 use its_state::LastBlockExt;
-use sp_core::Pair;
-use sp_keyring::ed25519::Keyring;
-use sp_runtime::{
-	app_crypto::ed25519, generic::SignedBlock, testing::H256, traits::Header as HeaderT,
-};
+use its_test::sidechain_block_builder::SidechainBlockBuilder;
+use sp_runtime::{app_crypto::ed25519, traits::Header as HeaderT};
 use std::time::Duration;
 
 pub const SLOT_DURATION: Duration = Duration::from_millis(300);
@@ -83,12 +79,7 @@ impl Proposer<ParentchainBlock, SignedSidechainBlock> for ProposerMock {
 		_max_duration: Duration,
 	) -> Result<Proposal<SignedSidechainBlock>, ConsensusError> {
 		Ok(Proposal {
-			block: TestBlockBuilder::new()
-				.with_timestamp(duration_now().as_millis() as u64)
-				.with_parentchain_head(self.parentchain_header.hash())
-				.with_parent_hash(H256::random())
-				.with_shard(H256::random())
-				.build_signed(Keyring::Alice.pair()),
+			block: SidechainBlockBuilder::random().build_signed(),
 			parentchain_effects: Default::default(),
 		})
 	}
@@ -106,100 +97,6 @@ impl<SB: SidechainBlockT> LastBlockExt<SB> for StateMock<SB> {
 
 pub fn validateer(account: AccountId) -> Enclave {
 	Enclave::new(account, Default::default(), Default::default(), Default::default())
-}
-
-pub struct TestBlockBuilder {
-	author: ed25519::Public,
-	block_number: u64,
-	parent_hash: H256,
-	parentchain_head: H256,
-	shard: H256,
-	signed_top_hashes: Vec<H256>,
-	encrypted_payload: Vec<u8>,
-	timestamp: u64,
-}
-
-impl Default for TestBlockBuilder {
-	fn default() -> Self {
-		Self {
-			author: Default::default(),
-			block_number: 1,
-			parent_hash: Default::default(),
-			parentchain_head: Default::default(),
-			shard: Default::default(),
-			signed_top_hashes: Default::default(),
-			encrypted_payload: Default::default(),
-			timestamp: 0,
-		}
-	}
-}
-
-impl TestBlockBuilder {
-	pub fn new() -> Self {
-		Default::default()
-	}
-
-	pub fn with_author(mut self, author: ed25519::Public) -> Self {
-		self.author = author;
-		self
-	}
-
-	pub fn with_parent_hash(mut self, hash: H256) -> Self {
-		self.parent_hash = hash;
-		self
-	}
-
-	pub fn with_parentchain_head(mut self, header: H256) -> Self {
-		self.parentchain_head = header;
-		self
-	}
-
-	pub fn with_block_number(mut self, block_number: u64) -> Self {
-		self.block_number = block_number;
-		self
-	}
-
-	pub fn with_timestamp(mut self, timestamp: u64) -> Self {
-		self.timestamp = timestamp;
-		self
-	}
-
-	pub fn with_shard(mut self, shard: H256) -> Self {
-		self.shard = shard;
-		self
-	}
-
-	pub fn with_encrypted_payload(mut self, payload: Vec<u8>) -> Self {
-		self.encrypted_payload = payload;
-		self
-	}
-
-	pub fn build(self) -> SidechainBlock {
-		SidechainBlock::new(
-			self.author,
-			self.block_number,
-			self.parent_hash,
-			self.parentchain_head,
-			self.shard,
-			self.signed_top_hashes,
-			self.encrypted_payload,
-			self.timestamp,
-		)
-	}
-
-	/// Build a signed block. Sets the author to Alice and signs it by Alice.
-	pub fn build_signed(mut self, authority: AuthorityPair) -> SignedSidechainBlock {
-		self.author = authority.public();
-		self.build().sign_block(&authority)
-	}
-}
-
-#[test]
-fn build_signed_block_has_valid_signature() {
-	let signed_block = TestBlockBuilder::new()
-		.with_parentchain_head(H256::random())
-		.build_signed(Keyring::Bob.pair());
-	assert!(signed_block.verify_signature());
 }
 
 pub fn default_header() -> Header {

--- a/sidechain/test/Cargo.toml
+++ b/sidechain/test/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "its-test"
+version = "0.8.0"
+authors = ["Integritee AG <hello@integritee.network>"]
+edition = "2018"
+
+[dependencies]
+# sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+
+# local dependencies
+itp-time-utils = { path = "../../core-primitives/time-utils", default-features = false }
+itp-types = { path = "../../core-primitives/types", default-features = false }
+its-primitives = { path = "../primitives", default-features = false }
+
+# Substrate dependencies
+sp-core = { version = "4.0.0-dev", git = "https://github.com/paritytech/substrate.git", branch = "master", default_features = false }
+
+
+[features]
+default = ["std"]
+std = [
+    "itp-time-utils/std",
+    "itp-types/std",
+    "its-primitives/std",
+    # substrate
+    "sp-core/std",
+]
+sgx = [
+    "itp-time-utils/sgx",
+    "itp-types/sgx",
+    "sgx_tstd",
+]

--- a/sidechain/test/src/lib.rs
+++ b/sidechain/test/src/lib.rs
@@ -1,0 +1,23 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+		http://www.apache.org/licenses/LICENSE-2.0
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+#![feature(trait_alias)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+pub mod sidechain_block_builder;

--- a/sidechain/test/src/sidechain_block_builder.rs
+++ b/sidechain/test/src/sidechain_block_builder.rs
@@ -47,7 +47,7 @@ impl Default for SidechainBlockBuilder {
 	fn default() -> Self {
 		SidechainBlockBuilder {
 			signer: Pair::from_seed(&ENCLAVE_SEED),
-			number: Default::default(),
+			number: 1,
 			parent_hash: BlockHash::default(),
 			parentchain_block_hash: Default::default(),
 			signed_top_hashes: Default::default(),
@@ -62,7 +62,7 @@ impl SidechainBlockBuilder {
 	pub fn random() -> Self {
 		SidechainBlockBuilder {
 			signer: Pair::from_seed(&ENCLAVE_SEED),
-			number: 17,
+			number: 42,
 			parent_hash: BlockHash::random(),
 			parentchain_block_hash: BlockHash::random(),
 			signed_top_hashes: vec![H256::random(), H256::random()],

--- a/sidechain/test/src/sidechain_block_builder.rs
+++ b/sidechain/test/src/sidechain_block_builder.rs
@@ -1,0 +1,127 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Builder pattern for a signed sidechain block.
+
+use itp_time_utils;
+use itp_types::H256;
+use its_primitives::{
+	traits::{Block as BlockTrait, SignBlock},
+	types::{
+		block::{BlockHash, BlockNumber, Timestamp},
+		Block, ShardIdentifier, SignedBlock,
+	},
+};
+use sp_core::{ed25519, Pair};
+
+type Seed = [u8; 32];
+const ENCLAVE_SEED: Seed = *b"12345678901234567890123456789012";
+
+pub struct SidechainBlockBuilder {
+	signer: ed25519::Pair,
+	number: BlockNumber,
+	parent_hash: BlockHash,
+	parentchain_block_hash: H256,
+	signed_top_hashes: Vec<H256>,
+	encrypted_payload: Vec<u8>,
+	shard: ShardIdentifier,
+	timestamp: Timestamp,
+}
+
+impl Default for SidechainBlockBuilder {
+	fn default() -> Self {
+		SidechainBlockBuilder {
+			signer: Pair::from_seed(&ENCLAVE_SEED),
+			number: Default::default(),
+			parent_hash: BlockHash::default(),
+			parentchain_block_hash: Default::default(),
+			signed_top_hashes: Default::default(),
+			encrypted_payload: Default::default(),
+			shard: Default::default(),
+			timestamp: Default::default(),
+		}
+	}
+}
+
+impl SidechainBlockBuilder {
+	pub fn random() -> Self {
+		SidechainBlockBuilder {
+			signer: Pair::from_seed(&ENCLAVE_SEED),
+			number: 17,
+			parent_hash: BlockHash::random(),
+			parentchain_block_hash: BlockHash::random(),
+			signed_top_hashes: vec![H256::random(), H256::random()],
+			encrypted_payload: vec![1, 3, 42, 8, 11, 33],
+			shard: ShardIdentifier::random(),
+			timestamp: itp_time_utils::now_as_u64(),
+		}
+	}
+	pub fn with_signer(mut self, signer: ed25519::Pair) -> Self {
+		self.signer = signer;
+		self
+	}
+
+	pub fn with_number(mut self, number: BlockNumber) -> Self {
+		self.number = number;
+		self
+	}
+
+	pub fn with_parent_hash(mut self, parent_hash: BlockHash) -> Self {
+		self.parent_hash = parent_hash;
+		self
+	}
+
+	pub fn with_parentchain_block_hash(mut self, parentchain_block_hash: H256) -> Self {
+		self.parentchain_block_hash = parentchain_block_hash;
+		self
+	}
+
+	pub fn with_signed_top_hashes(mut self, signed_top_hashes: Vec<H256>) -> Self {
+		self.signed_top_hashes = signed_top_hashes;
+		self
+	}
+
+	pub fn with_payload(mut self, payload: Vec<u8>) -> Self {
+		self.encrypted_payload = payload;
+		self
+	}
+
+	pub fn with_shard(mut self, shard: ShardIdentifier) -> Self {
+		self.shard = shard;
+		self
+	}
+
+	pub fn with_timestamp(mut self, timestamp: Timestamp) -> Self {
+		self.timestamp = timestamp;
+		self
+	}
+
+	pub fn build(self) -> SignedBlock {
+		Block::new(
+			self.signer.public(),
+			self.number,
+			self.parent_hash,
+			self.parentchain_block_hash,
+			self.shard,
+			self.signed_top_hashes,
+			self.encrypted_payload,
+			self.timestamp,
+		)
+		.sign_block(&self.signer)
+	}
+}

--- a/sidechain/test/src/sidechain_block_builder.rs
+++ b/sidechain/test/src/sidechain_block_builder.rs
@@ -111,17 +111,29 @@ impl SidechainBlockBuilder {
 		self
 	}
 
-	pub fn build(self) -> SignedBlock {
+	pub fn build(&self) -> Block {
 		Block::new(
 			self.signer.public(),
 			self.number,
 			self.parent_hash,
 			self.parentchain_block_hash,
 			self.shard,
-			self.signed_top_hashes,
-			self.encrypted_payload,
+			self.signed_top_hashes.clone(),
+			self.encrypted_payload.clone(),
 			self.timestamp,
 		)
-		.sign_block(&self.signer)
 	}
+
+	pub fn build_signed(&self) -> SignedBlock {
+		let signer = &self.signer.clone();
+		self.build().sign_block(signer)
+	}
+}
+
+#[test]
+fn build_signed_block_has_valid_signature() {
+	use its_primitives::traits::SignedBlock as SignedBlockTrait;
+
+	let signed_block = SidechainBlockBuilder::default().build_signed();
+	assert!(signed_block.verify_signature());
 }


### PR DESCRIPTION
Move TestBlockBuilder to its own crate & rename to SidechainBlockBuilder, as it's not aura specific.

I'm unsure if the test crate is correct place for that, I'm open for your opinion here.
I did not want to place it in the itp-test crate, as it's sidechain specific.

@gaudenzkessler @echevrier please give your review as well. Most important would be : Would you find the `SidechainBlockBuilder `again, in case you'd need to for a test? And if not, where would you expect it?