### PR TITLE
replace own worker address by localhost and do not end gossip loop when peer connections fails

### DIFF
--- a/service/src/worker.rs
+++ b/service/src/worker.rs
@@ -97,8 +97,17 @@ where
 		Ok(())
 	}
 
+	/// Returns a list of peers. The address of the worker self is replaced by ws://localhost.
 	fn peers(&self) -> WorkerResult<Vec<EnclaveMetadata>> {
-		Ok(self.node_api.all_enclaves(None)?)
+		let mut peers = self.node_api.all_enclaves(None)?;
+		peers.iter_mut().for_each(|e| {
+			if e.url.trim_start_matches("ws://").trim_start_matches("wss://")
+				== self._config.worker_url()
+			{
+				e.url = format!("ws://localhost:{}", self._config.worker_rpc_port);
+			}
+		});
+		Ok(peers)
 	}
 }
 

--- a/service/src/worker.rs
+++ b/service/src/worker.rs
@@ -72,10 +72,22 @@ where
 
 		for p in peers.iter() {
 			// Todo: once the two direct servers are merged, remove this.
-			let url = worker_url_into_async_rpc_url(&p.url)?;
+			let url = match worker_url_into_async_rpc_url(&p.url) {
+				Ok(url) => url,
+				Err(e) => {
+					error!("Could not create async rpc url: {:?}", e);
+					continue
+				},
+			};
 			trace!("Gossiping block to peer with address: {:?}", url);
-			// FIXME: Websocket connectionto a worker  should stay once etablished.
-			let client = WsClientBuilder::default().build(&url).await?;
+			// FIXME: Websocket connection to a worker should stay once established.
+			let client = match WsClientBuilder::default().build(&url).await {
+				Ok(c) => c,
+				Err(e) => {
+					error!("Could not establish connection to peer: {:?}", e);
+					continue
+				},
+			};
 			let blocks = blocks_json.clone();
 			if let Err(e) = client.request::<Vec<u8>>("sidechain_importBlock", blocks.into()).await
 			{


### PR DESCRIPTION
- Replace in list of peers the own address of the worker itself by ws://localhost.
- Do not end gossip block loop when the connecting to peer fails.