### PR TITLE
create alive service to deterine that the service is up, running and registered

### DIFF
--- a/service/src/alive_service.rs
+++ b/service/src/alive_service.rs
@@ -1,0 +1,55 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Service to determine if the integritee services is alive and registered to the node,
+//! hosted on a http server.
+
+use crate::error::ServiceResult;
+use lazy_static::lazy_static;
+use log::*;
+use parking_lot::RwLock;
+use std::net::SocketAddr;
+use warp::Filter;
+
+lazy_static! {
+	static ref ALIVE_HANDLE: RwLock<bool> = RwLock::new(false);
+}
+
+pub async fn start_alive_server() -> ServiceResult<()> {
+	let port = 1234;
+	let is_alive_route = warp::path!("is_alive").and_then(|| async move {
+		if *ALIVE_HANDLE.read() {
+			Ok("I am alive")
+		} else {
+			Err(warp::reject::not_found())
+		}
+	});
+
+	let socket_addr: SocketAddr = ([0, 0, 0, 0], port).into();
+
+	info!("Running alive server on: {:?}", socket_addr);
+	warp::serve(is_alive_route).run(socket_addr).await;
+
+	info!("Alive server shut down");
+	Ok(())
+}
+
+/// Set alive handler value to true.
+pub fn set_alive() {
+	let mut alive_lock = ALIVE_HANDLE.write();
+	*alive_lock = true;
+}

--- a/service/src/initialized_service.rs
+++ b/service/src/initialized_service.rs
@@ -15,7 +15,7 @@
 
 */
 
-//! Service to determine if the integritee services is alive and registered to the node,
+//! Service to determine if the integritee services is initialized and registered on the node,
 //! hosted on a http server.
 
 use crate::error::ServiceResult;
@@ -26,14 +26,14 @@ use std::net::SocketAddr;
 use warp::Filter;
 
 lazy_static! {
-	static ref ALIVE_HANDLE: RwLock<bool> = RwLock::new(false);
+	static ref INITIALIZED_HANDLE: RwLock<bool> = RwLock::new(false);
 }
 
-pub async fn start_alive_server() -> ServiceResult<()> {
+pub async fn start_initialized_server() -> ServiceResult<()> {
 	let port = 1234;
-	let is_alive_route = warp::path!("is_alive").and_then(|| async move {
-		if *ALIVE_HANDLE.read() {
-			Ok("I am alive")
+	let is_initialized_route = warp::path!("is_initialized").and_then(|| async move {
+		if *INITIALIZED_HANDLE.read() {
+			Ok("I am initialized.")
 		} else {
 			Err(warp::reject::not_found())
 		}
@@ -41,15 +41,15 @@ pub async fn start_alive_server() -> ServiceResult<()> {
 
 	let socket_addr: SocketAddr = ([0, 0, 0, 0], port).into();
 
-	info!("Running alive server on: {:?}", socket_addr);
-	warp::serve(is_alive_route).run(socket_addr).await;
+	info!("Running initialized server on: {:?}", socket_addr);
+	warp::serve(is_initialized_route).run(socket_addr).await;
 
-	info!("Alive server shut down");
+	info!("Initialized server shut down");
 	Ok(())
 }
 
-/// Set alive handler value to true.
-pub fn set_alive() {
-	let mut alive_lock = ALIVE_HANDLE.write();
-	*alive_lock = true;
+/// Set initialized handler value to true.
+pub fn set_initialized() {
+	let mut initialized_lock = INITIALIZED_HANDLE.write();
+	*initialized_lock = true;
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -19,9 +19,9 @@
 
 use crate::{
 	account_funding::{setup_account_funding, EnclaveAccountInfoProvider},
-	alive_service::{set_alive, start_alive_server},
 	error::Error,
 	globals::tokio_handle::{GetTokioHandle, GlobalTokioHandle},
+	initialized_service::{set_initialized, start_initialized_server},
 	ocall_bridge::{
 		bridge_api::Bridge as OCallBridge, component_factory::OCallBridgeComponentFactory,
 	},
@@ -95,11 +95,11 @@ use substrate_api_client::{
 use teerex_primitives::ShardIdentifier;
 
 mod account_funding;
-mod alive_service;
 mod config;
 mod enclave;
 mod error;
 mod globals;
+mod initialized_service;
 mod ocall_bridge;
 mod parentchain_block_syncer;
 mod prometheus_metrics;
@@ -314,10 +314,10 @@ fn start_worker<E, T, D>(
 	let tee_accountid = enclave_account(enclave.as_ref());
 
 	// ------------------------------------------------------------------------
-	// Start alive server
+	// Start initialized server
 	tokio_handle.spawn(async move {
-		if let Err(e) = start_alive_server().await {
-			error!("Unexpected error in alive server: {:?}", e);
+		if let Err(e) = start_initialized_server().await {
+			error!("Unexpected error in initialized server: {:?}", e);
 		}
 	});
 
@@ -506,8 +506,8 @@ fn start_worker<E, T, D>(
 		})
 		.unwrap();
 
-	// Set that the service is alive.
-	set_alive();
+	// Set that the service is initialized.
+	set_initialized();
 
 	println!("[+] Subscribed to events. waiting...");
 	let timeout = Duration::from_millis(10);


### PR DESCRIPTION
 * Introduced an http service which returns 200 (OK) if the service is not fully up and 404 (not found), if  not
 * set this alive value to true, at the end of start worker method
 * ![image](https://user-images.githubusercontent.com/92718752/160805542-7cbd938c-e37d-4549-8719-6de6f04be7b5.png)


closes #695
