### PR TITLE
remove set -e from init_env.sh source

### DIFF
--- a/scripts/init_env.sh
+++ b/scripts/init_env.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 # script that sets the correct environment variables to execute other scripts
 


### PR DESCRIPTION
Bash scripts should have an `set -e` statement to prevent the script to continue in case of an error. In an environment file that is importet via `source` you should not have this statement, since this behaviour is overtaken to the current session. 

It is save to delete the statement from `init_env.sh` since there process that can return a result different than 0. 