### PR TITLE
Test https connection with different certificates which should be blocked

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,9 +3,9 @@ name: Build, Test, Clippy
 on:
   workflow_dispatch:
   push:
-    branches: [ master, exchange_rate_oracle ]
+    branches: [ master, teeracle-demo ]
   pull_request:
-    branches: [ master, exchange_rate_oracle ]
+    branches: [ master, teeracle-demo ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/core/rest-client/src/http_client.rs
+++ b/core/rest-client/src/http_client.rs
@@ -440,7 +440,6 @@ mod tests {
 		let result = get_for_test_certificates(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 		let msg = format!("error {:?}", result.err());
-		println!("{}", msg);
 		assert!(msg.contains("UnknownIssuer"));
 	}
 

--- a/core/rest-client/src/http_client.rs
+++ b/core/rest-client/src/http_client.rs
@@ -439,6 +439,9 @@ mod tests {
 		let base_url = Url::parse("https://self-signed.badssl.com").unwrap();
 		let result = get_for_test_certificates(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
+		let msg = format!("error {:?}", result.err());
+		println!("{}", msg);
+		assert!(msg.contains("UnknownIssuer"));
 	}
 
 	#[test]

--- a/core/rest-client/src/http_client.rs
+++ b/core/rest-client/src/http_client.rs
@@ -228,6 +228,7 @@ fn add_to_headers(headers: &mut Headers, key: HeaderName, value: HeaderValue) {
 mod tests {
 
 	use super::*;
+	use core::assert_matches::assert_matches;
 	use http::header::CONNECTION;
 	use serde::{Deserialize, Serialize};
 	use std::vec::Vec;
@@ -431,5 +432,67 @@ mod tests {
 		serde_json::from_slice::<'a, T>(encoded_body).map_err(|err| {
 			Error::DeserializeParseError(err, String::from_utf8_lossy(encoded_body).to_string())
 		})
+	}
+
+	#[test]
+	fn get_from_site_with_self_signed_certificate_fails() {
+		let base_url = Url::parse("https://self-signed.badssl.com").unwrap();
+		let result = get_for_test_certificates(base_url);
+		assert_matches!(result, Err(Error::HttpReqError(_)));
+	}
+
+	#[test]
+	fn get_from_site_with_letsencrypt_isrgrootx1_valid_certificate_fails() {
+		let base_url = Url::parse("https://valid-isrgrootx1.letsencrypt.org").unwrap();
+		let result = get_for_test_certificates(base_url);
+		assert_matches!(result, Err(Error::HttpReqError(_)));
+	}
+
+	#[test]
+	fn get_from_site_with_letsencrypt_isrgrootx1_revoked_certificate_fails() {
+		let base_url = Url::parse("https://revoked-isrgrootx1.letsencrypt.org").unwrap();
+		let result = get_for_test_certificates(base_url);
+		assert_matches!(result, Err(Error::HttpReqError(_)));
+	}
+
+	#[test]
+	fn get_from_site_with_letsencrypt_isrgrootx1_expired_certificate_fails() {
+		let base_url = Url::parse("https://expired-isrgrootx1.letsencrypt.org").unwrap();
+		let result = get_for_test_certificates(base_url);
+		assert_matches!(result, Err(Error::HttpReqError(_)));
+	}
+
+	#[test]
+	fn get_from_site_with_letsencrypt_isrgrootx2_valid_certificate_fails() {
+		let base_url = Url::parse("https://valid-isrgrootx2.letsencrypt.org").unwrap();
+		let result = get_for_test_certificates(base_url);
+		assert_matches!(result, Err(Error::HttpReqError(_)));
+	}
+
+	#[test]
+	fn get_from_site_with_letsencrypt_isrgrootx2_revoked_certificate_fails() {
+		let base_url = Url::parse("https://revoked-isrgrootx2.letsencrypt.org").unwrap();
+		let result = get_for_test_certificates(base_url);
+		assert_matches!(result, Err(Error::HttpReqError(_)));
+	}
+
+	#[test]
+	fn get_from_site_with_letsencrypt_isrgrootx2_expired_certificate_fails() {
+		let base_url = Url::parse("https://expired-isrgrootx2.letsencrypt.org").unwrap();
+		let result = get_for_test_certificates(base_url);
+		assert_matches!(result, Err(Error::HttpReqError(_)));
+	}
+
+	fn get_for_test_certificates(base_url: Url) -> Result<(Response, EncodedBody), Error> {
+		#[derive(Serialize, Deserialize, Debug)]
+		struct HttpTestResponse {}
+
+		impl RestPath<()> for HttpTestResponse {
+			fn get_path(_: ()) -> Result<String, Error> {
+				Ok(format!("anything"))
+			}
+		}
+		let http_client = HttpClient::new(true, Some(Duration::from_secs(3u64)), None, None);
+		http_client.send_request::<(), HttpTestResponse>(base_url, Method::GET, (), None, None)
 	}
 }

--- a/core/rest-client/src/http_client.rs
+++ b/core/rest-client/src/http_client.rs
@@ -437,7 +437,7 @@ mod tests {
 	#[test]
 	fn get_from_site_with_self_signed_certificate_fails() {
 		let base_url = Url::parse("https://self-signed.badssl.com").unwrap();
-		let result = get_for_test_certificates(base_url);
+		let result = send_http_get_request(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 		let msg = format!("error {:?}", result.err());
 		assert!(msg.contains("UnknownIssuer"));
@@ -446,46 +446,46 @@ mod tests {
 	#[test]
 	fn get_from_site_with_letsencrypt_isrgrootx1_valid_certificate_fails() {
 		let base_url = Url::parse("https://valid-isrgrootx1.letsencrypt.org").unwrap();
-		let result = get_for_test_certificates(base_url);
+		let result = send_http_get_request(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 	}
 
 	#[test]
 	fn get_from_site_with_letsencrypt_isrgrootx1_revoked_certificate_fails() {
 		let base_url = Url::parse("https://revoked-isrgrootx1.letsencrypt.org").unwrap();
-		let result = get_for_test_certificates(base_url);
+		let result = send_http_get_request(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 	}
 
 	#[test]
 	fn get_from_site_with_letsencrypt_isrgrootx1_expired_certificate_fails() {
 		let base_url = Url::parse("https://expired-isrgrootx1.letsencrypt.org").unwrap();
-		let result = get_for_test_certificates(base_url);
+		let result = send_http_get_request(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 	}
 
 	#[test]
 	fn get_from_site_with_letsencrypt_isrgrootx2_valid_certificate_fails() {
 		let base_url = Url::parse("https://valid-isrgrootx2.letsencrypt.org").unwrap();
-		let result = get_for_test_certificates(base_url);
+		let result = send_http_get_request(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 	}
 
 	#[test]
 	fn get_from_site_with_letsencrypt_isrgrootx2_revoked_certificate_fails() {
 		let base_url = Url::parse("https://revoked-isrgrootx2.letsencrypt.org").unwrap();
-		let result = get_for_test_certificates(base_url);
+		let result = send_http_get_request(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 	}
 
 	#[test]
 	fn get_from_site_with_letsencrypt_isrgrootx2_expired_certificate_fails() {
 		let base_url = Url::parse("https://expired-isrgrootx2.letsencrypt.org").unwrap();
-		let result = get_for_test_certificates(base_url);
+		let result = send_http_get_request(base_url);
 		assert_matches!(result, Err(Error::HttpReqError(_)));
 	}
 
-	fn get_for_test_certificates(base_url: Url) -> Result<(Response, EncodedBody), Error> {
+	fn send_http_get_request(base_url: Url) -> Result<(Response, EncodedBody), Error> {
 		#[derive(Serialize, Deserialize, Debug)]
 		struct HttpTestResponse {}
 

--- a/core/rest-client/src/lib.rs
+++ b/core/rest-client/src/lib.rs
@@ -18,6 +18,7 @@
 //! REST API Client, supporting SSL/TLS
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");


### PR DESCRIPTION
Add tests to ensure that per default the http client blocks the connection for some certificates known to be insecure, as https://github.com/integritee-network/worker/issues/552 cannot be implemented for now:
Check following certificates: 

- Self signed certificate
- let's encrypt certificates from test set-up. See https://letsencrypt.org/certificates/