### PR TITLE
Tokio runtime limited to 2 worker threads, gossiping leverages async tasks

### DIFF
--- a/service/src/globals/tokio_handle.rs
+++ b/service/src/globals/tokio_handle.rs
@@ -38,7 +38,11 @@ pub struct GlobalTokioHandle;
 impl GlobalTokioHandle {
 	/// this needs to be called once at application startup!
 	pub fn initialize() {
-		let rt = tokio::runtime::Runtime::new().unwrap();
+		let rt = tokio::runtime::Builder::new_multi_thread()
+			.enable_all()
+			.worker_threads(2)
+			.build()
+			.unwrap();
 		*TOKIO_HANDLE.write() = Some(rt);
 	}
 


### PR DESCRIPTION
This is cherry picked from a future PR of mine. Should resolve #570 .
When we instantiate the tokio runtime, we limit the number of worker threads to 2 for now, to avoid running out of enclave TCS (as is the case in #570). 

When the tokio runtime is default constructed, it will use as many worker threads as cores are available. So as soon as we put some load onto the tokio tasks, we saturate the threads and more. And since the gossiping calls into the enclave, we use a TCS for every worker thread.