### PR TITLE
Change slot claim strategy to RoundRobin

### DIFF
--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -258,7 +258,7 @@ where
 		block_import_trigger,
 		proposer_environment,
 	)
-	.with_claim_strategy(SlotClaimStrategy::Always)
+	.with_claim_strategy(SlotClaimStrategy::RoundRobin)
 	.with_allow_delayed_proposal(true);
 
 	let (blocks, xts): (Vec<_>, Vec<_>) =


### PR DESCRIPTION
We suspect the `Always` claim strategy is the cause for many errors in our sidechain block production and imports. So we change it to `RoundRobin`, which is the setting it should be at for multiple validateers.