### PR TITLE
Bump integritee-node runtime spec

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,6 @@ jobs:
           cd bin
           ./integritee-service test -u -e
 
-      # Todo: #REBRAND path names
       - name: Upload worker
         uses: actions/upload-artifact@v2
         with:
@@ -170,10 +169,10 @@ jobs:
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: ci.yml
-          name: integritee-node-dev-a97ddbce0048a9b48eef76799f3e42e37690c334
+          name: integritee-node-dev-61afcf67486a3ea3ec8d7f54feb7a064f6d94fc2
           # in fact this action should download the latest artifact, but sometimes fails. Then we need to
           # set the `run_id` to force a download of an updated binary.
-          run_id: 1544655658
+          run_id: 1613002484
           path: node
           repo: integritee-network/integritee-node
 

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -106,7 +106,7 @@ pub mod node {
 	pub static PROPOSED_SIDECHAIN_BLOCK: u8 = 4u8;
 	pub static SHIELD_FUNDS: u8 = 5u8;
 	// bump this to be consistent with integritee-node runtime
-	pub static RUNTIME_SPEC_VERSION: u32 = 5;
-	pub static RUNTIME_TRANSACTION_VERSION: u32 = 1;
+	pub static RUNTIME_SPEC_VERSION: u32 = 6;
+	pub static RUNTIME_TRANSACTION_VERSION: u32 = 2;
 	pub static UNSHIELD: u8 = 6u8;
 }


### PR DESCRIPTION
@gaudenzkessler this will make the worker compatible with the newest integritee-node docker container.