### PR TITLE
New --clean-reset and --request-state options to run worker in a single command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2998,6 +2998,7 @@ dependencies = [
  "derive_more",
  "futures 0.3.21",
  "futures-timer",
+ "itp-settings",
  "itp-sgx-io",
  "itp-time-utils",
  "itp-types",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ worker/bin$ touch sealed_stf_state.bin
 ### execute tests
 Run these with
 ```
-integritee-service/bin$ ./integritee-service test_enclave --all
+integritee-service/bin$ ./integritee-service test --all
 ```
 
 ### End-to-end test with benchmarking
@@ -47,8 +47,7 @@ run worker
 
 ```
 export RUST_LOG=debug,substrate_api_client=warn,sp_io=warn,ws=warn,integritee_service=info,enclave_runtime=info,sp_io::misc=debug,runtime=debug,enclave_runtime::state=warn,ita_stf::sgx=info,light_client=warn,rustls=warn
-rm -rf shards/ light_client_db.bin
-./integritee-service -r 2002 -p 9979 -w 2001 run 2>&1 | tee worker.log
+./integritee-service --clean-reset -r 2002 -p 9979 -w 2001 run 2>&1 | tee worker.log
 ```
 
 wait until you see the worker synching a few blocks. then check MRENCLAVE and update bot-community.py constants accordingly

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -35,7 +35,6 @@ pub mod files {
 	pub const SEALED_SIGNER_SEED_FILE: &str = "ed25519_key_sealed.bin";
 	pub const AES_KEY_FILE_AND_INIT_V: &str = "aes_key_sealed.bin";
 	pub const LIGHT_CLIENT_DB: &str = "light_client_db.bin";
-	pub const MR_ENCLAVE_FILE: &str = "mrenclave.b58";
 
 	pub const RA_DUMP_CERT_DER_FILE: &str = "ra_dump_cert.der";
 

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -39,8 +39,9 @@ pub mod files {
 	pub const RA_DUMP_CERT_DER_FILE: &str = "ra_dump_cert.der";
 
 	// used by worker and enclave
-	pub const SHARDS_PATH: &str = "./shards";
+	pub const SHARDS_PATH: &str = "shards";
 	pub const ENCRYPTED_STATE_FILE: &str = "state.bin";
+	pub const LAST_SLOT_BIN: &str = "last_slot.bin";
 
 	#[cfg(feature = "production")]
 	pub static RA_SPID_FILE: &str = "spid_production.txt";

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -35,6 +35,7 @@ pub mod files {
 	pub const SEALED_SIGNER_SEED_FILE: &str = "ed25519_key_sealed.bin";
 	pub const AES_KEY_FILE_AND_INIT_V: &str = "aes_key_sealed.bin";
 	pub const LIGHT_CLIENT_DB: &str = "light_client_db.bin";
+	pub const MR_ENCLAVE_FILE: &str = "mrenclave.b58";
 
 	pub const RA_DUMP_CERT_DER_FILE: &str = "ra_dump_cert.der";
 

--- a/core-primitives/sgx/crypto/src/error.rs
+++ b/core-primitives/sgx/crypto/src/error.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use derive_more::{Display, From};
 use sgx_types::sgx_status_t;
 use std::prelude::v1::Box;
@@ -7,6 +24,7 @@ pub enum Error {
 	IO(std::io::Error),
 	InvalidNonceKeyLength,
 	Codec(codec::Error),
+	LockPoisoning,
 	Other(Box<dyn std::error::Error + Sync + Send + 'static>),
 }
 

--- a/core-primitives/sgx/crypto/src/lib.rs
+++ b/core-primitives/sgx/crypto/src/lib.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 //! All the different crypto schemes that we use in sgx
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -19,6 +36,7 @@ pub mod sgx_reexport_prelude {
 pub mod aes;
 pub mod ed25519;
 pub mod error;
+pub mod key_repository;
 pub mod traits;
 
 #[cfg(feature = "sgx")]

--- a/core-primitives/sgx/crypto/src/mocks.rs
+++ b/core-primitives/sgx/crypto/src/mocks.rs
@@ -24,8 +24,48 @@ use std::sync::RwLock;
 use crate::{
 	aes::Aes,
 	error::{Error, Result},
+	key_repository::{AccessKey, MutateKey},
 };
 use itp_sgx_io::{SealedIO, StaticSealedIO};
+
+#[derive(Default)]
+pub struct KeyRepositoryMock<KeyType>
+where
+	KeyType: Clone + Default,
+{
+	key: RwLock<KeyType>,
+}
+
+impl<KeyType> KeyRepositoryMock<KeyType>
+where
+	KeyType: Clone + Default,
+{
+	pub fn new(key: KeyType) -> Self {
+		KeyRepositoryMock { key: RwLock::new(key) }
+	}
+}
+
+impl<KeyType> AccessKey for KeyRepositoryMock<KeyType>
+where
+	KeyType: Clone + Default,
+{
+	type KeyType = KeyType;
+
+	fn retrieve_key(&self) -> Result<Self::KeyType> {
+		Ok(self.key.read().unwrap().clone())
+	}
+}
+
+impl<KeyType> MutateKey<KeyType> for KeyRepositoryMock<KeyType>
+where
+	KeyType: Clone + Default,
+{
+	fn update_key(&self, key: KeyType) -> Result<()> {
+		let mut lock = self.key.write().unwrap();
+		*lock = key;
+		Ok(())
+	}
+}
 
 #[derive(Default)]
 pub struct AesSealMock {

--- a/core-primitives/sgx/crypto/src/traits.rs
+++ b/core-primitives/sgx/crypto/src/traits.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 //! Abstraction over the state crypto that is used in the enclave
 use std::{fmt::Debug, vec::Vec};
 

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -30,7 +30,9 @@ sgx = [
     "sgx-externalities/sgx",
     "thiserror_sgx",
 ]
-test = []
+test = [
+    "itp-sgx-crypto/mocks"
+]
 
 [dependencies]
 # sgx dependencies

--- a/core-primitives/stf-state-handler/src/file_io.rs
+++ b/core-primitives/stf-state-handler/src/file_io.rs
@@ -293,7 +293,7 @@ pub mod sgx {
 	/// List any valid shards that are found in the shard path.
 	/// Ignore any items (files, directories) that are not valid shard identifiers.
 	pub(crate) fn list_shards() -> Result<Vec<ShardIdentifier>> {
-		let directory_items = list_items_in_directory(&PathBuf::from(SHARDS_PATH));
+		let directory_items = list_items_in_directory(&PathBuf::from(format!("./{}", SHARDS_PATH)));
 		Ok(directory_items
 			.iter()
 			.flat_map(|item| {
@@ -328,7 +328,7 @@ pub fn purge_shard_dir(shard: &ShardIdentifier) {
 }
 
 pub(crate) fn shard_path(shard: &ShardIdentifier) -> PathBuf {
-	PathBuf::from(format!("{}/{}", SHARDS_PATH, shard.encode().to_base58()))
+	PathBuf::from(format!("./{}/{}", SHARDS_PATH, shard.encode().to_base58()))
 }
 
 #[cfg(any(test, feature = "sgx"))]

--- a/core-primitives/stf-state-handler/src/file_io.rs
+++ b/core-primitives/stf-state-handler/src/file_io.rs
@@ -88,11 +88,11 @@ pub trait StateFileIo {
 pub mod sgx {
 
 	use super::*;
-	use crate::{error::Error, state_key_repository::AccessStateKey};
+	use crate::error::Error;
 	use base58::FromBase58;
 	use codec::Decode;
 	use ita_stf::{State as StfState, StateType as StfStateType, Stf};
-	use itp_sgx_crypto::StateCrypto;
+	use itp_sgx_crypto::{key_repository::AccessKey, StateCrypto};
 	use itp_sgx_io::{read as io_read, write as io_write};
 	use itp_types::H256;
 	use log::*;
@@ -106,7 +106,8 @@ pub mod sgx {
 
 	impl<StateKeyRepository> SgxStateFileIo<StateKeyRepository>
 	where
-		StateKeyRepository: AccessStateKey,
+		StateKeyRepository: AccessKey,
+		<StateKeyRepository as AccessKey>::KeyType: StateCrypto,
 	{
 		pub fn new(state_key_repository: Arc<StateKeyRepository>) -> Self {
 			SgxStateFileIo { state_key_repository }
@@ -146,9 +147,10 @@ pub mod sgx {
 		}
 	}
 
-	impl<StateKey> StateFileIo for SgxStateFileIo<StateKey>
+	impl<StateKeyRepository> StateFileIo for SgxStateFileIo<StateKeyRepository>
 	where
-		StateKey: AccessStateKey,
+		StateKeyRepository: AccessKey,
+		<StateKeyRepository as AccessKey>::KeyType: StateCrypto,
 	{
 		type StateType = StfState;
 		type HashType = H256;

--- a/core-primitives/stf-state-handler/src/lib.rs
+++ b/core-primitives/stf-state-handler/src/lib.rs
@@ -37,7 +37,6 @@ pub mod handle_state;
 mod in_memory_state_file_io;
 pub mod query_shard_state;
 pub mod state_handler;
-pub mod state_key_repository;
 mod state_snapshot_primitives;
 pub mod state_snapshot_repository;
 pub mod state_snapshot_repository_loader;

--- a/core-primitives/stf-state-handler/src/test/mocks/state_key_repository_mock.rs
+++ b/core-primitives/stf-state-handler/src/test/mocks/state_key_repository_mock.rs
@@ -21,11 +21,11 @@ use std::sync::SgxRwLock as RwLock;
 #[cfg(feature = "std")]
 use std::sync::RwLock;
 
-use crate::{
+use itp_sgx_crypto::{
 	error::Result,
-	state_key_repository::{AccessStateKey, MutateStateKey},
+	key_repository::{AccessKey, MutateKey},
+	StateCrypto,
 };
-use itp_sgx_crypto::StateCrypto;
 
 #[derive(Default)]
 pub struct StateKeyRepositoryMock<KeyType>
@@ -45,7 +45,7 @@ where
 	}
 }
 
-impl<KeyType> AccessStateKey for StateKeyRepositoryMock<KeyType>
+impl<KeyType> AccessKey for StateKeyRepositoryMock<KeyType>
 where
 	KeyType: StateCrypto + Clone + Default,
 {
@@ -56,7 +56,7 @@ where
 	}
 }
 
-impl<KeyType> MutateStateKey<KeyType> for StateKeyRepositoryMock<KeyType>
+impl<KeyType> MutateKey<KeyType> for StateKeyRepositoryMock<KeyType>
 where
 	KeyType: StateCrypto + Clone + Default,
 {

--- a/core-primitives/stf-state-handler/src/test/sgx_tests.rs
+++ b/core-primitives/stf-state-handler/src/test/sgx_tests.rs
@@ -27,11 +27,10 @@ use crate::{
 	state_handler::StateHandler,
 	state_snapshot_repository::StateSnapshotRepository,
 	state_snapshot_repository_loader::StateSnapshotRepositoryLoader,
-	test::mocks::state_key_repository_mock::StateKeyRepositoryMock,
 };
 use codec::{Decode, Encode};
 use ita_stf::{State as StfState, StateType as StfStateType};
-use itp_sgx_crypto::{Aes, AesSeal, StateCrypto};
+use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes, AesSeal, StateCrypto};
 use itp_sgx_io::{write, StaticSealedIO};
 use itp_types::{ShardIdentifier, H256};
 use sgx_externalities::SgxExternalitiesTrait;
@@ -40,7 +39,8 @@ use std::{sync::Arc, thread, vec::Vec};
 
 const STATE_SNAPSHOTS_CACHE_SIZE: usize = 3;
 
-type TestStateFileIo = SgxStateFileIo<StateKeyRepositoryMock<Aes>>;
+type StateKeyRepositoryMock = KeyRepositoryMock<Aes>;
+type TestStateFileIo = SgxStateFileIo<StateKeyRepositoryMock>;
 type TestStateRepository = StateSnapshotRepository<TestStateFileIo, StfState, H256>;
 type TestStateRepositoryLoader = StateSnapshotRepositoryLoader<TestStateFileIo, StfState, H256>;
 type TestStateHandler = StateHandler<TestStateRepository>;

--- a/core-primitives/top-pool-author/Cargo.toml
+++ b/core-primitives/top-pool-author/Cargo.toml
@@ -71,3 +71,6 @@ derive_more = { version = "0.99.5" }
 log = { version = "0.4", default-features = false }
 sp-core = { version = "6.0.0", default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19"}
+
+[dev-dependencies]
+itp-sgx-crypto = { path = "../sgx/crypto", features = ["mocks"] }

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -28,7 +28,7 @@ use codec::{Decode, Encode};
 use ita_stf::{hash, Getter, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_enclave_metrics::EnclaveMetric;
 use itp_ocall_api::EnclaveMetricsOCallApi;
-use itp_sgx_crypto::ShieldingCrypto;
+use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCrypto};
 use itp_stf_state_handler::query_shard_state::QueryShardState;
 use itp_top_pool::{
 	error::{Error as PoolError, IntoPoolError},
@@ -64,12 +64,13 @@ where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: ShieldingCrypto,
+	EncryptionKey: AccessKey,
+	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
 {
 	top_pool: Arc<TopPool>,
 	top_filter: TopFilter,
 	state_facade: Arc<StateFacade>,
-	encryption_key: EncryptionKey,
+	shielding_key_repo: Arc<EncryptionKey>,
 	ocall_api: Arc<OCallApi>,
 }
 
@@ -79,7 +80,8 @@ where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: ShieldingCrypto,
+	EncryptionKey: AccessKey,
+	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	/// Create new instance of Authoring API.
@@ -87,10 +89,10 @@ where
 		top_pool: Arc<TopPool>,
 		top_filter: TopFilter,
 		state_facade: Arc<StateFacade>,
-		encryption_key: EncryptionKey,
+		encryption_key: Arc<EncryptionKey>,
 		ocall_api: Arc<OCallApi>,
 	) -> Self {
-		Author { top_pool, top_filter, state_facade, encryption_key, ocall_api }
+		Author { top_pool, top_filter, state_facade, shielding_key_repo: encryption_key, ocall_api }
 	}
 }
 
@@ -105,7 +107,8 @@ where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: ShieldingCrypto,
+	EncryptionKey: AccessKey,
+	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	fn process_top(
@@ -124,7 +127,11 @@ where
 		};
 
 		// decrypt call
-		let request_vec = match self.encryption_key.decrypt(ext.as_slice()) {
+		let shielding_key = match self.shielding_key_repo.retrieve_key() {
+			Ok(k) => k,
+			Err(_) => return Box::pin(ready(Err(ClientError::BadFormatDecipher.into()))),
+		};
+		let request_vec = match shielding_key.decrypt(ext.as_slice()) {
 			Ok(req) => req,
 			Err(_) => return Box::pin(ready(Err(ClientError::BadFormatDecipher.into()))),
 		};
@@ -192,7 +199,8 @@ where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: ShieldingCrypto,
+	EncryptionKey: AccessKey,
+	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	fn submit_top(
@@ -286,7 +294,8 @@ where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: ShieldingCrypto,
+	EncryptionKey: AccessKey,
+	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	type Hash = <TopPool as TrustedOperationPool>::Hash;
@@ -302,7 +311,8 @@ where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: ShieldingCrypto,
+	EncryptionKey: AccessKey,
+	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	type Hash = <TopPool as TrustedOperationPool>::Hash;

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -59,29 +59,29 @@ const TX_SOURCE: TrustedOperationSource = TrustedOperationSource::External;
 /// Authoring API for RPC calls
 ///
 ///
-pub struct Author<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
+pub struct Author<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
 where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: AccessKey,
-	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
 {
 	top_pool: Arc<TopPool>,
 	top_filter: TopFilter,
 	state_facade: Arc<StateFacade>,
-	shielding_key_repo: Arc<EncryptionKey>,
+	shielding_key_repo: Arc<ShieldingKeyRepository>,
 	ocall_api: Arc<OCallApi>,
 }
 
-impl<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
-	Author<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
+impl<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
+	Author<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
 where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: AccessKey,
-	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	/// Create new instance of Authoring API.
@@ -89,7 +89,7 @@ where
 		top_pool: Arc<TopPool>,
 		top_filter: TopFilter,
 		state_facade: Arc<StateFacade>,
-		encryption_key: Arc<EncryptionKey>,
+		encryption_key: Arc<ShieldingKeyRepository>,
 		ocall_api: Arc<OCallApi>,
 	) -> Self {
 		Author { top_pool, top_filter, state_facade, shielding_key_repo: encryption_key, ocall_api }
@@ -101,14 +101,14 @@ enum TopSubmissionMode {
 	SubmitWatch,
 }
 
-impl<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
-	Author<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
+impl<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
+	Author<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
 where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: AccessKey,
-	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	fn process_top(
@@ -192,15 +192,15 @@ fn map_top_error<P: TrustedOperationPool>(error: P::Error) -> RpcError {
 	.into()
 }
 
-impl<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
+impl<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
 	AuthorApi<TxHash<TopPool>, BlockHash<TopPool>>
-	for Author<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
+	for Author<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
 where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: AccessKey,
-	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	fn submit_top(
@@ -288,14 +288,14 @@ where
 	}
 }
 
-impl<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi> OnBlockImported
-	for Author<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
+impl<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi> OnBlockImported
+	for Author<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
 where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: AccessKey,
-	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	type Hash = <TopPool as TrustedOperationPool>::Hash;
@@ -305,14 +305,14 @@ where
 	}
 }
 
-impl<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi> SendState
-	for Author<TopPool, TopFilter, StateFacade, EncryptionKey, OCallApi>
+impl<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi> SendState
+	for Author<TopPool, TopFilter, StateFacade, ShieldingKeyRepository, OCallApi>
 where
 	TopPool: TrustedOperationPool + Sync + Send + 'static,
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
-	EncryptionKey: AccessKey,
-	<EncryptionKey as AccessKey>::KeyType: ShieldingCrypto,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	type Hash = <TopPool as TrustedOperationPool>::Hash;

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -43,18 +43,18 @@ pub trait ExecuteIndirectCalls {
 		ParentchainBlock: ParentchainBlockTrait<Hash = H256>;
 }
 
-pub struct IndirectCallsExecutor<ShieldingKey, StfExecutor> {
-	shielding_key_repo: Arc<ShieldingKey>,
+pub struct IndirectCallsExecutor<ShieldingKeyRepository, StfExecutor> {
+	shielding_key_repo: Arc<ShieldingKeyRepository>,
 	stf_executor: Arc<StfExecutor>,
 }
 
-impl<ShieldingKey, StfExecutor> IndirectCallsExecutor<ShieldingKey, StfExecutor>
+impl<ShieldingKeyRepository, StfExecutor> IndirectCallsExecutor<ShieldingKeyRepository, StfExecutor>
 where
-	ShieldingKey: AccessKey,
-	<ShieldingKey as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
 	StfExecutor: StfExecuteTrustedCall + StfExecuteShieldFunds,
 {
-	pub fn new(authority: Arc<ShieldingKey>, stf_executor: Arc<StfExecutor>) -> Self {
+	pub fn new(authority: Arc<ShieldingKeyRepository>, stf_executor: Arc<StfExecutor>) -> Self {
 		IndirectCallsExecutor { shielding_key_repo: authority, stf_executor }
 	}
 
@@ -91,11 +91,11 @@ where
 	}
 }
 
-impl<ShieldingKey, StfExecutor> ExecuteIndirectCalls
-	for IndirectCallsExecutor<ShieldingKey, StfExecutor>
+impl<ShieldingKeyRepository, StfExecutor> ExecuteIndirectCalls
+	for IndirectCallsExecutor<ShieldingKeyRepository, StfExecutor>
 where
-	ShieldingKey: AccessKey,
-	<ShieldingKey as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
 	StfExecutor: StfExecuteTrustedCall + StfExecuteShieldFunds,
 {
 	fn execute_indirect_calls_in_extrinsics<ParentchainBlock>(

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -21,7 +21,7 @@ use crate::error::Result;
 use codec::{Decode, Encode};
 use ita_stf::{AccountId, TrustedCallSigned};
 use itp_settings::node::{CALL_WORKER, SHIELD_FUNDS, TEEREX_MODULE};
-use itp_sgx_crypto::ShieldingCrypto;
+use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCrypto};
 use itp_stf_executor::traits::{StatePostProcessing, StfExecuteShieldFunds, StfExecuteTrustedCall};
 use itp_types::{CallWorkerFn, OpaqueCall, ShardIdentifier, ShieldFundsFn, H256};
 use log::*;
@@ -44,17 +44,18 @@ pub trait ExecuteIndirectCalls {
 }
 
 pub struct IndirectCallsExecutor<ShieldingKey, StfExecutor> {
-	shielding_key: ShieldingKey,
+	shielding_key_repo: Arc<ShieldingKey>,
 	stf_executor: Arc<StfExecutor>,
 }
 
 impl<ShieldingKey, StfExecutor> IndirectCallsExecutor<ShieldingKey, StfExecutor>
 where
-	ShieldingKey: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
+	ShieldingKey: AccessKey,
+	<ShieldingKey as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
 	StfExecutor: StfExecuteTrustedCall + StfExecuteShieldFunds,
 {
-	pub fn new(authority: ShieldingKey, stf_executor: Arc<StfExecutor>) -> Self {
-		IndirectCallsExecutor { shielding_key: authority, stf_executor }
+	pub fn new(authority: Arc<ShieldingKey>, stf_executor: Arc<StfExecutor>) -> Self {
+		IndirectCallsExecutor { shielding_key_repo: authority, stf_executor }
 	}
 
 	fn handle_shield_funds_xt(&self, xt: &UncheckedExtrinsicV4<ShieldFundsFn>) -> Result<()> {
@@ -64,7 +65,8 @@ where
 
 		debug!("decrypt the account id");
 
-		let account_vec = self.shielding_key.decrypt(account_encrypted)?;
+		let shielding_key = self.shielding_key_repo.retrieve_key()?;
+		let account_vec = shielding_key.decrypt(account_encrypted)?;
 
 		let account = AccountId::decode(&mut account_vec.as_slice())?;
 
@@ -82,8 +84,8 @@ where
         	call, bs58::encode(shard.encode()).into_string(), cyphertext);
 
 		debug!("decrypt the call");
-		//let request_vec = Rsa3072KeyPair::decrypt(&cyphertext)?;
-		let request_vec = self.shielding_key.decrypt(&cyphertext)?;
+		let shielding_key = self.shielding_key_repo.retrieve_key()?;
+		let request_vec = shielding_key.decrypt(&cyphertext)?;
 
 		Ok(TrustedCallSigned::decode(&mut request_vec.as_slice()).map(|call| (call, shard))?)
 	}
@@ -92,7 +94,8 @@ where
 impl<ShieldingKey, StfExecutor> ExecuteIndirectCalls
 	for IndirectCallsExecutor<ShieldingKey, StfExecutor>
 where
-	ShieldingKey: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
+	ShieldingKey: AccessKey,
+	<ShieldingKey as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
 	StfExecutor: StfExecuteTrustedCall + StfExecuteShieldFunds,
 {
 	fn execute_indirect_calls_in_extrinsics<ParentchainBlock>(

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1649,6 +1649,7 @@ name = "its-consensus-slots"
 version = "0.8.0"
 dependencies = [
  "derive_more",
+ "itp-settings",
  "itp-sgx-io",
  "itp-time-utils",
  "itp-types",

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -38,7 +38,7 @@ use itp_block_import_queue::BlockImportQueue;
 use itp_component_container::ComponentContainer;
 use itp_extrinsics_factory::ExtrinsicsFactory;
 use itp_nonce_cache::NonceCache;
-use itp_sgx_crypto::{key_repository::KeyRepository, Aes, AesSeal};
+use itp_sgx_crypto::{key_repository::KeyRepository, Aes, AesSeal, Rsa3072Seal};
 use itp_stf_executor::executor::StfExecutor;
 use itp_stf_state_handler::{
 	file_io::sgx::SgxStateFileIo, state_snapshot_repository::StateSnapshotRepository, StateHandler,
@@ -66,6 +66,7 @@ use sgx_externalities::SgxExternalities;
 use sp_core::ed25519::Pair;
 
 pub type EnclaveStateKeyRepository = KeyRepository<Aes, AesSeal>;
+pub type EnclaveShieldingKeyRepository = KeyRepository<Rsa3072KeyPair, Rsa3072Seal>;
 pub type EnclaveStateFileIo = SgxStateFileIo<EnclaveStateKeyRepository>;
 pub type EnclaveStateSnapshotRepository =
 	StateSnapshotRepository<EnclaveStateFileIo, StfState, H256>;
@@ -73,7 +74,8 @@ pub type EnclaveStateHandler = StateHandler<EnclaveStateSnapshotRepository>;
 pub type EnclaveOCallApi = OcallApi;
 pub type EnclaveStfExecutor = StfExecutor<EnclaveOCallApi, EnclaveStateHandler, SgxExternalities>;
 pub type EnclaveExtrinsicsFactory = ExtrinsicsFactory<Pair, NonceCache>;
-pub type EnclaveIndirectCallsExecutor = IndirectCallsExecutor<Rsa3072KeyPair, EnclaveStfExecutor>;
+pub type EnclaveIndirectCallsExecutor =
+	IndirectCallsExecutor<EnclaveShieldingKeyRepository, EnclaveStfExecutor>;
 pub type EnclaveValidatorAccessor = ValidatorAccessor<ParentchainBlock>;
 pub type EnclaveParentChainBlockImporter = ParentchainBlockImporter<
 	ParentchainBlock,
@@ -98,8 +100,13 @@ pub type EnclaveSidechainApi = SidechainApi<ParentchainBlock>;
 pub type EnclaveSidechainState =
 	SidechainDB<<SignedSidechainBlock as SignedSidechainBlockTrait>::Block, SgxExternalities>;
 pub type EnclaveTopPool = BasicPool<EnclaveSidechainApi, ParentchainBlock, EnclaveRpcResponder>;
-pub type EnclaveTopPoolAuthor =
-	Author<EnclaveTopPool, AuthorTopFilter, EnclaveStateHandler, Rsa3072KeyPair, EnclaveOCallApi>;
+pub type EnclaveTopPoolAuthor = Author<
+	EnclaveTopPool,
+	AuthorTopFilter,
+	EnclaveStateHandler,
+	EnclaveShieldingKeyRepository,
+	EnclaveOCallApi,
+>;
 pub type EnclaveTopPoolOperationHandler = TopPoolOperationHandler<
 	ParentchainBlock,
 	SignedSidechainBlock,
@@ -139,6 +146,11 @@ pub type EnclaveSidechainBlockImportQueueWorker = BlockImportQueueWorker<
 /// State key repository
 pub static GLOBAL_STATE_KEY_REPOSITORY_COMPONENT: ComponentContainer<EnclaveStateKeyRepository> =
 	ComponentContainer::new("State key repository");
+
+/// Shielding key repository
+pub static GLOBAL_SHIELDING_KEY_REPOSITORY_COMPONENT: ComponentContainer<
+	EnclaveShieldingKeyRepository,
+> = ComponentContainer::new("Shielding key repository");
 
 /// STF executor.
 pub static GLOBAL_STF_EXECUTOR_COMPONENT: ComponentContainer<EnclaveStfExecutor> =

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -38,11 +38,10 @@ use itp_block_import_queue::BlockImportQueue;
 use itp_component_container::ComponentContainer;
 use itp_extrinsics_factory::ExtrinsicsFactory;
 use itp_nonce_cache::NonceCache;
-use itp_sgx_crypto::{Aes, AesSeal};
+use itp_sgx_crypto::{key_repository::KeyRepository, Aes, AesSeal};
 use itp_stf_executor::executor::StfExecutor;
 use itp_stf_state_handler::{
-	file_io::sgx::SgxStateFileIo, state_key_repository::StateKeyRepository,
-	state_snapshot_repository::StateSnapshotRepository, StateHandler,
+	file_io::sgx::SgxStateFileIo, state_snapshot_repository::StateSnapshotRepository, StateHandler,
 };
 use itp_top_pool::basic_pool::BasicPool;
 use itp_top_pool_author::{
@@ -66,7 +65,7 @@ use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
 use sgx_externalities::SgxExternalities;
 use sp_core::ed25519::Pair;
 
-pub type EnclaveStateKeyRepository = StateKeyRepository<Aes, AesSeal>;
+pub type EnclaveStateKeyRepository = KeyRepository<Aes, AesSeal>;
 pub type EnclaveStateFileIo = SgxStateFileIo<EnclaveStateKeyRepository>;
 pub type EnclaveStateSnapshotRepository =
 	StateSnapshotRepository<EnclaveStateFileIo, StfState, H256>;

--- a/enclave-runtime/src/test/mocks/types.rs
+++ b/enclave-runtime/src/test/mocks/types.rs
@@ -20,7 +20,7 @@
 
 use crate::test::mocks::rpc_responder_mock::RpcResponderMock;
 use itc_parentchain::block_import_dispatcher::trigger_parentchain_block_import_mock::TriggerParentchainBlockImportMock;
-use itp_sgx_crypto::Aes;
+use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes};
 use itp_stf_executor::executor::StfExecutor;
 use itp_test::mock::{
 	handle_state_mock::HandleStateMock, metrics_ocall_mock::MetricsOCallMock,
@@ -48,6 +48,8 @@ pub type TestSigner = spEd25519::Pair;
 
 pub type TestShieldingKey = Rsa3072KeyPair;
 
+pub type TestShieldingKeyRepo = KeyRepositoryMock<TestShieldingKey>;
+
 pub type TestStateKey = Aes;
 
 pub type TestStateHandler = HandleStateMock;
@@ -67,7 +69,7 @@ pub type TestTopPool =
 	BasicPool<SidechainApi<ParentchainBlock>, ParentchainBlock, TestRpcResponder>;
 
 pub type TestTopPoolAuthor =
-	Author<TestTopPool, AuthorTopFilter, TestStateHandler, TestShieldingKey, MetricsOCallMock>;
+	Author<TestTopPool, AuthorTopFilter, TestStateHandler, TestShieldingKeyRepo, MetricsOCallMock>;
 
 pub type TestTopPoolExecutor = TopPoolOperationHandler<
 	ParentchainBlock,

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -67,6 +67,7 @@ pub fn produce_sidechain_block_and_import_it() {
 	let signer = TestSigner::from_seed(b"42315678901234567890123456789012");
 	let shielding_key = TestShieldingKey::new().unwrap();
 	let state_key = TestStateKey::new([3u8; 16], [1u8; 16]);
+	let shielding_key_repo = Arc::new(TestShieldingKeyRepo::new(shielding_key));
 
 	let ocall_api = create_ocall_api(&signer);
 
@@ -82,7 +83,7 @@ pub fn produce_sidechain_block_and_import_it() {
 		top_pool,
 		AuthorTopFilter {},
 		state_handler.clone(),
-		shielding_key,
+		shielding_key_repo,
 		Arc::new(MetricsOCallMock {}),
 	));
 	let top_pool_operation_handler =

--- a/enclave-runtime/src/tls_ra/seal_handler.rs
+++ b/enclave-runtime/src/tls_ra/seal_handler.rs
@@ -23,22 +23,19 @@ use codec::{Decode, Encode};
 use ita_stf::{State as StfState, StateType as StfStateType};
 use itp_sgx_crypto::{
 	key_repository::{AccessKey, MutateKey},
-	Aes, Error as CryptoError,
+	Aes,
 };
-use itp_sgx_io::StaticSealedIO;
 use itp_stf_state_handler::handle_state::HandleState;
 use itp_types::ShardIdentifier;
 use log::*;
 use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
-use std::{marker::PhantomData, sync::Arc, vec::Vec};
-
-pub trait SealedIOForShieldingKey = StaticSealedIO<Unsealed = Rsa3072KeyPair, Error = CryptoError>;
+use std::{sync::Arc, vec::Vec};
 
 /// Handles the sealing and unsealing of the shielding key, state key and the state.
 #[derive(Default)]
-pub struct SealHandler<ShieldingKeyHandler, StateKeyRepository, StateHandler>
+pub struct SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
-	ShieldingKeyHandler: SealedIOForShieldingKey,
+	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	// Constraint StateT = StfState currently necessary because SgxExternalities Encode/Decode does not work.
 	// See https://github.com/integritee-network/sgx-runtime/issues/46.
@@ -46,21 +43,22 @@ where
 {
 	state_handler: Arc<StateHandler>,
 	state_key_repository: Arc<StateKeyRepository>,
-	_phantom_key_handler: PhantomData<ShieldingKeyHandler>,
+	shielding_key_repository: Arc<ShieldingKeyRepository>,
 }
 
-impl<ShieldingKeyHandler, StateKeyRepository, StateHandler>
-	SealHandler<ShieldingKeyHandler, StateKeyRepository, StateHandler>
+impl<ShieldingKeyRepository, StateKeyRepository, StateHandler>
+	SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
-	ShieldingKeyHandler: SealedIOForShieldingKey,
+	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	StateHandler: HandleState<StateT = StfState>,
 {
 	pub fn new(
 		state_handler: Arc<StateHandler>,
 		state_key_repository: Arc<StateKeyRepository>,
+		shielding_key_repository: Arc<ShieldingKeyRepository>,
 	) -> Self {
-		Self { state_handler, state_key_repository, _phantom_key_handler: Default::default() }
+		Self { state_handler, state_key_repository, shielding_key_repository }
 	}
 }
 pub trait SealStateAndKeys {
@@ -75,10 +73,10 @@ pub trait UnsealStateAndKeys {
 	fn unseal_state(&self, shard: &ShardIdentifier) -> EnclaveResult<Vec<u8>>;
 }
 
-impl<ShieldingKeyHandler, StateKeyRepository, StateHandler> SealStateAndKeys
-	for SealHandler<ShieldingKeyHandler, StateKeyRepository, StateHandler>
+impl<ShieldingKeyRepository, StateKeyRepository, StateHandler> SealStateAndKeys
+	for SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
-	ShieldingKeyHandler: SealedIOForShieldingKey,
+	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	StateHandler: HandleState<StateT = StfState>,
 {
@@ -87,7 +85,7 @@ where
 			error!("    [Enclave] Received Invalid RSA key");
 			EnclaveError::Other(e.into())
 		})?;
-		ShieldingKeyHandler::seal_to_static_file(key)?;
+		self.shielding_key_repository.update_key(key)?;
 		info!("Successfully stored a new shielding key");
 		Ok(())
 	}
@@ -109,15 +107,18 @@ where
 	}
 }
 
-impl<ShieldingKeyHandler, StateKeyRepository, StateHandler> UnsealStateAndKeys
-	for SealHandler<ShieldingKeyHandler, StateKeyRepository, StateHandler>
+impl<ShieldingKeyRepository, StateKeyRepository, StateHandler> UnsealStateAndKeys
+	for SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
-	ShieldingKeyHandler: SealedIOForShieldingKey,
+	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	StateHandler: HandleState<StateT = StfState>,
 {
 	fn unseal_shielding_key(&self) -> EnclaveResult<Vec<u8>> {
-		let shielding_key = ShieldingKeyHandler::unseal_from_static_file()?;
+		let shielding_key = self
+			.shielding_key_repository
+			.retrieve_key()
+			.map_err(|e| EnclaveError::Other(format!("{:?}", e).into()))?;
 		serde_json::to_vec(&shielding_key).map_err(|e| EnclaveError::Other(e.into()))
 	}
 
@@ -137,13 +138,15 @@ where
 #[cfg(feature = "test")]
 pub mod test {
 	use super::*;
-	use itp_sgx_crypto::mocks::sgx::Rsa3072SealMock;
-	use itp_stf_state_handler::test::mocks::state_key_repository_mock::StateKeyRepositoryMock;
+	use itp_sgx_crypto::mocks::KeyRepositoryMock;
 	use itp_test::mock::handle_state_mock::HandleStateMock;
 	use sgx_externalities::SgxExternalitiesTrait;
 
+	type StateKeyRepositoryMock = KeyRepositoryMock<Aes>;
+	type ShieldingKeyRepositoryMock = KeyRepositoryMock<Rsa3072KeyPair>;
+
 	type SealHandlerMock =
-		SealHandler<Rsa3072SealMock, StateKeyRepositoryMock<Aes>, HandleStateMock>;
+		SealHandler<ShieldingKeyRepositoryMock, StateKeyRepositoryMock, HandleStateMock>;
 
 	pub fn seal_shielding_key_works() {
 		let seal_handler = SealHandlerMock::default();

--- a/enclave-runtime/src/tls_ra/tls_ra_server.rs
+++ b/enclave-runtime/src/tls_ra/tls_ra_server.rs
@@ -21,14 +21,15 @@ use super::{authentication::ClientAuth, Opcode, TcpHeader};
 use crate::{
 	attestation::create_ra_report_and_signature,
 	error::{Error as EnclaveError, Result as EnclaveResult},
-	global_components::GLOBAL_STATE_KEY_REPOSITORY_COMPONENT,
+	global_components::{
+		GLOBAL_SHIELDING_KEY_REPOSITORY_COMPONENT, GLOBAL_STATE_KEY_REPOSITORY_COMPONENT,
+	},
 	ocall::OcallApi,
 	tls_ra::seal_handler::{SealHandler, UnsealStateAndKeys},
 	GLOBAL_STATE_HANDLER_COMPONENT,
 };
 use itp_component_container::ComponentGetter;
 use itp_ocall_api::EnclaveAttestationOCallApi;
-use itp_sgx_crypto::Rsa3072Seal;
 use itp_types::ShardIdentifier;
 use log::*;
 use rustls::{ServerConfig, ServerSession, Stream};
@@ -123,7 +124,16 @@ pub unsafe extern "C" fn run_state_provisioning_server(
 		},
 	};
 
-	let seal_handler = SealHandler::<Rsa3072Seal, _, _>::new(state_handler, state_key_repository);
+	let shielding_key_repository = match GLOBAL_SHIELDING_KEY_REPOSITORY_COMPONENT.get() {
+		Ok(s) => s,
+		Err(e) => {
+			error!("{:?}", e);
+			return sgx_status_t::SGX_ERROR_UNEXPECTED
+		},
+	};
+
+	let seal_handler =
+		SealHandler::new(state_handler, state_key_repository, shielding_key_repository);
 
 	if let Err(e) =
 		run_state_provisioning_server_internal(socket_fd, sign_type, skip_ra, seal_handler)

--- a/local-setup/github-action-config.json
+++ b/local-setup/github-action-config.json
@@ -11,6 +11,7 @@
     {
       "source": "bin",
       "flags": [
+        "--clean-reset",
         "-P",
         "2000",
         "-w",
@@ -28,6 +29,7 @@
     {
       "source": "bin",
       "flags": [
+        "--clean-reset",
         "-P",
         "3000",
         "-w",
@@ -39,7 +41,8 @@
       ],
       "subcommand_flags": [
         "--skip-ra",
-        "--dev"
+        "--dev",
+        "--request-state"
       ]
     }
   ]

--- a/local-setup/launch.py
+++ b/local-setup/launch.py
@@ -38,16 +38,10 @@ def run_node(config):
     print(f'Run node with command: {node_cmd}')
     return Popen(node_cmd, stdout=node_log, stderr=STDOUT, bufsize=1)
 
+
 def run_worker(config, i: int):
     log = open(f'{log_dir}/worker{i}.log', 'w+')
     w = setup_worker(f'/tmp/w{i}', config["source"], log)
-
-    if i > 1:
-        print(f'Worker {i} fetching keys from registered worker.')
-        skip_ra = "--skip-ra" in config["subcommand_flags"]
-        print(f'Skip remote attestation: {skip_ra}')
-
-        w.sync_state(flags=config["flags"], skip_ra=skip_ra)
 
     print(f'Starting worker {i} in background')
     w.run_in_background(log_file=log, flags=config["flags"], subcommand_flags=config["subcommand_flags"])
@@ -67,7 +61,7 @@ def main(processes, config_path):
         # sleep to prevent nonce clash when bootstrapping the enclave's account
         sleep(6)
         if i == 1:
-             # Give worker 1 some time to register itself, otherwise key & state sharing will not work.
+            # Give worker 1 some time to register itself, otherwise key & state sharing will not work.
             sleep(60)
 
         i += 1

--- a/local-setup/launch.py
+++ b/local-setup/launch.py
@@ -54,12 +54,14 @@ def main(processes, config_path):
         config = json.load(config_file)
 
     processes.append(run_node(config))
+    # sleep to give the node some time to startup
+    sleep(3)
 
     i = 1
     for w_conf in config["workers"]:
         processes.append(run_worker(w_conf, i))
         # sleep to prevent nonce clash when bootstrapping the enclave's account
-        sleep(6)
+        sleep(3)
         if i == 1:
             # Give worker 1 some time to register itself, otherwise key & state sharing will not work.
             sleep(60)

--- a/local-setup/py/worker.py
+++ b/local-setup/py/worker.py
@@ -49,11 +49,8 @@ class Worker:
         print('Copying source files to working directory')
         self.setup_cwd()
 
-        self.purge()
-        self.init()
-
     def init(self):
-        """ Initializes the environment such the the worker can be run. """
+        """ Initializes the environment such that the worker can be run. """
         print('Initializing worker')
         print(self.init_shard())
         print(self.write_signer_pub())

--- a/local-setup/simple-config.json
+++ b/local-setup/simple-config.json
@@ -17,6 +17,7 @@
     {
       "source": "bin",
       "flags": [
+        "--clean-reset",
         "-P",
         "2090",
         "-p",
@@ -36,6 +37,7 @@
     {
       "source": "bin",
       "flags": [
+        "--clean-reset",
         "-P",
         "3090",
         "-p",
@@ -49,7 +51,8 @@
       ],
       "subcommand_flags": [
         "--skip-ra",
-        "--dev"
+        "--dev",
+        "--request-state"
       ]
     }
   ]

--- a/local-setup/tutorial-config.json
+++ b/local-setup/tutorial-config.json
@@ -17,6 +17,7 @@
     {
       "source": "bin",
       "flags": [
+        "--clean-reset",
         "-P",
         "2000",
         "-p",
@@ -34,6 +35,7 @@
     {
       "source": "bin",
       "flags": [
+        "--clean-reset",
         "-P",
         "3000",
         "-p",
@@ -45,7 +47,8 @@
       ],
       "subcommand_flags": [
         "--skip-ra",
-        "--dev"
+        "--dev",
+        "--request-state"
       ]
     }
   ]

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -79,6 +79,10 @@ args:
         help: Set the port for the untrusted HTTP server
         takes_value: true
         required: false
+    - clean-reset:
+          long: clean-reset
+          short: c
+          help: Cleans and purges any previous state and key files and generates them anew before starting.
 
 subcommands:
     - run:
@@ -96,6 +100,10 @@ subcommands:
                 long: dev
                 short: d
                 help: Set this flag if running in development mode to bootstrap enclave account on parentchain via //Alice.
+            - request-state:
+                long: request-state
+                short: r
+                help: Run the worker and request key and state provisioning from another worker.
     - request-state:
         about: join a shard by requesting key provisioning from another worker
         args:

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -176,12 +176,12 @@ fn main() {
 		let skip_ra = smatches.is_present("skip-ra");
 		let dev = smatches.is_present("dev");
 
-		let node_api =
-			node_api_factory.create_api().expect("Failed to create parentchain node API");
-
 		if clean_reset {
 			setup::initialize_shard_and_keys(enclave.as_ref(), &shard).unwrap();
 		}
+
+		let node_api =
+			node_api_factory.create_api().expect("Failed to create parentchain node API");
 
 		let request_state = smatches.is_present("request-state");
 		if request_state {

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -54,10 +54,7 @@ use itp_node_api_extensions::{
 	AccountApi, ChainApi, PalletTeerexApi,
 };
 use itp_settings::{
-	files::{
-		SHIELDING_KEY_FILE, SIDECHAIN_PURGE_INTERVAL, SIDECHAIN_PURGE_LIMIT,
-		SIDECHAIN_STORAGE_PATH, SIGNING_KEY_FILE,
-	},
+	files::{SIDECHAIN_PURGE_INTERVAL, SIDECHAIN_PURGE_LIMIT, SIDECHAIN_STORAGE_PATH},
 	sidechain::SLOT_DURATION,
 };
 use its_consensus_slots::start_slot_worker;
@@ -78,7 +75,6 @@ use sp_core::{
 use sp_finality_grandpa::VersionedAuthorityList;
 use sp_keyring::AccountKeyring;
 use std::{
-	fs::{self, File},
 	path::PathBuf,
 	str,
 	sync::{
@@ -102,6 +98,7 @@ mod initialized_service;
 mod ocall_bridge;
 mod parentchain_block_syncer;
 mod prometheus_metrics;
+mod setup;
 mod sync_block_gossiper;
 mod sync_state;
 mod tests;
@@ -131,6 +128,11 @@ fn main() {
 	info!("*** Starting service in SGX production mode");
 	#[cfg(not(feature = "production"))]
 	info!("*** Starting service in SGX debug mode");
+
+	let clean_reset = matches.is_present("clean-reset");
+	if clean_reset {
+		setup::purge_files_from_cwd().unwrap();
+	}
 
 	// build the entire dependency tree
 	let tokio_handle = Arc::new(GlobalTokioHandle {});
@@ -177,6 +179,20 @@ fn main() {
 		let node_api =
 			node_api_factory.create_api().expect("Failed to create parentchain node API");
 
+		if clean_reset {
+			setup::initialize_shard_and_keys(enclave.as_ref(), &shard).unwrap();
+		}
+
+		let request_state = smatches.is_present("request-state");
+		if request_state {
+			sync_state::sync_state(
+				&node_api,
+				&extract_shard(smatches, enclave.as_ref()),
+				enclave.as_ref(),
+				skip_ra,
+			);
+		}
+
 		start_worker(
 			config,
 			&shard,
@@ -198,68 +214,40 @@ fn main() {
 			smatches.is_present("skip-ra"),
 		);
 	} else if matches.is_present("shielding-key") {
-		info!("*** Get the public key from the TEE\n");
-		let pubkey = enclave.get_rsa_shielding_pubkey().unwrap();
-		let file = File::create(SHIELDING_KEY_FILE).unwrap();
-		match serde_json::to_writer(file, &pubkey) {
-			Err(x) => {
-				error!("[-] Failed to write '{}'. {}", SHIELDING_KEY_FILE, x);
-			},
-			_ => {
-				println!("[+] File '{}' written successfully", SHIELDING_KEY_FILE);
-			},
-		}
+		setup::generate_shielding_key_file(enclave.as_ref());
 	} else if matches.is_present("signing-key") {
-		info!("*** Get the signing key from the TEE\n");
-		let pubkey = enclave.get_ecc_signing_pubkey().unwrap();
-		debug!("[+] Signing key raw: {:?}", pubkey);
-		match fs::write(SIGNING_KEY_FILE, pubkey) {
-			Err(x) => {
-				error!("[-] Failed to write '{}'. {}", SIGNING_KEY_FILE, x);
-			},
-			_ => {
-				println!("[+] File '{}' written successfully", SIGNING_KEY_FILE);
-			},
-		}
+		setup::generate_signing_key_file(enclave.as_ref());
 	} else if matches.is_present("dump-ra") {
 		info!("*** Perform RA and dump cert to disk");
 		enclave.dump_ra_to_disk().unwrap();
 	} else if matches.is_present("mrenclave") {
 		println!("{}", enclave.get_mrenclave().unwrap().encode().to_base58());
-	} else if let Some(_matches) = matches.subcommand_matches("init-shard") {
-		let shard = extract_shard(_matches, enclave.as_ref());
-		match enclave.init_shard(shard.encode()) {
-			Err(e) => {
-				println!("Failed to initialize shard {:?}: {:?}", shard, e);
-			},
-			Ok(_) => {
-				println!("Successfully initialized shard {:?}", shard);
-			},
-		}
-	} else if let Some(_matches) = matches.subcommand_matches("test") {
-		if _matches.is_present("provisioning-server") {
+	} else if let Some(sub_matches) = matches.subcommand_matches("init-shard") {
+		setup::init_shard(enclave.as_ref(), &extract_shard(sub_matches, enclave.as_ref()));
+	} else if let Some(sub_matches) = matches.subcommand_matches("test") {
+		if sub_matches.is_present("provisioning-server") {
 			println!("*** Running Enclave MU-RA TLS server\n");
 			enclave_run_state_provisioning_server(
 				enclave.as_ref(),
 				sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
 				&config.mu_ra_url(),
-				_matches.is_present("skip-ra"),
+				sub_matches.is_present("skip-ra"),
 			);
 			println!("[+] Done!");
-		} else if _matches.is_present("provisioning-client") {
+		} else if sub_matches.is_present("provisioning-client") {
 			println!("*** Running Enclave MU-RA TLS client\n");
-			let shard = extract_shard(_matches, enclave.as_ref());
+			let shard = extract_shard(sub_matches, enclave.as_ref());
 			enclave_request_state_provisioning(
 				enclave.as_ref(),
 				sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
 				&config.mu_ra_url_external(),
 				&shard,
-				_matches.is_present("skip-ra"),
+				sub_matches.is_present("skip-ra"),
 			)
 			.unwrap();
 			println!("[+] Done!");
 		} else {
-			tests::run_enclave_tests(_matches);
+			tests::run_enclave_tests(sub_matches);
 		}
 	} else {
 		println!("For options: use --help");

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -1,0 +1,208 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::error::{Error, ServiceResult};
+use codec::Encode;
+use itp_enclave_api::{enclave_base::EnclaveBase, Enclave};
+use itp_settings::files::{
+	LAST_SLOT_BIN, LIGHT_CLIENT_DB, SHARDS_PATH, SHIELDING_KEY_FILE, SIDECHAIN_STORAGE_PATH,
+	SIGNING_KEY_FILE,
+};
+use itp_types::ShardIdentifier;
+use log::*;
+use std::{fs, fs::File, path::PathBuf};
+
+/// Purge all worker files from the current working directory (cwd).
+pub(crate) fn purge_files_from_cwd() -> ServiceResult<()> {
+	let current_directory = std::env::current_dir().map_err(|e| Error::Custom(e.into()))?;
+	println!("[+] Performing a clean reset of the worker");
+
+	println!("[+] Purge any previous files");
+	purge_files(&current_directory)?;
+
+	Ok(())
+}
+
+/// Initializes the shard and generates the key files after a purge.
+pub(crate) fn initialize_shard_and_keys(
+	enclave: &Enclave,
+	shard_identifier: &ShardIdentifier,
+) -> ServiceResult<()> {
+	println!("[+] Initialize the shard");
+	init_shard(enclave, shard_identifier);
+
+	println!("[+] Generate key files");
+	generate_signing_key_file(enclave);
+	generate_shielding_key_file(enclave);
+
+	Ok(())
+}
+
+fn list_items_in_directory(directory: &PathBuf) -> Vec<String> {
+	let items = match directory.read_dir() {
+		Ok(rd) => rd,
+		Err(_) => return Vec::new(),
+	};
+
+	items
+		.flat_map(|fr| fr.map(|de| de.file_name().into_string().ok()).ok().flatten())
+		.collect()
+}
+
+pub(crate) fn init_shard(enclave: &Enclave, shard_identifier: &ShardIdentifier) {
+	match enclave.init_shard(shard_identifier.encode()) {
+		Err(e) => {
+			println!("Failed to initialize shard {:?}: {:?}", shard_identifier, e);
+		},
+		Ok(_) => {
+			println!("Successfully initialized shard {:?}", shard_identifier);
+		},
+	}
+}
+
+pub(crate) fn generate_signing_key_file(enclave: &Enclave) {
+	info!("*** Get the signing key from the TEE\n");
+	let pubkey = enclave.get_ecc_signing_pubkey().unwrap();
+	debug!("[+] Signing key raw: {:?}", pubkey);
+	match fs::write(SIGNING_KEY_FILE, pubkey) {
+		Err(x) => {
+			error!("[-] Failed to write '{}'. {}", SIGNING_KEY_FILE, x);
+		},
+		_ => {
+			println!("[+] File '{}' written successfully", SIGNING_KEY_FILE);
+		},
+	}
+}
+
+pub(crate) fn generate_shielding_key_file(enclave: &Enclave) {
+	info!("*** Get the public key from the TEE\n");
+	let pubkey = enclave.get_rsa_shielding_pubkey().unwrap();
+	let file = File::create(SHIELDING_KEY_FILE).unwrap();
+	match serde_json::to_writer(file, &pubkey) {
+		Err(x) => {
+			error!("[-] Failed to write '{}'. {}", SHIELDING_KEY_FILE, x);
+		},
+		_ => {
+			println!("[+] File '{}' written successfully", SHIELDING_KEY_FILE);
+		},
+	}
+}
+
+fn purge_files(root_directory: &PathBuf) -> ServiceResult<()> {
+	remove_dir_if_it_exists(&root_directory, SHARDS_PATH)?;
+	remove_dir_if_it_exists(&root_directory, SIDECHAIN_STORAGE_PATH)?;
+
+	remove_file_if_it_exists(&root_directory, LAST_SLOT_BIN)?;
+	remove_file_if_it_exists(&root_directory, LIGHT_CLIENT_DB)?;
+	remove_file_if_it_exists(&root_directory, light_client_backup_file().as_str())?;
+
+	Ok(())
+}
+
+fn remove_dir_if_it_exists(root_directory: &PathBuf, dir_name: &str) -> ServiceResult<()> {
+	let directory_path = root_directory.join(dir_name);
+	if directory_path.exists() {
+		fs::remove_dir_all(directory_path).map_err(|e| Error::Custom(e.into()))?;
+	}
+	Ok(())
+}
+
+fn remove_file_if_it_exists(root_directory: &PathBuf, file_name: &str) -> ServiceResult<()> {
+	let file = root_directory.join(file_name);
+	if file.exists() {
+		fs::remove_file(file).map_err(|e| Error::Custom(e.into()))?;
+	}
+	Ok(())
+}
+
+fn light_client_backup_file() -> String {
+	format!("{}.1", LIGHT_CLIENT_DB)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use itp_settings::files::SHARDS_PATH;
+	use std::fs;
+
+	#[test]
+	fn purge_files_deletes_all_relevant_files() {
+		let test_directory_handle =
+			TestDirectoryHandle::new(PathBuf::from("test_purge_files_deletes_all_relevant_files"));
+		let root_directory = test_directory_handle.path();
+
+		let shards_path = root_directory.join(SHARDS_PATH);
+		fs::create_dir_all(&shards_path).unwrap();
+		fs::File::create(&shards_path.join("state_1.bin")).unwrap();
+		fs::File::create(&shards_path.join("state_2.bin")).unwrap();
+
+		let sidechain_db_path = root_directory.join(SIDECHAIN_STORAGE_PATH);
+		fs::create_dir_all(&sidechain_db_path).unwrap();
+		fs::File::create(&sidechain_db_path.join("sidechain_db_1.bin")).unwrap();
+		fs::File::create(&sidechain_db_path.join("sidechain_db_2.bin")).unwrap();
+		fs::File::create(&sidechain_db_path.join("sidechain_db_3.bin")).unwrap();
+
+		fs::File::create(&root_directory.join(LAST_SLOT_BIN)).unwrap();
+		fs::File::create(&root_directory.join(LIGHT_CLIENT_DB)).unwrap();
+		fs::File::create(&root_directory.join(light_client_backup_file())).unwrap();
+
+		purge_files(&root_directory).unwrap();
+
+		assert!(!shards_path.exists());
+		assert!(!sidechain_db_path.exists());
+		assert!(!root_directory.join(LAST_SLOT_BIN).exists());
+		assert!(!root_directory.join(LIGHT_CLIENT_DB).exists());
+		assert!(!root_directory.join(light_client_backup_file()).exists());
+	}
+
+	#[test]
+	fn purge_files_succeeds_when_no_files_exist() {
+		let test_directory_handle = TestDirectoryHandle::new(PathBuf::from(
+			"test_purge_files_succeeds_when_no_files_exist",
+		));
+		let root_directory = test_directory_handle.path();
+
+		assert!(purge_files(&root_directory).is_ok());
+	}
+
+	/// Directory handle to automatically initialize a directory
+	/// and upon dropping the reference, removing it again.
+	struct TestDirectoryHandle {
+		path: PathBuf,
+	}
+
+	impl TestDirectoryHandle {
+		pub fn new(path: PathBuf) -> Self {
+			let test_path = std::env::current_dir().unwrap().join(&path);
+			fs::create_dir_all(&test_path).unwrap();
+			TestDirectoryHandle { path: test_path }
+		}
+
+		pub fn path(&self) -> &PathBuf {
+			&self.path
+		}
+	}
+
+	impl Drop for TestDirectoryHandle {
+		fn drop(&mut self) {
+			if self.path.exists() {
+				fs::remove_dir_all(&self.path).unwrap();
+			}
+		}
+	}
+}

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -17,12 +17,11 @@
 */
 
 use crate::error::{Error, ServiceResult};
-use base58::ToBase58;
 use codec::Encode;
 use itp_enclave_api::{enclave_base::EnclaveBase, Enclave};
 use itp_settings::files::{
-	LAST_SLOT_BIN, LIGHT_CLIENT_DB, MR_ENCLAVE_FILE, SHARDS_PATH, SHIELDING_KEY_FILE,
-	SIDECHAIN_STORAGE_PATH, SIGNING_KEY_FILE,
+	LAST_SLOT_BIN, LIGHT_CLIENT_DB, SHARDS_PATH, SHIELDING_KEY_FILE, SIDECHAIN_STORAGE_PATH,
+	SIGNING_KEY_FILE,
 };
 use itp_types::ShardIdentifier;
 use log::*;
@@ -50,7 +49,6 @@ pub(crate) fn initialize_shard_and_keys(
 	println!("[+] Generate key files");
 	generate_signing_key_file(enclave);
 	generate_shielding_key_file(enclave);
-	generate_mrenclave_file(enclave);
 
 	Ok(())
 }
@@ -94,25 +92,12 @@ pub(crate) fn generate_shielding_key_file(enclave: &Enclave) {
 	}
 }
 
-pub(crate) fn generate_mrenclave_file(enclave: &Enclave) {
-	let mr_enclave_b58 = enclave.get_mrenclave().unwrap().encode().to_base58();
-	match fs::write(MR_ENCLAVE_FILE, mr_enclave_b58) {
-		Err(e) => {
-			error!("[-] Failed to write '{}'. {}", MR_ENCLAVE_FILE, e);
-		},
-		_ => {
-			println!("[+] File '{}' written successfully", MR_ENCLAVE_FILE);
-		},
-	}
-}
-
 fn purge_files(root_directory: &Path) -> ServiceResult<()> {
 	remove_dir_if_it_exists(root_directory, SHARDS_PATH)?;
 	remove_dir_if_it_exists(root_directory, SIDECHAIN_STORAGE_PATH)?;
 
 	remove_file_if_it_exists(root_directory, LAST_SLOT_BIN)?;
 	remove_file_if_it_exists(root_directory, LIGHT_CLIENT_DB)?;
-	remove_file_if_it_exists(root_directory, MR_ENCLAVE_FILE)?;
 	remove_file_if_it_exists(root_directory, light_client_backup_file().as_str())?;
 
 	Ok(())
@@ -164,7 +149,6 @@ mod tests {
 		fs::File::create(&root_directory.join(LAST_SLOT_BIN)).unwrap();
 		fs::File::create(&root_directory.join(LIGHT_CLIENT_DB)).unwrap();
 		fs::File::create(&root_directory.join(light_client_backup_file())).unwrap();
-		fs::File::create(&root_directory.join(MR_ENCLAVE_FILE)).unwrap();
 
 		purge_files(&root_directory).unwrap();
 
@@ -173,7 +157,6 @@ mod tests {
 		assert!(!root_directory.join(LAST_SLOT_BIN).exists());
 		assert!(!root_directory.join(LIGHT_CLIENT_DB).exists());
 		assert!(!root_directory.join(light_client_backup_file()).exists());
-		assert!(!root_directory.join(MR_ENCLAVE_FILE).exists());
 	}
 
 	#[test]

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -32,13 +32,13 @@ pub(crate) fn purge_files_from_cwd() -> ServiceResult<()> {
 	let current_directory = std::env::current_dir().map_err(|e| Error::Custom(e.into()))?;
 	println!("[+] Performing a clean reset of the worker");
 
-	println!("[+] Purge any previous files");
+	println!("[+] Purge all files from previous runs");
 	purge_files(&current_directory)?;
 
 	Ok(())
 }
 
-/// Initializes the shard and generates the key files after a purge.
+/// Initializes the shard and generates the key files.
 pub(crate) fn initialize_shard_and_keys(
 	enclave: &Enclave,
 	shard_identifier: &ShardIdentifier,
@@ -92,6 +92,7 @@ pub(crate) fn generate_shielding_key_file(enclave: &Enclave) {
 	}
 }
 
+/// Purge all worker files in a given path.
 fn purge_files(root_directory: &Path) -> ServiceResult<()> {
 	remove_dir_if_it_exists(root_directory, SHARDS_PATH)?;
 	remove_dir_if_it_exists(root_directory, SIDECHAIN_STORAGE_PATH)?;

--- a/service/src/utils.rs
+++ b/service/src/utils.rs
@@ -60,12 +60,9 @@ pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) -> Res
 }
 
 pub fn check_files() {
-	use itp_settings::files::{
-		ENCLAVE_FILE, RA_API_KEY_FILE, RA_SPID_FILE, SHIELDING_KEY_FILE, SIGNING_KEY_FILE,
-	};
+	use itp_settings::files::{ENCLAVE_FILE, RA_API_KEY_FILE, RA_SPID_FILE};
 	debug!("*** Check files");
-	let files =
-		vec![ENCLAVE_FILE, SHIELDING_KEY_FILE, SIGNING_KEY_FILE, RA_SPID_FILE, RA_API_KEY_FILE];
+	let files = vec![ENCLAVE_FILE, RA_SPID_FILE, RA_API_KEY_FILE];
 	for f in files.iter() {
 		assert!(Path::new(f).exists(), "File doesn't exist: {}", f);
 	}

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -23,6 +23,7 @@ sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19"}
 
 # local deps
+itp-settings = { path = "../../../core-primitives/settings", default-features = false }
 itp-sgx-io = { path = "../../../core-primitives/sgx/io", default-features = false }
 itp-time-utils = { path = "../../../core-primitives/time-utils", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -23,7 +23,7 @@ sp-consensus-slots = { version = "0.10.0-dev", default-features = false, git = "
 sp-runtime = { version = "6.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19"}
 
 # local deps
-itp-settings = { path = "../../../core-primitives/settings", default-features = false }
+itp-settings = { path = "../../../core-primitives/settings" }
 itp-sgx-io = { path = "../../../core-primitives/sgx/io", default-features = false }
 itp-time-utils = { path = "../../../core-primitives/time-utils", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -140,6 +140,7 @@ impl<T: StaticSealedIO<Unsealed = Slot, Error = ConsensusError>> GetLastSlot for
 pub mod sgx {
 	use super::*;
 	use codec::{Decode, Encode};
+	use itp_settings::files::LAST_SLOT_BIN;
 	use itp_sgx_io::{seal, unseal, StaticSealedIO};
 	use lazy_static::lazy_static;
 	use std::sync::SgxRwLock;
@@ -149,8 +150,6 @@ pub mod sgx {
 	lazy_static! {
 		static ref FILE_LOCK: SgxRwLock<()> = Default::default();
 	}
-
-	const LAST_SLOT_BIN: &'static str = "last_slot.bin";
 
 	impl StaticSealedIO for LastSlotSeal {
 		type Error = ConsensusError;


### PR DESCRIPTION
Allows us to run the worker in one command, no need to call it multiple
times to initialize and 'manually' do the file purging in the python script.

* `--clean-reset` purges all files and initializes the shard and key files
* `--request-state`, a new sub-command of `run`, will request the state from a peer worker (instead of having a separate call `./integritee-service request-state`)
*  Do **NOT** check for the existence of the shielding key and signing key files at startup anymore. In case they're absent, they'll be initialized anyway.

Because we request state and keys now in a single run, we need a way to change the shielding key at runtime. This is done using the same mechanism as for the state key (aka key repository). So any components using a shielding key, access the key through a repository.

Closes #526