### PR TITLE
bootstrap parentchain blocks for primary validateer

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -279,10 +279,10 @@ fn main() {
 				.description("query enclave registry and list all workers")
 				.runner(|_args: &str, matches: &ArgMatches<'_>| {
 					let api = get_chain_api(matches);
-					let wcount = api.enclave_count().unwrap();
+					let wcount = api.enclave_count(None).unwrap();
 					println!("number of workers registered: {}", wcount);
 					for w in 1..=wcount {
-						let enclave = api.enclave(w).unwrap();
+						let enclave = api.enclave(w, None).unwrap();
 						if enclave.is_none() {
 							println!("error reading enclave data");
 							continue

--- a/core-primitives/api-client-extensions/src/pallet_teerex.rs
+++ b/core-primitives/api-client-extensions/src/pallet_teerex.rs
@@ -1,5 +1,5 @@
 use itp_types::{Enclave, IpfsHash, ShardIdentifier};
-use sp_core::Pair;
+use sp_core::{Pair, H256 as Hash};
 use sp_runtime::MultiSignature;
 use substrate_api_client::{Api, RpcClient};
 
@@ -9,40 +9,56 @@ pub const TEEREX: &str = "Teerex";
 
 /// ApiClient extension that enables communication with the `teerex` pallet.
 pub trait PalletTeerexApi {
-	fn enclave(&self, index: u64) -> ApiResult<Option<Enclave>>;
-	fn enclave_count(&self) -> ApiResult<u64>;
-	fn all_enclaves(&self) -> ApiResult<Vec<Enclave>>;
-	fn worker_for_shard(&self, shard: &ShardIdentifier) -> ApiResult<Option<Enclave>>;
-	fn latest_ipfs_hash(&self, shard: &ShardIdentifier) -> ApiResult<Option<IpfsHash>>;
+	fn enclave(&self, index: u64, at_block: Option<Hash>) -> ApiResult<Option<Enclave>>;
+	fn enclave_count(&self, at_block: Option<Hash>) -> ApiResult<u64>;
+	fn all_enclaves(&self, at_block: Option<Hash>) -> ApiResult<Vec<Enclave>>;
+	fn worker_for_shard(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Hash>,
+	) -> ApiResult<Option<Enclave>>;
+	fn latest_ipfs_hash(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Hash>,
+	) -> ApiResult<Option<IpfsHash>>;
 }
 
 impl<P: Pair, Client: RpcClient> PalletTeerexApi for Api<P, Client>
 where
 	MultiSignature: From<P::Signature>,
 {
-	fn enclave(&self, index: u64) -> ApiResult<Option<Enclave>> {
-		self.get_storage_map(TEEREX, "EnclaveRegistry", index, None)
+	fn enclave(&self, index: u64, at_block: Option<Hash>) -> ApiResult<Option<Enclave>> {
+		self.get_storage_map(TEEREX, "EnclaveRegistry", index, at_block)
 	}
 
-	fn enclave_count(&self) -> ApiResult<u64> {
-		Ok(self.get_storage_value(TEEREX, "EnclaveCount", None)?.unwrap_or(0u64))
+	fn enclave_count(&self, at_block: Option<Hash>) -> ApiResult<u64> {
+		Ok(self.get_storage_value(TEEREX, "EnclaveCount", at_block)?.unwrap_or(0u64))
 	}
 
-	fn all_enclaves(&self) -> ApiResult<Vec<Enclave>> {
-		let count = self.enclave_count()?;
+	fn all_enclaves(&self, at_block: Option<Hash>) -> ApiResult<Vec<Enclave>> {
+		let count = self.enclave_count(at_block)?;
 		let mut enclaves = Vec::with_capacity(count as usize);
 		for n in 1..=count {
-			enclaves.push(self.enclave(n)?.unwrap())
+			enclaves.push(self.enclave(n, at_block)?.unwrap())
 		}
 		Ok(enclaves)
 	}
 
-	fn worker_for_shard(&self, shard: &ShardIdentifier) -> ApiResult<Option<Enclave>> {
-		self.get_storage_map(TEEREX, "WorkerForShard", shard, None)?
-			.map_or_else(|| Ok(None), |w_index| self.enclave(w_index))
+	fn worker_for_shard(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Hash>,
+	) -> ApiResult<Option<Enclave>> {
+		self.get_storage_map(TEEREX, "WorkerForShard", shard, at_block)?
+			.map_or_else(|| Ok(None), |w_index| self.enclave(w_index, at_block))
 	}
 
-	fn latest_ipfs_hash(&self, shard: &ShardIdentifier) -> ApiResult<Option<IpfsHash>> {
-		self.get_storage_map(TEEREX, "LatestIPFSHash", shard, None)
+	fn latest_ipfs_hash(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Hash>,
+	) -> ApiResult<Option<IpfsHash>> {
+		self.get_storage_map(TEEREX, "LatestIPFSHash", shard, at_block)
 	}
 }

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -566,12 +566,6 @@ fn sync_parentchain_internal(blocks_to_sync: Vec<SignedBlock>) -> Result<()> {
 /// Triggers the import of parentchain blocks when using a queue to sync parentchain block import
 /// with sidechain block production.
 ///
-/// Imports all blocks in the current queue. This ensures the first validateer of a parentchain
-/// syncs up to the parentchain block where itself is registered. Otherwise the `authority_set` will
-/// return None, resulting in not importing any parentchain blocks and an endless loop (#589).
-/// Should only be used for the first validateer as this is a bootstrapping problem. For all validateers
-/// following, the sidechain block import should be the parentchain block import trigger until they are up to date.
-///
 /// This trigger is only useful in combination with a `TriggeredDispatcher` and sidechain. In case no
 /// sidechain and the `ImmediateDispatcher` are used, this function is obsolete.
 #[no_mangle]

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -566,13 +566,18 @@ fn sync_parentchain_internal(blocks_to_sync: Vec<SignedBlock>) -> Result<()> {
 /// Triggers the import of parentchain blocks when using a queue to sync parentchain block import
 /// with sidechain block production.
 ///
-/// Imports all blocks in the queue except the latest one, which has to be triggered by the sidechain component.
+/// Imports all blocks in the current queue. This ensures the first validateer of a parentchain
+/// syncs up to the parentchain block where itself is registered. Otherwise the `authority_set` will
+/// return None, resulting in not importing any parentchain blocks and an endless loop (#589).
+/// Should only be used for the first validateer as this is a bootstrapping problem. For all validateers
+/// following, the sidechain block import should be the parentchain block import trigger until they are up to date.
+///
 /// This trigger is only useful in combination with a `TriggeredDispatcher` and sidechain. In case no
 /// sidechain and the `ImmediateDispatcher` are used, this function is obsolete.
 #[no_mangle]
 pub unsafe extern "C" fn trigger_parentchain_block_import() -> sgx_status_t {
 	match GLOBAL_PARENTCHAIN_IMPORT_DISPATCHER_COMPONENT.get() {
-		Some(dispatcher) => match dispatcher.import_all_but_latest() {
+		Some(dispatcher) => match dispatcher.import_all() {
 			Ok(_) => sgx_status_t::SGX_SUCCESS,
 			Err(e) => {
 				error!("Failed to trigger import of parentchain blocks: {:?}", e);

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
 	FromUtf8(#[from] std::string::FromUtf8Error),
 	#[error("Application setup error!")]
 	ApplicationSetup,
+	#[error("Retrieved empty value")]
+	EmptyValue,
 	#[error("Custom Error: {0}")]
 	Custom(Box<dyn std::error::Error>),
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -355,7 +355,7 @@ fn start_worker<E, T, D>(
 	// ------------------------------------------------------------------------
 	// Start interval sidechain block production (execution of trusted calls, sidechain block production).
 
-	let last_synced_header = bootstrap_parentchain_blocks_for_primary_valdiateer(
+	let last_synced_header = bootstrap_parentchain_blocks_for_primary_validateer(
 		&node_api,
 		enclave.clone(),
 		&last_synced_header,
@@ -792,7 +792,7 @@ fn bootstrap_funds_from_alice(
 
 /// In case this is the first validateer on the specified parentchain, we need to trigger
 /// the parentchain block import to import until the block where we have registered ourselves.
-fn bootstrap_parentchain_blocks_for_primary_valdiateer<E: EnclaveBase + TeerexApi + Sidechain>(
+fn bootstrap_parentchain_blocks_for_primary_validateer<E: EnclaveBase + TeerexApi + Sidechain>(
 	node_api: &Api<sr25519::Pair, WsRpcClient>,
 	enclave_api: Arc<E>,
 	last_synced_header: &Header,
@@ -804,8 +804,10 @@ fn bootstrap_parentchain_blocks_for_primary_valdiateer<E: EnclaveBase + TeerexAp
 	let enclave_count_of_previous_block =
 		node_api.enclave_count(Some(*registry_header.parent_hash()))?;
 
-	// If we're first in line, we must sync and import atleast until the block we have registered ourselves.
 	if enclave_count_of_previous_block == 0 {
+		info!(
+			"We're the first validateer to be registered, syncing parentchain blocks until the one we have registered ourselves on."
+		);
 		let parentchain_block_syncer =
 			ParentchainBlockSyncer::new(node_api.clone(), enclave_api.clone());
 		while last_synced_header.number() < registry_header.number() {

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -811,8 +811,6 @@ fn bootstrap_parentchain_blocks_for_primary_validateer<E: EnclaveBase + TeerexAp
 		let parentchain_block_syncer =
 			ParentchainBlockSyncer::new(node_api.clone(), enclave_api.clone());
 		while last_synced_header.number() < registry_header.number() {
-			// Otherwise we're spamming syncing messages.
-			thread::sleep(Duration::from_secs(1));
 			last_synced_header = parentchain_block_syncer.sync_parentchain(last_synced_header);
 		}
 		enclave_api.trigger_parentchain_block_import()?;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -791,7 +791,7 @@ fn bootstrap_funds_from_alice(
 }
 
 /// In case this is the first validateer on the specified parentchain, we need to trigger
-/// the parentchain block import to import until the block where we have registered ourselves.
+/// the parentchain block import up until the block where we have registered ourselves.
 fn bootstrap_parentchain_blocks_for_primary_validateer<E: EnclaveBase + TeerexApi + Sidechain>(
 	node_api: &Api<sr25519::Pair, WsRpcClient>,
 	enclave_api: Arc<E>,

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -352,11 +352,12 @@ fn start_worker<E, T, D>(
 	let last_synced_header = init_light_client(&node_api, enclave.clone()).unwrap();
 	println!("*** [+] Finished syncing light client, syncing parent chain...");
 
-	// Syncing all prentchain blocks, this might take a while..
+	// Syncing all parentchain blocks, this might take a while..
 	let parentchain_block_syncer =
 		Arc::new(ParentchainBlockSyncer::new(node_api.clone(), enclave.clone()));
 	let mut last_synced_header = parentchain_block_syncer.sync_parentchain(last_synced_header);
 
+	// If we're the first validateer to register, also trigger parentchain block import.
 	let register_enclave_xt_header =
 		node_api.get_header(register_enclave_xt_hash).unwrap().unwrap();
 	if primary_validateer(&node_api, &register_enclave_xt_header).unwrap() {

--- a/service/src/parentchain_block_syncer.rs
+++ b/service/src/parentchain_block_syncer.rs
@@ -25,6 +25,11 @@ use std::{cmp::min, sync::Arc};
 
 const BLOCK_SYNC_BATCH_SIZE: u32 = 1000;
 
+pub trait SyncParentchainBlocks {
+	/// Fetches the parentchainblocks to sync from the parentchain and feeds them to the enclave.
+	/// Returns the latest synced block Header.
+	fn sync_parentchain(&self, last_synced_header: Header) -> Header;
+}
 /// Supplies functionality to sync parentchain blocks.
 pub(crate) struct ParentchainBlockSyncer<ParentchainApi: ChainApi, EnclaveApi: Sidechain> {
 	parentchain_api: ParentchainApi,
@@ -39,11 +44,15 @@ where
 	pub fn new(parentchain_api: ParentchainApi, enclave_api: Arc<EnclaveApi>) -> Self {
 		ParentchainBlockSyncer { parentchain_api, enclave_api }
 	}
+}
 
-	/// Fetches the amount of blocks to sync from the parentchain and feeds them to the enclave.
-	/// Returns the latest synced block Header.
-	///
-	pub fn sync_parentchain(&self, last_synced_header: Header) -> Header {
+impl<ParentchainApi, EnclaveApi> SyncParentchainBlocks
+	for ParentchainBlockSyncer<ParentchainApi, EnclaveApi>
+where
+	ParentchainApi: ChainApi,
+	EnclaveApi: Sidechain,
+{
+	fn sync_parentchain(&self, last_synced_header: Header) -> Header {
 		trace!("Getting current head");
 		let curr_block: SignedBlock = self.parentchain_api.last_finalized_block().unwrap().unwrap();
 		let curr_block_number = curr_block.block.header.number;

--- a/service/src/tests/mock.rs
+++ b/service/src/tests/mock.rs
@@ -1,5 +1,5 @@
 use itp_api_client_extensions::{ApiResult, PalletTeerexApi};
-use itp_types::{Enclave, ShardIdentifier};
+use itp_types::{Enclave, ShardIdentifier, H256 as Hash};
 
 pub struct TestNodeApi;
 
@@ -14,21 +14,29 @@ pub fn enclaves() -> Vec<Enclave> {
 }
 
 impl PalletTeerexApi for TestNodeApi {
-	fn enclave(&self, index: u64) -> ApiResult<Option<Enclave>> {
+	fn enclave(&self, index: u64, _at_block: Option<Hash>) -> ApiResult<Option<Enclave>> {
 		Ok(Some(enclaves().remove(index as usize)))
 	}
-	fn enclave_count(&self) -> ApiResult<u64> {
+	fn enclave_count(&self, _at_block: Option<Hash>) -> ApiResult<u64> {
 		unreachable!()
 	}
 
-	fn all_enclaves(&self) -> ApiResult<Vec<Enclave>> {
+	fn all_enclaves(&self, _at_block: Option<Hash>) -> ApiResult<Vec<Enclave>> {
 		Ok(enclaves())
 	}
 
-	fn worker_for_shard(&self, _: &ShardIdentifier) -> ApiResult<Option<Enclave>> {
+	fn worker_for_shard(
+		&self,
+		_: &ShardIdentifier,
+		_at_block: Option<Hash>,
+	) -> ApiResult<Option<Enclave>> {
 		unreachable!()
 	}
-	fn latest_ipfs_hash(&self, _: &ShardIdentifier) -> ApiResult<Option<[u8; 46]>> {
+	fn latest_ipfs_hash(
+		&self,
+		_: &ShardIdentifier,
+		_at_block: Option<Hash>,
+	) -> ApiResult<Option<[u8; 46]>> {
 		unreachable!()
 	}
 }

--- a/service/src/tests/parentchain_block_syncer_test.rs
+++ b/service/src/tests/parentchain_block_syncer_test.rs
@@ -16,6 +16,7 @@
 */
 
 use crate::{
+	parentchain_block_syncer::SyncParentchainBlocks,
 	tests::mocks::{
 		parentchain_api_mock::ParentchainApiMock, sidechain_api_mock::SidechainApiMock,
 	},

--- a/service/src/tests/worker.rs
+++ b/service/src/tests/worker.rs
@@ -32,5 +32,5 @@ fn worker_rw_lock_works() {
 
 	let w = WORKER.read();
 	// call some random function to see how the worker needs to be called.
-	assert_eq!(w.as_ref().unwrap().node_api().all_enclaves().unwrap(), enclaves())
+	assert_eq!(w.as_ref().unwrap().node_api().all_enclaves(None).unwrap(), enclaves())
 }

--- a/service/src/worker.rs
+++ b/service/src/worker.rs
@@ -86,7 +86,7 @@ where
 	}
 
 	fn peers(&self) -> WorkerResult<Vec<EnclaveMetadata>> {
-		Ok(self.node_api.all_enclaves()?)
+		Ok(self.node_api.all_enclaves(None)?)
 	}
 }
 


### PR DESCRIPTION
solves #589 

- Introduces a little more flexibility to PalletTeerexApi functions with the introduction of `block_at` variable.
- if we're the first validateer to register, we sync all parentchain blocks up until the one we have registered ourselves in.