### PR TITLE
[RPC Interface] hex encode rpc call values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,6 +2189,7 @@ dependencies = [
  "itc-rpc-client",
  "itp-node-api-extensions",
  "itp-types",
+ "itp-utils",
  "json",
  "log 0.4.17",
  "pallet-balances",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,8 +2756,10 @@ version = "0.8.0"
 dependencies = [
  "aes",
  "derive_more",
+ "hex",
  "itp-settings",
  "itp-sgx-io",
+ "itp-utils",
  "log 0.4.17",
  "ofb",
  "parity-scale-codec",
@@ -2965,7 +2967,6 @@ version = "0.8.0"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "hex",
- "itp-sgx-crypto",
  "parity-scale-codec",
  "sgx_tstd",
  "thiserror 1.0.31",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,6 +2926,7 @@ dependencies = [
  "itp-test",
  "itp-top-pool",
  "itp-types",
+ "itp-utils",
  "jsonrpc-core 16.1.0",
  "jsonrpc-core 18.0.0",
  "log 0.4.17",
@@ -2963,7 +2964,10 @@ version = "0.8.0"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "hex",
+ "parity-scale-codec",
+ "sgx_crypto_helper",
  "sgx_tstd",
+ "sgx_types",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,6 +2399,7 @@ version = "0.8.0"
 dependencies = [
  "itc-tls-websocket-server",
  "itp-types",
+ "itp-utils",
  "jsonrpc-core 16.1.0",
  "jsonrpc-core 18.0.0",
  "log 0.4.17",
@@ -2536,6 +2537,7 @@ dependencies = [
  "env_logger 0.9.0",
  "itc-tls-websocket-server",
  "itp-types",
+ "itp-utils",
  "log 0.4.17",
  "openssl",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
  "env_logger 0.9.0",
  "itp-enclave-api",
  "itp-types",
+ "itp-utils",
  "its-peer-fetch",
  "its-primitives",
  "its-storage",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
  "ac-primitives",
  "log 0.4.17",
  "parity-scale-codec",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -31,7 +31,7 @@ source = "git+https://github.com/scs/substrate-api-client?branch=polkadot-v0.9.2
 dependencies = [
  "ac-primitives",
  "frame-metadata",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "hex",
  "log 0.4.17",
@@ -39,8 +39,8 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "serde_json 1.0.81",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.31",
 ]
 
@@ -51,8 +51,8 @@ source = "git+https://github.com/scs/substrate-api-client?branch=polkadot-v0.9.2
 dependencies = [
  "hex",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -607,7 +607,7 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1198,7 +1198,7 @@ name = "frame-benchmarking"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "linregress",
  "log 0.4.17",
@@ -1207,12 +1207,12 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sp-api",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
+ "sp-runtime-interface",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-storage",
 ]
 
 [[package]]
@@ -1220,15 +1220,15 @@ name = "frame-executive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -1246,40 +1246,11 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "bitflags",
- "frame-metadata",
- "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "impl-trait-for-tuples",
- "log 0.4.17",
- "once_cell 1.10.0",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde 1.0.137",
- "smallvec 1.8.0",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "tt-call",
-]
-
-[[package]]
-name = "frame-support"
-version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "bitflags",
  "frame-metadata",
- "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "log 0.4.17",
  "once_cell 1.10.0",
@@ -1288,50 +1259,26 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "smallvec 1.8.0",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-core-hashing-proc-macro",
+ "sp-inherents",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
+ "sp-staking",
+ "sp-state-machine",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing",
  "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "Inflector",
- "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "Inflector",
- "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "proc-macro-crate",
+ "frame-support-procedural-tools",
  "proc-macro2",
  "quote",
  "syn",
@@ -1342,18 +1289,8 @@ name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -1374,14 +1311,14 @@ name = "frame-system"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
 ]
@@ -2073,11 +2010,11 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d
 dependencies = [
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "parity-scale-codec",
  "scale-info",
  "serde_json 1.0.81",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "webpki 0.21.0",
@@ -2200,10 +2137,10 @@ dependencies = [
  "serde 1.0.137",
  "serde_json 1.0.81",
  "sgx_crypto_helper",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-keyring",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "substrate-api-client",
  "substrate-bip39",
  "substrate-client-keystore",
@@ -2218,7 +2155,7 @@ version = "1.0.9"
 source = "git+https://github.com/integritee-network/integritee-node?branch=master#ecc97eafd9db460b75df46a99ba8edc01d4180de"
 dependencies = [
  "frame-executive",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-aura",
@@ -2244,10 +2181,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-session",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-transaction-pool",
@@ -2267,7 +2204,7 @@ dependencies = [
  "dashmap",
  "dirs 1.0.5",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "futures 0.3.21",
  "hex",
@@ -2307,10 +2244,10 @@ dependencies = [
  "sgx_types",
  "sgx_urts",
  "sha2 0.7.1",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-finality-grandpa",
  "sp-keyring",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "substrate-api-client",
  "teerex-primitives",
  "thiserror 1.0.31",
@@ -2368,7 +2305,7 @@ dependencies = [
  "base58 0.1.0",
  "derive_more",
  "env_logger 0.7.1 (git+https://github.com/mesalock-linux/env_logger-sgx)",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "hex",
  "integritee-node-runtime",
@@ -2384,11 +2321,11 @@ dependencies = [
  "sgx-externalities",
  "sgx-runtime",
  "sgx_tstd",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/integritee-network/sgx-runtime?branch=master)",
  "sp-keyring",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "substrate-api-client",
  "substrate-client-keystore",
 ]
@@ -2407,7 +2344,7 @@ dependencies = [
  "serde_json 1.0.81",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2432,7 +2369,7 @@ dependencies = [
  "log 0.4.17",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2453,7 +2390,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
  "tiny-keccak 2.0.2",
@@ -2475,8 +2412,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "substrate-api-client",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
@@ -2501,11 +2438,11 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
+ "sp-trie",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2569,7 +2506,7 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec",
  "serde_json 1.0.81",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "tokio",
 ]
 
@@ -2631,7 +2568,7 @@ dependencies = [
  "log 0.4.17",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2649,7 +2586,7 @@ dependencies = [
 name = "itp-enclave-api"
 version = "0.8.0"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "itp-enclave-api-ffi",
  "itp-settings",
  "itp-types",
@@ -2660,9 +2597,9 @@ dependencies = [
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.31",
 ]
 
@@ -2693,8 +2630,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "substrate-api-client",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
@@ -2706,9 +2643,9 @@ version = "0.8.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "substrate-api-client",
  "thiserror 1.0.31",
 ]
@@ -2733,8 +2670,8 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2772,7 +2709,7 @@ dependencies = [
  "sgx_rand",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
 ]
 
 [[package]]
@@ -2798,8 +2735,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2823,7 +2760,7 @@ dependencies = [
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2834,15 +2771,15 @@ version = "0.8.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "hash-db",
  "parity-scale-codec",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-trie",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2875,8 +2812,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2908,9 +2845,9 @@ dependencies = [
  "serde 1.0.137",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2938,8 +2875,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2955,9 +2892,9 @@ dependencies = [
  "serde 1.0.137",
  "serde_json 1.0.81",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-keyring",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
 ]
@@ -2966,7 +2903,7 @@ dependencies = [
 name = "itp-utils"
 version = "0.8.0"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "frame-support",
  "hex",
  "parity-scale-codec",
  "sgx_tstd",
@@ -2992,8 +2929,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -3004,7 +2941,7 @@ version = "0.8.0"
 dependencies = [
  "env_logger 0.9.0",
  "finality-grandpa",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "ita-stf",
  "itc-parentchain-block-import-dispatcher",
  "itp-enclave-metrics",
@@ -3029,9 +2966,9 @@ dependencies = [
  "parity-scale-codec",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-keyring",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3052,9 +2989,9 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-keyring",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -3079,7 +3016,7 @@ dependencies = [
  "sgx_tstd",
  "sp-consensus-slots",
  "sp-keyring",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "tokio",
 ]
 
@@ -3109,8 +3046,8 @@ version = "0.8.0"
 dependencies = [
  "parity-scale-codec",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3130,7 +3067,7 @@ dependencies = [
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
 ]
 
 [[package]]
@@ -3152,7 +3089,7 @@ dependencies = [
 name = "its-state"
 version = "0.8.0"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "itp-storage",
  "its-primitives",
  "log 0.4.17",
@@ -3160,9 +3097,9 @@ dependencies = [
  "serde 1.0.137",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/integritee-network/sgx-runtime?branch=master)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
@@ -3181,7 +3118,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.2",
  "rocksdb",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "temp-dir",
  "thiserror 1.0.31",
 ]
@@ -3195,8 +3132,8 @@ dependencies = [
  "its-primitives",
  "parity-scale-codec",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3215,8 +3152,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -3226,15 +3163,15 @@ name = "its-validateer-fetch"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "itp-ocall-api",
  "itp-storage",
  "itp-teerex-storage",
  "itp-test",
  "itp-types",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
@@ -4303,14 +4240,14 @@ name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4319,13 +4256,13 @@ name = "pallet-authorship"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-authorship",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4335,12 +4272,12 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4350,7 +4287,7 @@ version = "0.9.12"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
  "claims-primitives",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "rustc-hex",
@@ -4358,7 +4295,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_derive 1.0.137",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4368,20 +4305,20 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-finality-grandpa",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-session",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4390,12 +4327,12 @@ name = "pallet-multisig"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4404,14 +4341,14 @@ name = "pallet-parentchain"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.20#b97001102f9bd10a34b82878e9946074616b65c5"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4420,12 +4357,12 @@ name = "pallet-proxy"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4434,12 +4371,12 @@ name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
  "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4449,13 +4386,13 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4464,20 +4401,20 @@ name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "log 0.4.17",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-session",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-trie",
 ]
 
 [[package]]
@@ -4485,7 +4422,7 @@ name = "pallet-sidechain"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "pallet-teerex",
@@ -4494,9 +4431,9 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sidechain-primitives",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "teerex-primitives",
 ]
@@ -4506,12 +4443,12 @@ name = "pallet-sudo"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4520,15 +4457,15 @@ name = "pallet-teeracle"
 version = "0.1.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "pallet-teerex",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-fixed",
  "teeracle-primitives",
@@ -4539,7 +4476,7 @@ name = "pallet-teerex"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "ias-verify",
  "log 0.4.17",
@@ -4547,9 +4484,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "teerex-primitives",
 ]
@@ -4560,13 +4497,13 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -4576,15 +4513,15 @@ name = "pallet-transaction-payment"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
  "smallvec 1.8.0",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4596,7 +4533,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4604,14 +4541,14 @@ name = "pallet-treasury"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4620,13 +4557,13 @@ name = "pallet-utility"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4635,12 +4572,12 @@ name = "pallet-vesting"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -5698,9 +5635,9 @@ dependencies = [
  "hex",
  "parking_lot 0.12.0",
  "serde_json 1.0.81",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
  "thiserror 1.0.31",
 ]
 
@@ -6011,7 +5948,7 @@ version = "0.8.0"
 source = "git+https://github.com/integritee-network/sgx-runtime?branch=master#d131a9c98446edd3dfd812f87a484ab59c3b268f"
 dependencies = [
  "frame-executive",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-aura",
@@ -6028,10 +5965,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-session",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-transaction-pool",
@@ -6314,7 +6251,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
@@ -6417,9 +6354,9 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "thiserror 1.0.31",
@@ -6440,25 +6377,12 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
@@ -6466,21 +6390,6 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "integer-sqrt",
- "num-traits 0.2.15",
- "parity-scale-codec",
- "scale-info",
- "serde 1.0.137",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "integer-sqrt",
@@ -6488,7 +6397,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-debug-derive",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "static_assertions",
 ]
@@ -6500,8 +6409,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -6512,8 +6421,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -6527,10 +6436,10 @@ dependencies = [
  "futures-timer",
  "log 0.4.17",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "thiserror 1.0.31",
@@ -6545,11 +6454,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -6562,8 +6471,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-arithmetic",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -6571,52 +6480,6 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "base58 0.2.0",
- "bitflags",
- "blake2-rfc",
- "byteorder 1.4.3",
- "dyn-clonable",
- "ed25519-dalek",
- "futures 0.3.21",
- "hash-db",
- "hash256-std-hasher",
- "hex",
- "impl-serde",
- "lazy_static",
- "libsecp256k1",
- "log 0.4.17",
- "merlin",
- "num-traits 0.2.15",
- "parity-scale-codec",
- "parity-util-mem",
- "parking_lot 0.12.0",
- "primitive-types",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.5.5",
- "scale-info",
- "schnorrkel",
- "secp256k1",
- "secrecy",
- "serde 1.0.137",
- "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "ss58-registry",
- "substrate-bip39",
- "thiserror 1.0.31",
- "tiny-bip39 0.8.2",
- "wasmi",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "base58 0.2.0",
@@ -6646,12 +6509,12 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde 1.0.137",
- "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core-hashing",
+ "sp-debug-derive",
+ "sp-externalities",
+ "sp-runtime-interface",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-storage",
  "ss58-registry",
  "substrate-bip39",
  "thiserror 1.0.31",
@@ -6663,20 +6526,6 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "blake2",
- "byteorder 1.4.3",
- "digest 0.10.3",
- "sha2 0.10.2",
- "sha3",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "twox-hash",
-]
-
-[[package]]
-name = "sp-core-hashing"
-version = "4.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "blake2",
@@ -6691,32 +6540,11 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "proc-macro2",
- "quote",
- "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "syn",
-]
-
-[[package]]
-name = "sp-core-hashing-proc-macro"
-version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "proc-macro2",
  "quote",
- "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "syn",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "proc-macro2",
- "quote",
+ "sp-core-hashing",
  "syn",
 ]
 
@@ -6733,23 +6561,12 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.12.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "environmental",
  "parity-scale-codec",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-storage",
 ]
 
 [[package]]
@@ -6763,25 +6580,11 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sp-api",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "thiserror 1.0.31",
 ]
 
 [[package]]
@@ -6792,8 +6595,8 @@ dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
@@ -6813,40 +6616,15 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "futures 0.3.21",
- "hash-db",
- "libsecp256k1",
- "log 0.4.17",
- "parity-scale-codec",
- "parking_lot 0.12.0",
- "secp256k1",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-tracing",
+ "sp-trie",
+ "sp-wasm-interface",
  "tracing",
  "tracing-core",
 ]
@@ -6863,15 +6641,15 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "secp256k1",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-externalities",
+ "sp-keystore",
+ "sp-runtime-interface",
+ "sp-state-machine",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing",
+ "sp-trie",
+ "sp-wasm-interface",
  "tracing",
  "tracing-core",
 ]
@@ -6882,25 +6660,9 @@ version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "lazy_static",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "strum",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "async-trait",
- "futures 0.3.21",
- "merlin",
- "parity-scale-codec",
- "parking_lot 0.12.0",
- "schnorrkel",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "thiserror 1.0.31",
 ]
 
 [[package]]
@@ -6915,8 +6677,8 @@ dependencies = [
  "parking_lot 0.12.0",
  "schnorrkel",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-externalities",
  "thiserror 1.0.31",
 ]
 
@@ -6935,18 +6697,8 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "backtrace",
- "lazy_static",
- "regex 1.5.5",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6966,29 +6718,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "rustc-hash",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log 0.4.17",
- "parity-scale-codec",
- "parity-util-mem",
- "paste",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "scale-info",
- "serde 1.0.137",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core",
 ]
 
 [[package]]
@@ -7006,9 +6736,9 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scale-info",
  "serde 1.0.137",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
@@ -7016,47 +6746,18 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-externalities",
+ "sp-runtime-interface-proc-macro",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "Inflector",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -7079,21 +6780,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-staking"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -7103,30 +6793,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "hash-db",
- "log 0.4.17",
- "num-traits 0.2.15",
- "parity-scale-codec",
- "parking_lot 0.12.0",
- "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.8.0",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-panic-handler 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "thiserror 1.0.31",
- "tracing",
- "trie-root",
 ]
 
 [[package]]
@@ -7141,11 +6809,11 @@ dependencies = [
  "parking_lot 0.12.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.8.0",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-panic-handler 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-externalities",
+ "sp-panic-handler",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-trie",
  "thiserror 1.0.31",
  "tracing",
  "trie-root",
@@ -7159,25 +6827,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#73ca2dac
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-
-[[package]]
-name = "sp-std"
-version = "4.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
-
-[[package]]
-name = "sp-storage"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "impl-serde",
- "parity-scale-codec",
- "ref-cast",
- "serde 1.0.137",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
-]
 
 [[package]]
 name = "sp-storage"
@@ -7188,7 +6838,7 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde 1.0.137",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-debug-derive",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -7202,22 +6852,10 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec",
  "sp-api",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -7238,23 +6876,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-trie"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "hash-db",
- "memory-db",
- "parity-scale-codec",
- "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "thiserror 1.0.31",
- "trie-db",
- "trie-root",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -7266,7 +6888,7 @@ dependencies = [
  "memory-db",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "trie-db",
@@ -7283,8 +6905,8 @@ dependencies = [
  "parity-wasm 0.42.2",
  "scale-info",
  "serde 1.0.137",
- "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core-hashing-proc-macro",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version-proc-macro",
  "thiserror 1.0.31",
@@ -7299,18 +6921,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "impl-trait-for-tuples",
- "log 0.4.17",
- "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "wasmi",
 ]
 
 [[package]]
@@ -7408,7 +7018,7 @@ dependencies = [
  "ac-node-api",
  "ac-primitives",
  "frame-metadata",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "hex",
  "log 0.4.17",
@@ -7418,10 +7028,10 @@ dependencies = [
  "primitive-types",
  "serde 1.0.137",
  "serde_json 1.0.81",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-rpc",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "thiserror 1.0.31",
@@ -7451,10 +7061,10 @@ dependencies = [
  "parking_lot 0.12.0",
  "sc-keystore",
  "serde_json 1.0.81",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-keyring",
- "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-keystore",
 ]
 
 [[package]]
@@ -7544,7 +7154,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3120,6 +3120,7 @@ version = "0.8.0"
 dependencies = [
  "itp-top-pool-author",
  "itp-types",
+ "itp-utils",
  "its-primitives",
  "jsonrpc-core 16.1.0",
  "jsonrpc-core 18.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2188,6 +2188,7 @@ dependencies = [
  "ita-stf",
  "itc-rpc-client",
  "itp-node-api-extensions",
+ "itp-sgx-crypto",
  "itp-types",
  "itp-utils",
  "json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,10 +2756,8 @@ version = "0.8.0"
 dependencies = [
  "aes",
  "derive_more",
- "hex",
  "itp-settings",
  "itp-sgx-io",
- "itp-utils",
  "log 0.4.17",
  "ofb",
  "parity-scale-codec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,10 +2964,9 @@ version = "0.8.0"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "hex",
+ "itp-sgx-crypto",
  "parity-scale-codec",
- "sgx_crypto_helper",
  "sgx_tstd",
- "sgx_types",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
  "ac-primitives",
  "log 0.4.17",
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -31,7 +31,7 @@ source = "git+https://github.com/scs/substrate-api-client?branch=polkadot-v0.9.2
 dependencies = [
  "ac-primitives",
  "frame-metadata",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "hex",
  "log 0.4.17",
@@ -39,8 +39,8 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "serde_json 1.0.81",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
 
@@ -51,8 +51,8 @@ source = "git+https://github.com/scs/substrate-api-client?branch=polkadot-v0.9.2
 dependencies = [
  "hex",
  "parity-scale-codec",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -607,7 +607,7 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1198,7 +1198,7 @@ name = "frame-benchmarking"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "linregress",
  "log 0.4.17",
@@ -1207,12 +1207,12 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sp-api",
- "sp-application-crypto",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
- "sp-runtime-interface",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -1220,15 +1220,15 @@ name = "frame-executive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -1246,11 +1246,11 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
 dependencies = [
  "bitflags",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "impl-trait-for-tuples",
  "log 0.4.17",
  "once_cell 1.10.0",
@@ -1259,17 +1259,58 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "smallvec 1.8.0",
- "sp-arithmetic",
- "sp-core",
- "sp-core-hashing-proc-macro",
- "sp-inherents",
- "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
- "sp-staking",
- "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
+dependencies = [
+ "bitflags",
+ "frame-metadata",
+ "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "impl-trait-for-tuples",
+ "log 0.4.17",
+ "once_cell 1.10.0",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde 1.0.137",
+ "smallvec 1.8.0",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "Inflector",
+ "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1278,7 +1319,19 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "Inflector",
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -1289,8 +1342,18 @@ name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "frame-support-procedural-tools-derive"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -1311,14 +1374,14 @@ name = "frame-system"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
 ]
@@ -2010,11 +2073,11 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d
 dependencies = [
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "parity-scale-codec",
  "scale-info",
  "serde_json 1.0.81",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "webpki 0.21.0",
@@ -2135,10 +2198,10 @@ dependencies = [
  "serde 1.0.137",
  "serde_json 1.0.81",
  "sgx_crypto_helper",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "substrate-bip39",
  "substrate-client-keystore",
@@ -2153,7 +2216,7 @@ version = "1.0.9"
 source = "git+https://github.com/integritee-network/integritee-node?branch=master#ecc97eafd9db460b75df46a99ba8edc01d4180de"
 dependencies = [
  "frame-executive",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-aura",
@@ -2179,10 +2242,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-session",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-transaction-pool",
@@ -2202,7 +2265,7 @@ dependencies = [
  "dashmap",
  "dirs 1.0.5",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "futures 0.3.21",
  "hex",
@@ -2218,6 +2281,7 @@ dependencies = [
  "itp-stf-state-handler",
  "itp-test",
  "itp-types",
+ "itp-utils",
  "its-consensus-slots",
  "its-peer-fetch",
  "its-primitives",
@@ -2241,10 +2305,10 @@ dependencies = [
  "sgx_types",
  "sgx_urts",
  "sha2 0.7.1",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "teerex-primitives",
  "thiserror 1.0.31",
@@ -2302,7 +2366,7 @@ dependencies = [
  "base58 0.1.0",
  "derive_more",
  "env_logger 0.7.1 (git+https://github.com/mesalock-linux/env_logger-sgx)",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "hex",
  "integritee-node-runtime",
@@ -2318,11 +2382,11 @@ dependencies = [
  "sgx-externalities",
  "sgx-runtime",
  "sgx_tstd",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/integritee-network/sgx-runtime?branch=master)",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "substrate-client-keystore",
 ]
@@ -2340,7 +2404,7 @@ dependencies = [
  "serde_json 1.0.81",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2365,7 +2429,7 @@ dependencies = [
  "log 0.4.17",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2386,7 +2450,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
  "tiny-keccak 2.0.2",
@@ -2408,8 +2472,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
@@ -2434,11 +2498,11 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
- "sp-runtime",
- "sp-trie",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2500,7 +2564,7 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec",
  "serde_json 1.0.81",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "tokio",
 ]
 
@@ -2562,7 +2626,7 @@ dependencies = [
  "log 0.4.17",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2580,7 +2644,7 @@ dependencies = [
 name = "itp-enclave-api"
 version = "0.8.0"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "itp-enclave-api-ffi",
  "itp-settings",
  "itp-types",
@@ -2591,9 +2655,9 @@ dependencies = [
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
 
@@ -2624,8 +2688,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
@@ -2637,9 +2701,9 @@ version = "0.8.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "thiserror 1.0.31",
 ]
@@ -2664,8 +2728,8 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2703,7 +2767,7 @@ dependencies = [
  "sgx_rand",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -2729,8 +2793,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2754,7 +2818,7 @@ dependencies = [
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2765,15 +2829,15 @@ version = "0.8.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "hash-db",
  "parity-scale-codec",
  "sgx_tstd",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2806,8 +2870,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2839,9 +2903,9 @@ dependencies = [
  "serde 1.0.137",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2868,8 +2932,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2885,11 +2949,22 @@ dependencies = [
  "serde 1.0.137",
  "serde_json 1.0.81",
  "sgx_tstd",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
+]
+
+[[package]]
+name = "itp-utils"
+version = "0.8.0"
+dependencies = [
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "hex",
+ "sgx_tstd",
+ "thiserror 1.0.31",
+ "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -2910,8 +2985,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2922,7 +2997,7 @@ version = "0.8.0"
 dependencies = [
  "env_logger 0.9.0",
  "finality-grandpa",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "ita-stf",
  "itc-parentchain-block-import-dispatcher",
  "itp-enclave-metrics",
@@ -2947,9 +3022,9 @@ dependencies = [
  "parity-scale-codec",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -2970,9 +3045,9 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2997,7 +3072,7 @@ dependencies = [
  "sgx_tstd",
  "sp-consensus-slots",
  "sp-keyring",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "tokio",
 ]
 
@@ -3027,8 +3102,8 @@ version = "0.8.0"
 dependencies = [
  "parity-scale-codec",
  "serde 1.0.137",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3047,7 +3122,7 @@ dependencies = [
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -3069,7 +3144,7 @@ dependencies = [
 name = "its-state"
 version = "0.8.0"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "itp-storage",
  "its-primitives",
  "log 0.4.17",
@@ -3077,9 +3152,9 @@ dependencies = [
  "serde 1.0.137",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/integritee-network/sgx-runtime?branch=master)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
@@ -3098,7 +3173,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.2",
  "rocksdb",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "temp-dir",
  "thiserror 1.0.31",
 ]
@@ -3112,8 +3187,8 @@ dependencies = [
  "its-primitives",
  "parity-scale-codec",
  "sgx_tstd",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -3132,8 +3207,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -3143,15 +3218,15 @@ name = "its-validateer-fetch"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "itp-ocall-api",
  "itp-storage",
  "itp-teerex-storage",
  "itp-test",
  "itp-types",
  "parity-scale-codec",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
@@ -4220,14 +4295,14 @@ name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4236,13 +4311,13 @@ name = "pallet-authorship"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-authorship",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4252,12 +4327,12 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4267,7 +4342,7 @@ version = "0.9.12"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
  "claims-primitives",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "rustc-hex",
@@ -4275,7 +4350,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_derive 1.0.137",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4285,20 +4360,20 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-session",
- "sp-staking",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4307,12 +4382,12 @@ name = "pallet-multisig"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4321,14 +4396,14 @@ name = "pallet-parentchain"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.20#b97001102f9bd10a34b82878e9946074616b65c5"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4337,12 +4412,12 @@ name = "pallet-proxy"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4351,12 +4426,12 @@ name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4366,13 +4441,13 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4381,20 +4456,20 @@ name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "impl-trait-for-tuples",
  "log 0.4.17",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-session",
- "sp-staking",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -4402,7 +4477,7 @@ name = "pallet-sidechain"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "pallet-teerex",
@@ -4411,9 +4486,9 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sidechain-primitives",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "teerex-primitives",
 ]
@@ -4423,12 +4498,12 @@ name = "pallet-sudo"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4437,15 +4512,15 @@ name = "pallet-teeracle"
 version = "0.1.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "pallet-teerex",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-fixed",
  "teeracle-primitives",
@@ -4456,7 +4531,7 @@ name = "pallet-teerex"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=master#4d1b0e9d412b4e3b94f3e5afd853213b6ecc97b7"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "ias-verify",
  "log 0.4.17",
@@ -4464,9 +4539,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "teerex-primitives",
 ]
@@ -4477,13 +4552,13 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "frame-benchmarking",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -4493,15 +4568,15 @@ name = "pallet-transaction-payment"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
  "smallvec 1.8.0",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4513,7 +4588,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -4521,14 +4596,14 @@ name = "pallet-treasury"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "impl-trait-for-tuples",
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4537,13 +4612,13 @@ name = "pallet-utility"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -4552,12 +4627,12 @@ name = "pallet-vesting"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.17",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -5615,9 +5690,9 @@ dependencies = [
  "hex",
  "parking_lot 0.12.0",
  "serde_json 1.0.81",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
 
@@ -5928,7 +6003,7 @@ version = "0.8.0"
 source = "git+https://github.com/integritee-network/sgx-runtime?branch=master#d131a9c98446edd3dfd812f87a484ab59c3b268f"
 dependencies = [
  "frame-executive",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-aura",
@@ -5945,10 +6020,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-session",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-transaction-pool",
@@ -6231,7 +6306,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
@@ -6334,9 +6409,9 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "thiserror 1.0.31",
@@ -6357,14 +6432,42 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.137",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "integer-sqrt",
+ "num-traits 0.2.15",
+ "parity-scale-codec",
+ "scale-info",
+ "serde 1.0.137",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "static_assertions",
 ]
 
 [[package]]
@@ -6377,7 +6480,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-debug-derive",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "static_assertions",
 ]
@@ -6389,8 +6492,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -6401,8 +6504,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -6416,10 +6519,10 @@ dependencies = [
  "futures-timer",
  "log 0.4.17",
  "parity-scale-codec",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "sp-state-machine",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "thiserror 1.0.31",
@@ -6434,11 +6537,11 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-consensus",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -6451,10 +6554,56 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-arithmetic",
- "sp-runtime",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
+]
+
+[[package]]
+name = "sp-core"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "base58 0.2.0",
+ "bitflags",
+ "blake2-rfc",
+ "byteorder 1.4.3",
+ "dyn-clonable",
+ "ed25519-dalek",
+ "futures 0.3.21",
+ "hash-db",
+ "hash256-std-hasher",
+ "hex",
+ "impl-serde",
+ "lazy_static",
+ "libsecp256k1",
+ "log 0.4.17",
+ "merlin",
+ "num-traits 0.2.15",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "parking_lot 0.12.0",
+ "primitive-types",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.5.5",
+ "scale-info",
+ "schnorrkel",
+ "secp256k1",
+ "secrecy",
+ "serde 1.0.137",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "ss58-registry",
+ "substrate-bip39",
+ "thiserror 1.0.31",
+ "tiny-bip39 0.8.2",
+ "wasmi",
+ "zeroize",
 ]
 
 [[package]]
@@ -6489,18 +6638,32 @@ dependencies = [
  "secp256k1",
  "secrecy",
  "serde 1.0.137",
- "sp-core-hashing",
- "sp-debug-derive",
- "sp-externalities",
- "sp-runtime-interface",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "ss58-registry",
  "substrate-bip39",
  "thiserror 1.0.31",
  "tiny-bip39 0.8.2",
  "wasmi",
  "zeroize",
+]
+
+[[package]]
+name = "sp-core-hashing"
+version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "blake2",
+ "byteorder 1.4.3",
+ "digest 0.10.3",
+ "sha2 0.10.2",
+ "sha3",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "twox-hash",
 ]
 
 [[package]]
@@ -6520,11 +6683,32 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "syn",
+]
+
+[[package]]
+name = "sp-core-hashing-proc-macro"
+version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "proc-macro2",
  "quote",
- "sp-core-hashing",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "syn",
+]
+
+[[package]]
+name = "sp-debug-derive"
+version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -6541,12 +6725,23 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "environmental",
+ "parity-scale-codec",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+]
+
+[[package]]
+name = "sp-externalities"
+version = "0.12.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "environmental",
  "parity-scale-codec",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -6560,11 +6755,25 @@ dependencies = [
  "scale-info",
  "serde 1.0.137",
  "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-keystore",
- "sp-runtime",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "thiserror 1.0.31",
 ]
 
 [[package]]
@@ -6575,8 +6784,8 @@ dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
@@ -6596,15 +6805,40 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing",
- "sp-trie",
- "sp-wasm-interface",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "tracing",
+ "tracing-core",
+]
+
+[[package]]
+name = "sp-io"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "futures 0.3.21",
+ "hash-db",
+ "libsecp256k1",
+ "log 0.4.17",
+ "parity-scale-codec",
+ "parking_lot 0.12.0",
+ "secp256k1",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "tracing",
  "tracing-core",
 ]
@@ -6621,15 +6855,15 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.0",
  "secp256k1",
- "sp-core",
- "sp-externalities",
- "sp-keystore",
- "sp-runtime-interface",
- "sp-state-machine",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-state-machine 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing",
- "sp-trie",
- "sp-wasm-interface",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "tracing",
  "tracing-core",
 ]
@@ -6640,9 +6874,25 @@ version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "lazy_static",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "strum",
+]
+
+[[package]]
+name = "sp-keystore"
+version = "0.12.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "async-trait",
+ "futures 0.3.21",
+ "merlin",
+ "parity-scale-codec",
+ "parking_lot 0.12.0",
+ "schnorrkel",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "thiserror 1.0.31",
 ]
 
 [[package]]
@@ -6657,8 +6907,8 @@ dependencies = [
  "parking_lot 0.12.0",
  "schnorrkel",
  "serde 1.0.137",
- "sp-core",
- "sp-externalities",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
 
@@ -6677,8 +6927,18 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-panic-handler"
+version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "regex 1.5.5",
 ]
 
 [[package]]
@@ -6698,7 +6958,29 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "rustc-hash",
  "serde 1.0.137",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log 0.4.17",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "paste",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scale-info",
+ "serde 1.0.137",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -6716,11 +6998,28 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "scale-info",
  "serde 1.0.137",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "static_assertions",
 ]
 
 [[package]]
@@ -6731,13 +7030,25 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-externalities",
- "sp-runtime-interface-proc-macro",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "Inflector",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -6760,10 +7071,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core",
- "sp-runtime",
- "sp-staking",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-staking"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -6773,8 +7095,30 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.12.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "hash-db",
+ "log 0.4.17",
+ "num-traits 0.2.15",
+ "parity-scale-codec",
+ "parking_lot 0.12.0",
+ "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.8.0",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-panic-handler 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "thiserror 1.0.31",
+ "tracing",
+ "trie-root",
 ]
 
 [[package]]
@@ -6789,11 +7133,11 @@ dependencies = [
  "parking_lot 0.12.0",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.8.0",
- "sp-core",
- "sp-externalities",
- "sp-panic-handler",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-externalities 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-panic-handler 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-trie",
+ "sp-trie 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "tracing",
  "trie-root",
@@ -6807,7 +7151,25 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#d602397a
 [[package]]
 name = "sp-std"
 version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+
+[[package]]
+name = "sp-std"
+version = "4.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
+
+[[package]]
+name = "sp-storage"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "impl-serde",
+ "parity-scale-codec",
+ "ref-cast",
+ "serde 1.0.137",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+]
 
 [[package]]
 name = "sp-storage"
@@ -6818,7 +7180,7 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde 1.0.137",
- "sp-debug-derive",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -6832,10 +7194,22 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec",
  "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6856,7 +7230,23 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-trie"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "hash-db",
+ "memory-db",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "thiserror 1.0.31",
+ "trie-db",
+ "trie-root",
 ]
 
 [[package]]
@@ -6868,7 +7258,7 @@ dependencies = [
  "memory-db",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
  "trie-db",
@@ -6885,8 +7275,8 @@ dependencies = [
  "parity-wasm 0.42.2",
  "scale-info",
  "serde 1.0.137",
- "sp-core-hashing-proc-macro",
- "sp-runtime",
+ "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version-proc-macro",
  "thiserror 1.0.31",
@@ -6901,6 +7291,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "impl-trait-for-tuples",
+ "log 0.4.17",
+ "parity-scale-codec",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "wasmi",
 ]
 
 [[package]]
@@ -6998,7 +7400,7 @@ dependencies = [
  "ac-node-api",
  "ac-primitives",
  "frame-metadata",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "hex",
  "log 0.4.17",
@@ -7008,10 +7410,10 @@ dependencies = [
  "primitive-types",
  "serde 1.0.137",
  "serde_json 1.0.81",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-rpc",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "thiserror 1.0.31",
@@ -7041,10 +7443,10 @@ dependencies = [
  "parking_lot 0.12.0",
  "sc-keystore",
  "serde_json 1.0.81",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-keyring",
- "sp-keystore",
+ "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -7134,7 +7536,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde 1.0.137",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,9 +991,9 @@ checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ed25519"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d916019f70ae3a1faa1195685e290287f39207d38e6dfee727197cffcc002214"
+checksum = "f9cb2103c580a9f8732121f755eccb51312f7db26314664314c119298107064b"
 dependencies = [
  "signature",
 ]
@@ -1736,7 +1736,7 @@ dependencies = [
  "indexmap",
  "slab 0.4.6",
  "tokio",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tracing",
 ]
 
@@ -1917,7 +1917,7 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes 1.1.0",
  "fnv 1.0.7",
- "itoa 1.0.1",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ dependencies = [
  "http-body",
  "httparse 1.7.1",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2355,7 +2355,7 @@ dependencies = [
  "serde_json 1.0.81",
  "serde_urlencoded",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tracing",
  "typed-builder",
  "walkdir",
@@ -2617,9 +2617,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "itp-block-import-queue"
@@ -3415,7 +3415,7 @@ dependencies = [
  "thiserror 1.0.31",
  "tokio",
  "tokio-rustls",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "url 2.2.2",
 ]
 
@@ -3437,7 +3437,7 @@ dependencies = [
  "thiserror 1.0.31",
  "tokio",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -4292,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "pallet-aura"
@@ -5659,9 +5659,9 @@ checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "safe-mix"
@@ -5971,7 +5971,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde 1.0.137",
 ]
@@ -5983,7 +5983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde 1.0.137",
 ]
@@ -7152,7 +7152,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#d602397a0bbb24b5d627795b797259a44a5e29e9"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#73ca2dacd2bcfd300d270b4e0211621200c0c596"
 
 [[package]]
 name = "sp-std"
@@ -7496,9 +7496,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
+checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7817,9 +7817,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes 1.1.0",
  "futures-core 0.3.21",
@@ -7832,9 +7832,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes 1.1.0",
  "futures-core 0.3.21",
@@ -8285,7 +8285,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower-service",
  "tracing",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -38,8 +38,9 @@ sp-keyring = { version = "6.0.0", git = "https://github.com/paritytech/substrate
 sp-application-crypto = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 
-#local dependencies
+# local dependencies
 itp-node-api-extensions = { path = "../core-primitives/node-api-extensions" }
+itp-sgx-crypto = { path = "../core-primitives/sgx/crypto" }
 itp-types = { path = "../core-primitives/types" }
 itp-utils = { path = "../core-primitives/utils" }
 ita-stf = { path = "../app-libs/stf" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,7 +39,8 @@ sp-application-crypto = { version = "6.0.0", git = "https://github.com/paritytec
 sp-core = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 
 #local dependencies
-itp-types = { path = "../core-primitives/types" }
 itp-node-api-extensions = { path = "../core-primitives/node-api-extensions" }
+itp-types = { path = "../core-primitives/types" }
+itp-utils = { path = "../core-primitives/utils" }
 ita-stf = { path = "../app-libs/stf" }
 itc-rpc-client = { path = "../core/rpc-client" }

--- a/cli/src/command_utils.rs
+++ b/cli/src/command_utils.rs
@@ -30,6 +30,7 @@ use substrate_client_keystore::LocalKeystore;
 type AccountPublic = <Signature as Verify>::Signer;
 pub(crate) const KEYSTORE_PATH: &str = "my_keystore";
 
+/// Retrieves the public shielding key via the enclave websocket server.
 pub(crate) fn get_shielding_key(cli: &Cli) -> Result<Rsa3072PubKey, String> {
 	let worker_api_direct = get_worker_api_direct(cli);
 	worker_api_direct.get_rsa_pubkey().map_err(|e| e.to_string())

--- a/cli/src/command_utils.rs
+++ b/cli/src/command_utils.rs
@@ -16,9 +16,7 @@
 */
 
 use crate::Cli;
-use codec::Encode;
 use itc_rpc_client::direct_client::{DirectApi, DirectClient as DirectWorkerApi};
-use itp_utils::hex_encode;
 use log::*;
 use my_node_runtime::{AccountId, Signature};
 use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
@@ -35,21 +33,6 @@ pub(crate) const KEYSTORE_PATH: &str = "my_keystore";
 pub(crate) fn get_shielding_key(cli: &Cli) -> Result<Rsa3072PubKey, String> {
 	let worker_api_direct = get_worker_api_direct(cli);
 	worker_api_direct.get_rsa_pubkey().map_err(|e| e.to_string())
-}
-
-pub(crate) fn encrypt_to_hex_bytes<E: Encode>(
-	encryption_key: Rsa3072PubKey,
-	to_encrypt: E,
-) -> Result<Vec<u8>, String> {
-	let encoded = to_encrypt.encode();
-	let mut encrypted: Vec<u8> = Vec::new();
-	encryption_key
-		.encrypt_buffer(&encoded, &mut encrypted)
-		.map_err(|e| e.to_string())?;
-
-	let hex_encoded = hex_encode(encrypted);
-
-	Ok(hex_encoded.into_bytes())
 }
 
 pub(crate) fn get_chain_api(cli: &Cli) -> Api<sr25519::Pair, WsRpcClient> {

--- a/cli/src/command_utils.rs
+++ b/cli/src/command_utils.rs
@@ -18,6 +18,7 @@
 use crate::Cli;
 use codec::Encode;
 use itc_rpc_client::direct_client::{DirectApi, DirectClient as DirectWorkerApi};
+use itp_utils::hex_encode;
 use log::*;
 use my_node_runtime::{AccountId, Signature};
 use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
@@ -31,20 +32,24 @@ use substrate_client_keystore::LocalKeystore;
 type AccountPublic = <Signature as Verify>::Signer;
 pub(crate) const KEYSTORE_PATH: &str = "my_keystore";
 
-pub(crate) fn encode_encrypt<E: Encode>(
-	cli: &Cli,
-	to_encrypt: E,
-) -> Result<(Vec<u8>, Vec<u8>), String> {
+pub(crate) fn get_shielding_key(cli: &Cli) -> Result<Rsa3072PubKey, String> {
 	let worker_api_direct = get_worker_api_direct(cli);
-	let shielding_pubkey: Rsa3072PubKey = match worker_api_direct.get_rsa_pubkey() {
-		Ok(key) => key,
-		Err(err_msg) => return Err(err_msg.to_string()),
-	};
+	worker_api_direct.get_rsa_pubkey().map_err(|e| e.to_string())
+}
 
+pub(crate) fn encrypt_to_hex_bytes<E: Encode>(
+	encryption_key: Rsa3072PubKey,
+	to_encrypt: E,
+) -> Result<Vec<u8>, String> {
 	let encoded = to_encrypt.encode();
 	let mut encrypted: Vec<u8> = Vec::new();
-	shielding_pubkey.encrypt_buffer(&encoded, &mut encrypted).unwrap();
-	Ok((encoded, encrypted))
+	encryption_key
+		.encrypt_buffer(&encoded, &mut encrypted)
+		.map_err(|e| e.to_string())?;
+
+	let hex_encoded = hex_encode(encrypted);
+
+	Ok(hex_encoded.into_bytes())
 }
 
 pub(crate) fn get_chain_api(cli: &Cli) -> Api<sr25519::Pair, WsRpcClient> {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -367,7 +367,7 @@ fn shield_funds(cli: &Cli, arg_from: &str, arg_to: &str, amount: &Balance, shard
 	let to = get_accountid_from_str(arg_to);
 
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let encrypted_recevier = encryption_key.encrypt_to_hex_bytes(&to.encode()).unwrap();
+	let encrypted_recevier = encryption_key.encrypt(&to.encode()).unwrap();
 
 	// compose the extrinsic
 	let xt: UncheckedExtrinsicV4<([u8; 2], Vec<u8>, u128, H256)> =

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -24,8 +24,7 @@ use codec::{Decode, Encode};
 use ita_stf::ShardIdentifier;
 use itc_rpc_client::direct_client::DirectApi;
 use itp_node_api_extensions::{PalletTeerexApi, TEEREX};
-use itp_sgx_crypto::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
-use itp_utils::shielding_encrypt_to_hex_bytes;
+use itp_sgx_crypto::ShieldingCryptoEncrypt;
 use log::*;
 use my_node_runtime::{Balance, BalancesCall, Call, Event, Hash};
 use sp_application_crypto::{ed25519, sr25519};
@@ -368,7 +367,7 @@ fn shield_funds(cli: &Cli, arg_from: &str, arg_to: &str, amount: &Balance, shard
 	let to = get_accountid_from_str(arg_to);
 
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let encrypted_recevier = shielding_encrypt_to_hex_bytes(&encryption_key, to).unwrap();
+	let encrypted_recevier = encryption_key.encrypt_to_hex_bytes(&to.encode()).unwrap();
 
 	// compose the extrinsic
 	let xt: UncheckedExtrinsicV4<([u8; 2], Vec<u8>, u128, H256)> =

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -24,6 +24,7 @@ use codec::{Decode, Encode};
 use ita_stf::ShardIdentifier;
 use itc_rpc_client::direct_client::DirectApi;
 use itp_node_api_extensions::{PalletTeerexApi, TEEREX};
+use itp_utils::encrypt_to_hex_bytes;
 use log::*;
 use my_node_runtime::{Balance, BalancesCall, Call, Event, Hash};
 use sp_application_crypto::{ed25519, sr25519};

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -364,13 +364,13 @@ fn shield_funds(cli: &Cli, arg_from: &str, arg_to: &str, amount: &Balance, shard
 
 	// get the recipient
 	let to = get_accountid_from_str(arg_to);
-	let (_to_encoded, to_encrypted) = match encode_encrypt(cli, to) {
-		Ok((encoded, encrypted)) => (encoded, encrypted),
-		Err(e) => panic!("{}", e),
-	};
+
+	let encryption_key = get_shielding_key(cli).unwrap();
+	let encrypted_recevier = encrypt_to_hex_bytes(encryption_key, to).unwrap();
+
 	// compose the extrinsic
 	let xt: UncheckedExtrinsicV4<([u8; 2], Vec<u8>, u128, H256)> =
-		compose_extrinsic!(chain_api, TEEREX, "shield_funds", to_encrypted, *amount, shard);
+		compose_extrinsic!(chain_api, TEEREX, "shield_funds", encrypted_recevier, *amount, shard);
 
 	let tx_hash = chain_api.send_extrinsic(xt.hex_encode(), XtStatus::Finalized).unwrap();
 	println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -24,7 +24,8 @@ use codec::{Decode, Encode};
 use ita_stf::ShardIdentifier;
 use itc_rpc_client::direct_client::DirectApi;
 use itp_node_api_extensions::{PalletTeerexApi, TEEREX};
-use itp_utils::encrypt_to_hex_bytes;
+use itp_sgx_crypto::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
+use itp_utils::shielding_encrypt_to_hex_bytes;
 use log::*;
 use my_node_runtime::{Balance, BalancesCall, Call, Event, Hash};
 use sp_application_crypto::{ed25519, sr25519};
@@ -367,7 +368,7 @@ fn shield_funds(cli: &Cli, arg_from: &str, arg_to: &str, amount: &Balance, shard
 	let to = get_accountid_from_str(arg_to);
 
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let encrypted_recevier = encrypt_to_hex_bytes(encryption_key, to).unwrap();
+	let encrypted_recevier = shielding_encrypt_to_hex_bytes(&encryption_key, to).unwrap();
 
 	// compose the extrinsic
 	let xt: UncheckedExtrinsicV4<([u8; 2], Vec<u8>, u128, H256)> =

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -61,7 +61,7 @@ fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: TrustedOperation) ->
 	let data = Request { shard, cyphertext: operation_call_encrypted };
 	let rpc_method = "author_submitAndWatchExtrinsic".to_owned();
 	let jsonrpc_call: String =
-		RpcRequest::compose_jsonrpc_call(rpc_method, Some(hex_encode(data.encode())));
+		RpcRequest::compose_jsonrpc_call(rpc_method, vec![hex_encode(data.encode())]).unwrap();
 
 	let direct_api = get_worker_api_direct(cli);
 	let (sender, receiver) = channel();
@@ -70,6 +70,7 @@ fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: TrustedOperation) ->
 	loop {
 		match receiver.recv() {
 			Ok(response) => {
+				debug!("Response: {:?}", response);
 				let response: RpcResponse = serde_json::from_str(&response).unwrap();
 				let response_result = decode_hex(response.result).unwrap();
 				if let Ok(return_value) = RpcReturnValue::decode(&mut response_result.as_slice()) {
@@ -162,8 +163,9 @@ fn send_direct_request(
 
 	let jsonrpc_call: String = RpcRequest::compose_jsonrpc_call(
 		"author_submitAndWatchExtrinsic".to_string(),
-		Some(hex_encode(data)),
-	);
+		vec![hex_encode(data)],
+	)
+	.unwrap();
 
 	debug!("get direct api");
 	let direct_api = get_worker_api_direct(cli);

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -29,7 +29,7 @@ use itp_sgx_crypto::ShieldingCryptoEncrypt;
 use itp_types::{
 	DirectRequestStatus, RpcRequest, RpcResponse, RpcReturnValue, TrustedOperationStatus,
 };
-use itp_utils::hex_encode;
+use itp_utils::{decode_hex, hex_encode};
 use log::*;
 use my_node_runtime::{AccountId, Hash};
 use sp_core::{sr25519 as sr25519_core, Pair, H256};

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -25,11 +25,10 @@ use codec::{Decode, Encode};
 use ita_stf::{ShardIdentifier, TrustedCallSigned, TrustedOperation};
 use itc_rpc_client::direct_client::DirectApi;
 use itp_node_api_extensions::TEEREX;
-use itp_sgx_crypto::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
+use itp_sgx_crypto::ShieldingCryptoEncrypt;
 use itp_types::{
 	DirectRequestStatus, RpcRequest, RpcResponse, RpcReturnValue, TrustedOperationStatus,
 };
-use itp_utils::shielding_encrypt_to_hex_bytes;
 use log::*;
 use my_node_runtime::{AccountId, Hash};
 use sp_core::{sr25519 as sr25519_core, Pair, H256};
@@ -54,7 +53,7 @@ pub fn perform_trusted_operation(
 fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: TrustedOperation) -> Option<Vec<u8>> {
 	// TODO: ensure getter is signed?
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let operation_call_encrypted = shielding_encrypt_to_hex_bytes(&encryption_key, getter).unwrap();
+	let operation_call_encrypted = encryption_key.encrypt_to_hex_bytes(&getter.encode()).unwrap();
 	let shard = read_shard(trusted_args).unwrap();
 
 	// compose jsonrpc call
@@ -94,7 +93,7 @@ fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: TrustedOperation) ->
 fn send_request(cli: &Cli, trusted_args: &TrustedArgs, call: TrustedCallSigned) -> Option<Vec<u8>> {
 	let chain_api = get_chain_api(cli);
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let call_encrypted = shielding_encrypt_to_hex_bytes(&encryption_key, call).unwrap();
+	let call_encrypted = encryption_key.encrypt_to_hex_bytes(&call.encode()).unwrap();
 
 	let shard = read_shard(trusted_args).unwrap();
 
@@ -155,7 +154,7 @@ fn send_direct_request(
 ) -> Option<Vec<u8>> {
 	let encryption_key = get_shielding_key(cli).unwrap();
 	let operation_call_encrypted =
-		shielding_encrypt_to_hex_bytes(&encryption_key, operation_call).unwrap();
+		encryption_key.encrypt_to_hex_bytes(&operation_call.encode()).unwrap();
 	let shard = read_shard(trusted_args).unwrap();
 
 	// compose jsonrpc call

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -25,10 +25,11 @@ use codec::{Decode, Encode};
 use ita_stf::{ShardIdentifier, TrustedCallSigned, TrustedOperation};
 use itc_rpc_client::direct_client::DirectApi;
 use itp_node_api_extensions::TEEREX;
+use itp_sgx_crypto::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
 use itp_types::{
 	DirectRequestStatus, RpcRequest, RpcResponse, RpcReturnValue, TrustedOperationStatus,
 };
-use itp_utils::encrypt_to_hex_bytes;
+use itp_utils::shielding_encrypt_to_hex_bytes;
 use log::*;
 use my_node_runtime::{AccountId, Hash};
 use sp_core::{sr25519 as sr25519_core, Pair, H256};
@@ -53,7 +54,7 @@ pub fn perform_trusted_operation(
 fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: TrustedOperation) -> Option<Vec<u8>> {
 	// TODO: ensure getter is signed?
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let operation_call_encrypted = encrypt_to_hex_bytes(encryption_key, getter).unwrap();
+	let operation_call_encrypted = shielding_encrypt_to_hex_bytes(&encryption_key, getter).unwrap();
 	let shard = read_shard(trusted_args).unwrap();
 
 	// compose jsonrpc call
@@ -93,7 +94,7 @@ fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: TrustedOperation) ->
 fn send_request(cli: &Cli, trusted_args: &TrustedArgs, call: TrustedCallSigned) -> Option<Vec<u8>> {
 	let chain_api = get_chain_api(cli);
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let call_encrypted = encrypt_to_hex_bytes(encryption_key, call).unwrap();
+	let call_encrypted = shielding_encrypt_to_hex_bytes(&encryption_key, call).unwrap();
 
 	let shard = read_shard(trusted_args).unwrap();
 
@@ -153,7 +154,8 @@ fn send_direct_request(
 	operation_call: TrustedOperation,
 ) -> Option<Vec<u8>> {
 	let encryption_key = get_shielding_key(cli).unwrap();
-	let operation_call_encrypted = encrypt_to_hex_bytes(encryption_key, operation_call).unwrap();
+	let operation_call_encrypted =
+		shielding_encrypt_to_hex_bytes(&encryption_key, operation_call).unwrap();
 	let shard = read_shard(trusted_args).unwrap();
 
 	// compose jsonrpc call

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -16,10 +16,7 @@
 */
 
 use crate::{
-	command_utils::{
-		encrypt_to_hex_bytes, get_chain_api, get_pair_from_str, get_shielding_key,
-		get_worker_api_direct,
-	},
+	command_utils::{get_chain_api, get_pair_from_str, get_shielding_key, get_worker_api_direct},
 	trusted_commands::TrustedArgs,
 	Cli,
 };
@@ -31,6 +28,7 @@ use itp_node_api_extensions::TEEREX;
 use itp_types::{
 	DirectRequestStatus, RpcRequest, RpcResponse, RpcReturnValue, TrustedOperationStatus,
 };
+use itp_utils::encrypt_to_hex_bytes;
 use log::*;
 use my_node_runtime::{AccountId, Hash};
 use sp_core::{sr25519 as sr25519_core, Pair, H256};

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"], 
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_rand = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
+sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false }
 serde-sgx = { package = "serde", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx", optional = true  }
 serde_json-sgx = { package = "serde_json", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx", optional = true  }
 
@@ -43,7 +43,6 @@ sgx = [
     "sgx_tstd",
     "sgx_rand",
     "itp-sgx-io/sgx",
-    "sgx-crypto-helper",
     "serde_json-sgx",
     "serde-sgx"
 ]

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -10,7 +10,6 @@ aes = { version = "0.6.0" }
 ofb = { version = "0.4.0" }
 codec  = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.5" }
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.14", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
@@ -29,16 +28,13 @@ sp-core = { version = "6.0.0", default-features = false, git = "https://github.c
 # local deps
 itp-settings = { path = "../../settings" }
 itp-sgx-io = { path = "../io", default-features = false }
-itp-utils = { path = "../../utils", default-features = false }
 
 [features]
 default = ["std"]
 std = [
     "codec/std",
     "log/std",
-    "hex/std",
     "itp-sgx-io/std",
-    "itp-utils/std",
     "sp-core/std",
     'serde/std',
     'serde_json/std',
@@ -47,7 +43,6 @@ sgx = [
     "sgx_tstd",
     "sgx_rand",
     "itp-sgx-io/sgx",
-    "itp-utils/sgx",
     "serde_json-sgx",
     "serde-sgx"
 ]

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -10,6 +10,7 @@ aes = { version = "0.6.0" }
 ofb = { version = "0.4.0" }
 codec  = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.5" }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 log = { version = "0.4.14", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
@@ -28,13 +29,16 @@ sp-core = { version = "6.0.0", default-features = false, git = "https://github.c
 # local deps
 itp-settings = { path = "../../settings" }
 itp-sgx-io = { path = "../io", default-features = false }
+itp-utils = { path = "../../utils", default-features = false }
 
 [features]
 default = ["std"]
 std = [
     "codec/std",
     "log/std",
+    "hex/std",
     "itp-sgx-io/std",
+    "itp-utils/std",
     "sp-core/std",
     'serde/std',
     'serde_json/std',
@@ -43,6 +47,7 @@ sgx = [
     "sgx_tstd",
     "sgx_rand",
     "itp-sgx-io/sgx",
+    "itp-utils/sgx",
     "serde_json-sgx",
     "serde-sgx"
 ]

--- a/core-primitives/sgx/crypto/src/lib.rs
+++ b/core-primitives/sgx/crypto/src/lib.rs
@@ -40,11 +40,7 @@ pub mod key_repository;
 pub mod rsa3072;
 pub mod traits;
 
-#[cfg(feature = "sgx")]
-pub use self::aes::*;
-#[cfg(feature = "sgx")]
-pub use self::ed25519::*;
-pub use self::rsa3072::*;
+pub use self::{aes::*, ed25519::*, rsa3072::*};
 pub use error::*;
 pub use traits::*;
 

--- a/core-primitives/sgx/crypto/src/lib.rs
+++ b/core-primitives/sgx/crypto/src/lib.rs
@@ -37,16 +37,13 @@ pub mod aes;
 pub mod ed25519;
 pub mod error;
 pub mod key_repository;
-pub mod traits;
-
-#[cfg(feature = "sgx")]
 pub mod rsa3072;
+pub mod traits;
 
 #[cfg(feature = "sgx")]
 pub use self::aes::*;
 #[cfg(feature = "sgx")]
 pub use self::ed25519::*;
-#[cfg(feature = "sgx")]
 pub use self::rsa3072::*;
 pub use error::*;
 pub use traits::*;

--- a/core-primitives/sgx/crypto/src/mocks.rs
+++ b/core-primitives/sgx/crypto/src/mocks.rs
@@ -27,6 +27,7 @@ use crate::{
 	key_repository::{AccessKey, MutateKey},
 };
 use itp_sgx_io::{SealedIO, StaticSealedIO};
+use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
 
 #[derive(Default)]
 pub struct KeyRepositoryMock<KeyType>
@@ -103,24 +104,18 @@ impl SealedIO for AesSealMock {
 	}
 }
 
-#[cfg(feature = "sgx")]
-pub mod sgx {
-	use super::*;
-	use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
+#[derive(Default)]
+pub struct Rsa3072SealMock {}
 
-	#[derive(Default)]
-	pub struct Rsa3072SealMock {}
+impl StaticSealedIO for Rsa3072SealMock {
+	type Error = Error;
+	type Unsealed = Rsa3072KeyPair;
 
-	impl StaticSealedIO for Rsa3072SealMock {
-		type Error = Error;
-		type Unsealed = Rsa3072KeyPair;
+	fn unseal_from_static_file() -> Result<Self::Unsealed> {
+		Ok(Rsa3072KeyPair::default())
+	}
 
-		fn unseal_from_static_file() -> Result<Self::Unsealed> {
-			Ok(Rsa3072KeyPair::default())
-		}
-
-		fn seal_to_static_file(_unsealed: Self::Unsealed) -> Result<()> {
-			Ok(())
-		}
+	fn seal_to_static_file(_unsealed: Self::Unsealed) -> Result<()> {
+		Ok(())
 	}
 }

--- a/core-primitives/sgx/crypto/src/rsa3072.rs
+++ b/core-primitives/sgx/crypto/src/rsa3072.rs
@@ -22,6 +22,7 @@ use crate::{
 	traits::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt},
 };
 
+use itp_utils::hex_encode;
 use sgx_crypto_helper::{
 	rsa3072::{Rsa3072KeyPair, Rsa3072PubKey},
 	RsaKeyPair,
@@ -41,6 +42,11 @@ impl ShieldingCryptoEncrypt for Rsa3072KeyPair {
 			.map_err(|e| Error::Other(format!("{:?}", e).into()))?;
 		Ok(cipher_buffer)
 	}
+
+	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>> {
+		let encrypted = self.encrypt(data)?;
+		Ok(hex_encode(encrypted).into_bytes())
+	}
 }
 
 impl ShieldingCryptoDecrypt for Rsa3072KeyPair {
@@ -52,6 +58,12 @@ impl ShieldingCryptoDecrypt for Rsa3072KeyPair {
 			.map_err(|e| Error::Other(format!("{:?}", e).into()))?;
 		Ok(decrypted_buffer)
 	}
+
+	fn decrypt_from_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>> {
+		let encrypted_data =
+			hex::decode(data).map_err(|e| Error::Other(format!("{:?}", e).into()))?;
+		self.decrypt(&encrypted_data)
+	}
 }
 
 impl ShieldingCryptoEncrypt for Rsa3072PubKey {
@@ -62,6 +74,11 @@ impl ShieldingCryptoEncrypt for Rsa3072PubKey {
 		self.encrypt_buffer(data, &mut cipher_buffer)
 			.map_err(|e| Error::Other(format!("{:?}", e).into()))?;
 		Ok(cipher_buffer)
+	}
+
+	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>> {
+		let encrypted = self.encrypt(data)?;
+		Ok(hex_encode(encrypted).into_bytes())
 	}
 }
 

--- a/core-primitives/sgx/crypto/src/rsa3072.rs
+++ b/core-primitives/sgx/crypto/src/rsa3072.rs
@@ -21,8 +21,6 @@ use crate::{
 	error::{Error, Result},
 	traits::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt},
 };
-
-use itp_utils::hex_encode;
 use sgx_crypto_helper::{
 	rsa3072::{Rsa3072KeyPair, Rsa3072PubKey},
 	RsaKeyPair,
@@ -42,11 +40,6 @@ impl ShieldingCryptoEncrypt for Rsa3072KeyPair {
 			.map_err(|e| Error::Other(format!("{:?}", e).into()))?;
 		Ok(cipher_buffer)
 	}
-
-	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>> {
-		let encrypted = self.encrypt(data)?;
-		Ok(hex_encode(encrypted).into_bytes())
-	}
 }
 
 impl ShieldingCryptoDecrypt for Rsa3072KeyPair {
@@ -58,12 +51,6 @@ impl ShieldingCryptoDecrypt for Rsa3072KeyPair {
 			.map_err(|e| Error::Other(format!("{:?}", e).into()))?;
 		Ok(decrypted_buffer)
 	}
-
-	fn decrypt_from_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>> {
-		let encrypted_data =
-			hex::decode(data).map_err(|e| Error::Other(format!("{:?}", e).into()))?;
-		self.decrypt(&encrypted_data)
-	}
 }
 
 impl ShieldingCryptoEncrypt for Rsa3072PubKey {
@@ -74,11 +61,6 @@ impl ShieldingCryptoEncrypt for Rsa3072PubKey {
 		self.encrypt_buffer(data, &mut cipher_buffer)
 			.map_err(|e| Error::Other(format!("{:?}", e).into()))?;
 		Ok(cipher_buffer)
-	}
-
-	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>> {
-		let encrypted = self.encrypt(data)?;
-		Ok(hex_encode(encrypted).into_bytes())
 	}
 }
 

--- a/core-primitives/sgx/crypto/src/traits.rs
+++ b/core-primitives/sgx/crypto/src/traits.rs
@@ -27,11 +27,9 @@ pub trait StateCrypto {
 pub trait ShieldingCryptoEncrypt {
 	type Error: Debug;
 	fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
-	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }
 
 pub trait ShieldingCryptoDecrypt {
 	type Error: Debug;
 	fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
-	fn decrypt_from_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }

--- a/core-primitives/sgx/crypto/src/traits.rs
+++ b/core-primitives/sgx/crypto/src/traits.rs
@@ -24,8 +24,12 @@ pub trait StateCrypto {
 	fn decrypt(&self, data: &mut [u8]) -> Result<(), Self::Error>;
 }
 
-pub trait ShieldingCrypto {
+pub trait ShieldingCryptoEncrypt {
 	type Error: Debug;
 	fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
+}
+
+pub trait ShieldingCryptoDecrypt {
+	type Error: Debug;
 	fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }

--- a/core-primitives/sgx/crypto/src/traits.rs
+++ b/core-primitives/sgx/crypto/src/traits.rs
@@ -27,9 +27,11 @@ pub trait StateCrypto {
 pub trait ShieldingCryptoEncrypt {
 	type Error: Debug;
 	fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
+	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }
 
 pub trait ShieldingCryptoDecrypt {
 	type Error: Debug;
 	fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
+	fn decrypt_from_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error>;
 }

--- a/core-primitives/test/src/mock/shielding_crypto_mock.rs
+++ b/core-primitives/test/src/mock/shielding_crypto_mock.rs
@@ -42,20 +42,12 @@ impl ShieldingCryptoEncrypt for ShieldingCryptoMock {
 	fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
 		self.key.encrypt(data)
 	}
-
-	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
-		self.key.encrypt(data)
-	}
 }
 
 impl ShieldingCryptoDecrypt for ShieldingCryptoMock {
 	type Error = itp_sgx_crypto::Error;
 
 	fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
-		self.key.decrypt(data)
-	}
-
-	fn decrypt_from_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
 		self.key.decrypt(data)
 	}
 }

--- a/core-primitives/test/src/mock/shielding_crypto_mock.rs
+++ b/core-primitives/test/src/mock/shielding_crypto_mock.rs
@@ -42,12 +42,20 @@ impl ShieldingCryptoEncrypt for ShieldingCryptoMock {
 	fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
 		self.key.encrypt(data)
 	}
+
+	fn encrypt_to_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
+		self.key.encrypt(data)
+	}
 }
 
 impl ShieldingCryptoDecrypt for ShieldingCryptoMock {
 	type Error = itp_sgx_crypto::Error;
 
 	fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
+		self.key.decrypt(data)
+	}
+
+	fn decrypt_from_hex_bytes(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
 		self.key.decrypt(data)
 	}
 }

--- a/core-primitives/test/src/mock/shielding_crypto_mock.rs
+++ b/core-primitives/test/src/mock/shielding_crypto_mock.rs
@@ -15,7 +15,7 @@
 
 */
 
-use itp_sgx_crypto::ShieldingCrypto;
+use itp_sgx_crypto::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
 use sgx_crypto_helper::{rsa3072::Rsa3072KeyPair, RsaKeyPair};
 use std::vec::Vec;
 
@@ -36,12 +36,16 @@ impl Default for ShieldingCryptoMock {
 	}
 }
 
-impl ShieldingCrypto for ShieldingCryptoMock {
+impl ShieldingCryptoEncrypt for ShieldingCryptoMock {
 	type Error = itp_sgx_crypto::Error;
 
 	fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
 		self.key.encrypt(data)
 	}
+}
+
+impl ShieldingCryptoDecrypt for ShieldingCryptoMock {
+	type Error = itp_sgx_crypto::Error;
 
 	fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
 		self.key.decrypt(data)

--- a/core-primitives/top-pool-author/Cargo.toml
+++ b/core-primitives/top-pool-author/Cargo.toml
@@ -5,40 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = [
-    "ita-stf/std",
-    "itp-sgx-crypto/std",
-    "itc-direct-rpc-server/std",
-    "itc-tls-websocket-server/std",
-    "itp-enclave-metrics/std",
-    "itp-ocall-api/std",
-    "itp-stf-state-handler/std",
-    "itp-top-pool/std",
-    "itp-types/std",
-    "jsonrpc-core",
-    "log/std",
-    "thiserror",
-]
-sgx = [
-    "sgx_tstd",
-    "sgx-crypto-helper",
-    "jsonrpc-core_sgx",
-    "ita-stf/sgx",
-    "itc-direct-rpc-server/sgx",
-    "itc-tls-websocket-server/sgx",
-    "itp-enclave-metrics/sgx",
-    "itp-sgx-crypto/sgx",
-    "itp-stf-state-handler/sgx",
-    "itp-top-pool/sgx",
-    "itp-types/sgx",
-    "thiserror_sgx",
-]
-test = [ "itp-test/sgx", "itp-top-pool/mocks" ]
-
 [dependencies]
 # sgx dependencies
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
@@ -56,6 +22,7 @@ itp-stf-state-handler = { path = "../stf-state-handler", default-features = fals
 itp-test = { path = "../test", default-features = false, optional = true }
 itp-top-pool = { path = "../top-pool", default-features = false }
 itp-types = { path = "../types", default-features = false }
+itp-utils = { path = "../utils", default-features = false }
 
 # sgx enabled external libraries
 jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
@@ -74,3 +41,39 @@ sp-runtime = { version = "6.0.0", default-features = false, git = "https://githu
 
 [dev-dependencies]
 itp-sgx-crypto = { path = "../sgx/crypto", features = ["mocks"] }
+
+
+
+[features]
+default = ["std"]
+std = [
+    "ita-stf/std",
+    "itp-sgx-crypto/std",
+    "itc-direct-rpc-server/std",
+    "itc-tls-websocket-server/std",
+    "itp-enclave-metrics/std",
+    "itp-ocall-api/std",
+    "itp-stf-state-handler/std",
+    "itp-top-pool/std",
+    "itp-types/std",
+    "itp-utils/std",
+    "jsonrpc-core",
+    "log/std",
+    "thiserror",
+]
+sgx = [
+    "sgx_tstd",
+    "sgx-crypto-helper",
+    "jsonrpc-core_sgx",
+    "ita-stf/sgx",
+    "itc-direct-rpc-server/sgx",
+    "itc-tls-websocket-server/sgx",
+    "itp-enclave-metrics/sgx",
+    "itp-sgx-crypto/sgx",
+    "itp-stf-state-handler/sgx",
+    "itp-top-pool/sgx",
+    "itp-types/sgx",
+    "itp-utils/sgx",
+    "thiserror_sgx",
+]
+test = [ "itp-test/sgx", "itp-top-pool/mocks" ]

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -28,7 +28,7 @@ use codec::{Decode, Encode};
 use ita_stf::{hash, Getter, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_enclave_metrics::EnclaveMetric;
 use itp_ocall_api::EnclaveMetricsOCallApi;
-use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCrypto};
+use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCryptoDecrypt};
 use itp_stf_state_handler::query_shard_state::QueryShardState;
 use itp_top_pool::{
 	error::{Error as PoolError, IntoPoolError},
@@ -65,7 +65,7 @@ where
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt,
 {
 	top_pool: Arc<TopPool>,
 	top_filter: TopFilter,
@@ -81,7 +81,7 @@ where
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	/// Create new instance of Authoring API.
@@ -108,7 +108,7 @@ where
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	fn process_top(
@@ -200,7 +200,7 @@ where
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	fn submit_top(
@@ -295,7 +295,7 @@ where
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	type Hash = <TopPool as TrustedOperationPool>::Hash;
@@ -312,7 +312,7 @@ where
 	TopFilter: Filter<Value = TrustedOperation>,
 	StateFacade: QueryShardState,
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto,
+	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
 	type Hash = <TopPool as TrustedOperationPool>::Hash;

--- a/core-primitives/top-pool-author/src/author_tests.rs
+++ b/core-primitives/top-pool-author/src/author_tests.rs
@@ -25,7 +25,7 @@ use ita_stf::{
 	Getter, KeyPair, ShardIdentifier, TrustedCall, TrustedCallSigned, TrustedGetter,
 	TrustedOperation,
 };
-use itp_sgx_crypto::{mocks::KeyRepositoryMock, ShieldingCrypto};
+use itp_sgx_crypto::{mocks::KeyRepositoryMock, ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
 use itp_stf_state_handler::handle_state::HandleState;
 use itp_test::mock::{
 	handle_state_mock::HandleStateMock, metrics_ocall_mock::MetricsOCallMock,

--- a/core-primitives/top-pool-author/src/test_utils.rs
+++ b/core-primitives/top-pool-author/src/test_utils.rs
@@ -19,12 +19,12 @@
 use crate::sgx_reexport_prelude::*;
 
 use crate::traits::AuthorApi;
-use codec::Encode;
 use ita_stf::{ShardIdentifier, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_sgx_crypto::ShieldingCrypto;
 use jsonrpc_core::futures::executor;
 use sp_core::H256;
 use std::{fmt::Debug, vec::Vec};
+use itp_utils::encrypt_to_hex_bytes;
 
 /// Test utility function to submit a trusted operation on an RPC author
 pub fn submit_operation_to_top_pool<R, S>(
@@ -38,7 +38,8 @@ where
 	S: ShieldingCrypto,
 	S::Error: Debug,
 {
-	let top_encrypted = shielding_key.encrypt(top.encode().as_slice()).unwrap();
+
+	let top_encrypted = encrypt_to_hex_bytes(shielding_key, top).unwrap();
 	let submit_future = async { author.submit_top(top_encrypted, shard).await };
 	executor::block_on(submit_future)
 }

--- a/core-primitives/top-pool-author/src/test_utils.rs
+++ b/core-primitives/top-pool-author/src/test_utils.rs
@@ -20,11 +20,11 @@ use crate::sgx_reexport_prelude::*;
 
 use crate::traits::AuthorApi;
 use ita_stf::{ShardIdentifier, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
-use itp_sgx_crypto::ShieldingCrypto;
+use itp_sgx_crypto::ShieldingCryptoEncrypt;
 use jsonrpc_core::futures::executor;
 use sp_core::H256;
 use std::{fmt::Debug, vec::Vec};
-use itp_utils::encrypt_to_hex_bytes;
+use itp_utils::shielding_encrypt_to_hex_bytes;
 
 /// Test utility function to submit a trusted operation on an RPC author
 pub fn submit_operation_to_top_pool<R, S>(
@@ -35,11 +35,10 @@ pub fn submit_operation_to_top_pool<R, S>(
 ) -> Result<H256, jsonrpc_core::Error>
 where
 	R: AuthorApi<H256, H256>,
-	S: ShieldingCrypto,
+	S: ShieldingCryptoEncrypt,
 	S::Error: Debug,
 {
-
-	let top_encrypted = encrypt_to_hex_bytes(shielding_key, top).unwrap();
+	let top_encrypted = shielding_encrypt_to_hex_bytes(shielding_key, top).unwrap();
 	let submit_future = async { author.submit_top(top_encrypted, shard).await };
 	executor::block_on(submit_future)
 }

--- a/core-primitives/top-pool-author/src/test_utils.rs
+++ b/core-primitives/top-pool-author/src/test_utils.rs
@@ -19,12 +19,12 @@
 use crate::sgx_reexport_prelude::*;
 
 use crate::traits::AuthorApi;
+use codec::Encode;
 use ita_stf::{ShardIdentifier, TrustedCallSigned, TrustedGetterSigned, TrustedOperation};
 use itp_sgx_crypto::ShieldingCryptoEncrypt;
 use jsonrpc_core::futures::executor;
 use sp_core::H256;
 use std::{fmt::Debug, vec::Vec};
-use codec::Encode;
 
 /// Test utility function to submit a trusted operation on an RPC author
 pub fn submit_operation_to_top_pool<R, S>(

--- a/core-primitives/top-pool-author/src/test_utils.rs
+++ b/core-primitives/top-pool-author/src/test_utils.rs
@@ -38,7 +38,7 @@ where
 	S: ShieldingCryptoEncrypt,
 	S::Error: Debug,
 {
-	let top_encrypted = shielding_key.encrypt_to_hex_bytes(&top.encode()).unwrap();
+	let top_encrypted = shielding_key.encrypt(&top.encode()).unwrap();
 	let submit_future = async { author.submit_top(top_encrypted, shard).await };
 	executor::block_on(submit_future)
 }

--- a/core-primitives/top-pool-author/src/test_utils.rs
+++ b/core-primitives/top-pool-author/src/test_utils.rs
@@ -24,7 +24,7 @@ use itp_sgx_crypto::ShieldingCryptoEncrypt;
 use jsonrpc_core::futures::executor;
 use sp_core::H256;
 use std::{fmt::Debug, vec::Vec};
-use itp_utils::shielding_encrypt_to_hex_bytes;
+use codec::Encode;
 
 /// Test utility function to submit a trusted operation on an RPC author
 pub fn submit_operation_to_top_pool<R, S>(
@@ -38,7 +38,7 @@ where
 	S: ShieldingCryptoEncrypt,
 	S::Error: Debug,
 {
-	let top_encrypted = shielding_encrypt_to_hex_bytes(shielding_key, top).unwrap();
+	let top_encrypted = shielding_key.encrypt_to_hex_bytes(&top.encode()).unwrap();
 	let submit_future = async { author.submit_top(top_encrypted, shard).await };
 	executor::block_on(submit_future)
 }

--- a/core-primitives/types/src/rpc.rs
+++ b/core-primitives/types/src/rpc.rs
@@ -32,26 +32,26 @@ impl RpcReturnValue {
 }
 
 #[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize)]
-// Todo: result should not be Vec<u8>, but `T: Serialize`
 pub struct RpcResponse {
 	pub jsonrpc: String,
-	pub result: Vec<u8>, // encoded RpcReturnValue
+	pub result: String, // hex encoded RpcReturnValue
 	pub id: u32,
 }
 
 #[derive(Clone, Encode, Decode, Serialize, Deserialize)]
-// Todo: params should not be Vec<u8>, but `T: Serialize`
 pub struct RpcRequest {
 	pub jsonrpc: String,
 	pub method: String,
-	pub params: Vec<u8>,
+	pub params: String,
 	pub id: i32,
 }
 
 impl RpcRequest {
-	pub fn compose_jsonrpc_call(method: String, data: Vec<u8>) -> String {
+	pub fn compose_jsonrpc_call(method: String, data: Option<String>) -> String {
+		let params = data.unwrap_or_default();
+
 		let direct_invocation_call =
-			RpcRequest { jsonrpc: "2.0".to_owned(), method, params: data, id: 1 };
+			RpcRequest { jsonrpc: "2.0".to_owned(), method, params, id: 1 };
 		serde_json::to_string(&direct_invocation_call).unwrap()
 	}
 }

--- a/core-primitives/types/src/rpc.rs
+++ b/core-primitives/types/src/rpc.rs
@@ -42,16 +42,14 @@ pub struct RpcResponse {
 pub struct RpcRequest {
 	pub jsonrpc: String,
 	pub method: String,
-	pub params: String,
+	pub params: Option<String>,
 	pub id: i32,
 }
 
 impl RpcRequest {
 	pub fn compose_jsonrpc_call(method: String, data: Option<String>) -> String {
-		let params = data.unwrap_or_default();
-
 		let direct_invocation_call =
-			RpcRequest { jsonrpc: "2.0".to_owned(), method, params, id: 1 };
+			RpcRequest { jsonrpc: "2.0".to_owned(), method, params: data, id: 1 };
 		serde_json::to_string(&direct_invocation_call).unwrap()
 	}
 }

--- a/core-primitives/types/src/rpc.rs
+++ b/core-primitives/types/src/rpc.rs
@@ -42,14 +42,15 @@ pub struct RpcResponse {
 pub struct RpcRequest {
 	pub jsonrpc: String,
 	pub method: String,
-	pub params: Option<String>,
+	pub params: Vec<String>,
 	pub id: i32,
 }
 
 impl RpcRequest {
-	pub fn compose_jsonrpc_call(method: String, data: Option<String>) -> String {
-		let direct_invocation_call =
-			RpcRequest { jsonrpc: "2.0".to_owned(), method, params: data, id: 1 };
-		serde_json::to_string(&direct_invocation_call).unwrap()
+	pub fn compose_jsonrpc_call(
+		method: String,
+		params: Vec<String>,
+	) -> Result<String, serde_json::Error> {
+		serde_json::to_string(&RpcRequest { jsonrpc: "2.0".to_owned(), method, params, id: 1 })
 	}
 }

--- a/core-primitives/utils/Cargo.toml
+++ b/core-primitives/utils/Cargo.toml
@@ -6,13 +6,16 @@ edition = "2018"
 
 
 [dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 # substrate
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
 
-# sgx dependencies
+# teaclave
+sgx_crypto_helper = { default-features = false, branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
@@ -22,12 +25,12 @@ thiserror = { version = "1.0", optional = true }
 [features]
 default = ["std"]
 std = [
+    "codec/std",
     "hex/std",
     "frame-support/std",
     "thiserror",
 ]
 sgx = [
-    # sgx
     "sgx_tstd",
     "thiserror_sgx",
 ]

--- a/core-primitives/utils/Cargo.toml
+++ b/core-primitives/utils/Cargo.toml
@@ -10,7 +10,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 # substrate
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 
 # teaclave
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/core-primitives/utils/Cargo.toml
+++ b/core-primitives/utils/Cargo.toml
@@ -9,13 +9,14 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
+# local
+itp-sgx-crypto = { path = "../sgx/crypto", default-features = false }
+
 # substrate
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
 
 # teaclave
-sgx_crypto_helper = { default-features = false, branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
@@ -27,10 +28,12 @@ default = ["std"]
 std = [
     "codec/std",
     "hex/std",
+    "itp-sgx-crypto/std",
     "frame-support/std",
     "thiserror",
 ]
 sgx = [
     "sgx_tstd",
     "thiserror_sgx",
+    "itp-sgx-crypto/sgx",
 ]

--- a/core-primitives/utils/Cargo.toml
+++ b/core-primitives/utils/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "itp-utils"
+version = "0.8.0"
+authors = ["Integritee AG <hello@integritee.network>"]
+edition = "2018"
+
+
+[dependencies]
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+
+# substrate
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
+
+# sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+
+# sgx enabled external libraries
+thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
+# std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
+thiserror = { version = "1.0", optional = true }
+
+[features]
+default = ["std"]
+std = [
+    "hex/std",
+    "frame-support/std",
+    "thiserror",
+]
+sgx = [
+    # sgx
+    "sgx_tstd",
+    "thiserror_sgx",
+]

--- a/core-primitives/utils/Cargo.toml
+++ b/core-primitives/utils/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
-# local
-itp-sgx-crypto = { path = "../sgx/crypto", default-features = false }
-
 # substrate
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.19" }
 
@@ -28,12 +25,10 @@ default = ["std"]
 std = [
     "codec/std",
     "hex/std",
-    "itp-sgx-crypto/std",
     "frame-support/std",
     "thiserror",
 ]
 sgx = [
     "sgx_tstd",
     "thiserror_sgx",
-    "itp-sgx-crypto/sgx",
 ]

--- a/core-primitives/utils/src/buffer.rs
+++ b/core-primitives/utils/src/buffer.rs
@@ -1,0 +1,47 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Buffer utility functions.
+
+use crate::error::{Error, Result};
+use frame_support::ensure;
+use std::vec::Vec;
+
+/// Fills a given buffer with data and the left over buffer space with white spaces.
+pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) -> Result<()> {
+	ensure!(
+		data.len() <= writable.len(),
+		Error::InsufficientBufferSize(writable.len(), data.len())
+	);
+	let (left, right) = writable.split_at_mut(data.len());
+	left.clone_from_slice(&data);
+	// fill the right side with whitespace
+	right.iter_mut().for_each(|x| *x = 0x20);
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn write_slice_and_whitespace_pad_returns_error_if_buffer_too_small() {
+		let mut writable = vec![0; 32];
+		let data = vec![1; 33];
+		assert!(write_slice_and_whitespace_pad(&mut writable, data).is_err());
+	}
+}

--- a/core-primitives/utils/src/error.rs
+++ b/core-primitives/utils/src/error.rs
@@ -1,0 +1,32 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
+use std::boxed::Box;
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// extrinsics factory error
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+	#[error("Insufficient buffer size. Actual: {0}, required: {1}")]
+	InsufficientBufferSize(usize, usize),
+	#[error(transparent)]
+	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
+}

--- a/core-primitives/utils/src/error.rs
+++ b/core-primitives/utils/src/error.rs
@@ -29,8 +29,6 @@ pub enum Error {
 	InsufficientBufferSize(usize, usize),
 	#[error("Could not decode from hex data: {0}")]
 	Hex(hex::FromHexError),
-	#[error("Could not decode: {0}")]
-	Codec(codec::Error),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/core-primitives/utils/src/error.rs
+++ b/core-primitives/utils/src/error.rs
@@ -27,8 +27,6 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
 	#[error("Insufficient buffer size. Actual: {0}, required: {1}")]
 	InsufficientBufferSize(usize, usize),
-	#[error("Encryption faild due to: {0}")]
-	Encryption(sgx_types::sgx_status_t),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/core-primitives/utils/src/error.rs
+++ b/core-primitives/utils/src/error.rs
@@ -27,6 +27,10 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
 	#[error("Insufficient buffer size. Actual: {0}, required: {1}")]
 	InsufficientBufferSize(usize, usize),
+	#[error("Could not decode from hex data: {0}")]
+	Hex(hex::FromHexError),
+	#[error("Could not decode: {0}")]
+	Codec(codec::Error),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/core-primitives/utils/src/error.rs
+++ b/core-primitives/utils/src/error.rs
@@ -27,6 +27,8 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
 	#[error("Insufficient buffer size. Actual: {0}, required: {1}")]
 	InsufficientBufferSize(usize, usize),
+	#[error("Encryption faild due to: {0}")]
+	Encryption(sgx_types::sgx_status_t),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/core-primitives/utils/src/error.rs
+++ b/core-primitives/utils/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
 	InsufficientBufferSize(usize, usize),
 	#[error("Could not decode from hex data: {0}")]
 	Hex(hex::FromHexError),
+	#[error("Parity Scale Codec: {0}")]
+	Codec(codec::Error),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/core-primitives/utils/src/hex.rs
+++ b/core-primitives/utils/src/hex.rs
@@ -1,0 +1,92 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Hex encoding utility functions.
+
+use crate::error::{Error, Result};
+use codec::{Decode, Encode};
+use std::{string::String, vec::Vec};
+
+/// Trait to encode a given value to a hex string, prefixed with "0x".
+pub trait ToHexPrefixed {
+	fn to_hex(&self) -> String;
+}
+
+impl<T: Encode> ToHexPrefixed for T {
+	fn to_hex(&self) -> String {
+		hex_encode(self.encode())
+	}
+}
+
+/// Trait to decode a hex string to a given output.
+pub trait FromHexPrefixed {
+	type Output;
+
+	fn from_hex(msg: &str) -> Result<Self::Output>;
+}
+
+impl<T: Decode> FromHexPrefixed for T {
+	type Output = T;
+
+	fn from_hex(msg: &str) -> Result<Self::Output> {
+		let byte_array = decode_hex(msg)?;
+		Decode::decode(&mut byte_array.as_slice()).map_err(Error::Codec)
+	}
+}
+
+/// Hex encodes given data and preappends a "0x".
+pub fn hex_encode(data: Vec<u8>) -> String {
+	let mut hex_str = hex::encode(data);
+	hex_str.insert_str(0, "0x");
+	hex_str
+}
+
+/// Helper method for decoding hex.
+pub fn decode_hex<T: AsRef<[u8]>>(message: T) -> Result<Vec<u8>> {
+	let mut message = message.as_ref();
+	if message[..2] == [b'0', b'x'] {
+		message = &message[2..]
+	}
+	let decoded_message = hex::decode(message).map_err(Error::Hex)?;
+	Ok(decoded_message)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn hex_encode_decode_works() {
+		let data = "Hello World!".to_string();
+
+		let hex_encoded_data = hex_encode(data.encode());
+		let decoded_data =
+			String::decode(&mut decode_hex(hex_encoded_data).unwrap().as_slice()).unwrap();
+
+		assert_eq!(data, decoded_data);
+	}
+
+	#[test]
+	fn to_hex_from_hex_works() {
+		let data = "Hello World!".to_string();
+
+		let hex_encoded_data = data.to_hex();
+		let decoded_data = String::from_hex(&hex_encoded_data).unwrap();
+
+		assert_eq!(data, decoded_data);
+	}
+}

--- a/core-primitives/utils/src/lib.rs
+++ b/core-primitives/utils/src/lib.rs
@@ -44,7 +44,7 @@ pub fn hex_encode(data: Vec<u8>) -> String {
 	hex_str
 }
 
-/// helper method for decoding hex
+/// Helper method for decoding hex.
 pub fn decode_hex<T: AsRef<[u8]>>(message: T) -> Result<Vec<u8>> {
 	let mut message = message.as_ref();
 	if message[..2] == [b'0', b'x'] {

--- a/core-primitives/utils/src/lib.rs
+++ b/core-primitives/utils/src/lib.rs
@@ -60,15 +60,11 @@ pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) -> Res
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use std::assert_matches::assert_matches;
 
 	#[test]
 	fn write_slice_and_whitespace_pad_returns_error_if_buffer_too_small() {
 		let mut writable = vec![0; 32];
 		let data = vec![1; 33];
-		assert_matches!(
-			write_slice_and_whitespace_pad(&mut writable, data),
-			Err(Error::InsufficientBufferSize(_, _))
-		);
+		assert!(write_slice_and_whitespace_pad(&mut writable, data).is_err());
 	}
 }

--- a/core-primitives/utils/src/lib.rs
+++ b/core-primitives/utils/src/lib.rs
@@ -70,11 +70,23 @@ pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) -> Res
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use codec::{Decode, Encode};
 
 	#[test]
 	fn write_slice_and_whitespace_pad_returns_error_if_buffer_too_small() {
 		let mut writable = vec![0; 32];
 		let data = vec![1; 33];
 		assert!(write_slice_and_whitespace_pad(&mut writable, data).is_err());
+	}
+
+	#[test]
+	fn hex_encode_decode_works() {
+		let data = "Hello World!".to_string();
+
+		let hex_encoded_data = hex_encode(data.encode());
+		let decoded_data =
+			String::decode(&mut decode_hex(hex_encoded_data).unwrap().as_slice()).unwrap();
+
+		assert_eq!(data, decoded_data);
 	}
 }

--- a/core-primitives/utils/src/lib.rs
+++ b/core-primitives/utils/src/lib.rs
@@ -1,0 +1,74 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! General utility functions.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+// re-export module to properly feature gate sgx and regular std environment
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+pub mod sgx_reexport_prelude {
+	pub use thiserror_sgx as thiserror;
+}
+
+mod error;
+
+pub use error::{Error, Result};
+
+use frame_support::ensure;
+use hex;
+use std::{string::String, vec::Vec};
+
+pub fn hex_encode(data: Vec<u8>) -> String {
+	let mut hex_str = hex::encode(data);
+	hex_str.insert_str(0, "0x");
+	hex_str
+}
+
+pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) -> Result<()> {
+	ensure!(
+		data.len() <= writable.len(),
+		Error::InsufficientBufferSize(writable.len(), data.len())
+	);
+	let (left, right) = writable.split_at_mut(data.len());
+	left.clone_from_slice(&data);
+	// fill the right side with whitespace
+	right.iter_mut().for_each(|x| *x = 0x20);
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::assert_matches::assert_matches;
+
+	#[test]
+	fn write_slice_and_whitespace_pad_returns_error_if_buffer_too_small() {
+		let mut writable = vec![0; 32];
+		let data = vec![1; 33];
+		assert_matches!(
+			write_slice_and_whitespace_pad(&mut writable, data),
+			Err(Error::InsufficientBufferSize(_, _))
+		);
+	}
+}

--- a/core-primitives/utils/src/lib.rs
+++ b/core-primitives/utils/src/lib.rs
@@ -44,6 +44,16 @@ pub fn hex_encode(data: Vec<u8>) -> String {
 	hex_str
 }
 
+/// helper method for decoding hex
+pub fn decode_hex<T: AsRef<[u8]>>(message: T) -> Result<Vec<u8>> {
+	let mut message = message.as_ref();
+	if message[..2] == [b'0', b'x'] {
+		message = &message[2..]
+	}
+	let decoded_message = hex::decode(message).map_err(Error::Hex)?;
+	Ok(decoded_message)
+}
+
 /// Fills a given buffer with data and fill the left over buffer space with white spaces.
 pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) -> Result<()> {
 	ensure!(

--- a/core-primitives/utils/src/lib.rs
+++ b/core-primitives/utils/src/lib.rs
@@ -33,9 +33,37 @@ pub mod sgx_reexport_prelude {
 
 mod error;
 
+use codec::{Decode, Encode};
 pub use error::{Error, Result};
 use frame_support::ensure;
 use std::{string::String, vec::Vec};
+
+/// Trait to encode a given value to a hex string, prefixed with "0x".
+pub trait ToHexPrefixed {
+	fn to_hex(&self) -> String;
+}
+
+impl<T: Encode> ToHexPrefixed for T {
+	fn to_hex(&self) -> String {
+		hex_encode(self.encode())
+	}
+}
+
+/// Trait to decode a hex string to a given output.
+pub trait FromHexPrefixed {
+	type Output;
+
+	fn from_hex(msg: &str) -> Result<Self::Output>;
+}
+
+impl<T: Decode> FromHexPrefixed for T {
+	type Output = T;
+
+	fn from_hex(msg: &str) -> Result<Self::Output> {
+		let byte_array = decode_hex(msg)?;
+		Decode::decode(&mut byte_array.as_slice()).map_err(Error::Codec)
+	}
+}
 
 /// Hex encodes given data and preappends a "0x".
 pub fn hex_encode(data: Vec<u8>) -> String {
@@ -86,6 +114,16 @@ mod tests {
 		let hex_encoded_data = hex_encode(data.encode());
 		let decoded_data =
 			String::decode(&mut decode_hex(hex_encoded_data).unwrap().as_slice()).unwrap();
+
+		assert_eq!(data, decoded_data);
+	}
+
+	#[test]
+	fn to_hex_from_hex_works() {
+		let data = "Hello World!".to_string();
+
+		let hex_encoded_data = data.to_hex();
+		let decoded_data = String::from_hex(&hex_encoded_data).unwrap();
 
 		assert_eq!(data, decoded_data);
 	}

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -5,28 +5,10 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-sgx = [
-    "sgx_tstd",
-    "sgx_types",
-    "jsonrpc-core_sgx",
-    "thiserror_sgx",
-    "itc-tls-websocket-server/sgx",
-]
-std = [
-    "jsonrpc-core",
-    "itp-types/std",
-    "thiserror",
-    "itc-tls-websocket-server/std",
-]
-
 [dependencies]
 # sgx dependencies
-sgx_types   = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_tstd    = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
 
 # no-std dependencies
 codec  = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -36,6 +18,7 @@ sp-runtime = { version = "6.0.0", default-features = false, git = "https://githu
 
 # internal dependencies
 itp-types = { path = "../../core-primitives/types", default-features = false }
+itp-utils = { path = "../../core-primitives/utils", default-features = false }
 itc-tls-websocket-server = { path = "../tls-websocket-server", default-features = false }
 
 # sgx enabled external libraries
@@ -45,3 +28,21 @@ thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linu
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
 jsonrpc-core = { version = "18", optional = true }
 thiserror = { version = "1.0", optional = true }
+
+[features]
+default = ["std"]
+sgx = [
+    "sgx_tstd",
+    "sgx_types",
+    "jsonrpc-core_sgx",
+    "thiserror_sgx",
+    "itp-utils/sgx",
+    "itc-tls-websocket-server/sgx",
+]
+std = [
+    "jsonrpc-core",
+    "itp-types/std",
+    "itp-utils/std",
+    "thiserror",
+    "itc-tls-websocket-server/std",
+]

--- a/core/direct-rpc-server/src/builders/rpc_response_builder.rs
+++ b/core/direct-rpc-server/src/builders/rpc_response_builder.rs
@@ -18,6 +18,7 @@
 use crate::builders::rpc_return_value_builder::RpcReturnValueBuilder;
 use codec::Encode;
 use itp_types::{RpcResponse, RpcReturnValue};
+use itp_utils::hex_encode;
 
 /// builder pattern for RpcResponse
 pub struct RpcResponseBuilder {
@@ -54,11 +55,12 @@ impl RpcResponseBuilder {
 	pub fn build(self) -> RpcResponse {
 		let id = self.maybe_id.unwrap_or(1u32);
 		let json_rpc = self.maybe_json_rpc.unwrap_or(String::from("json_rpc"));
-		let result = self
-			.maybe_result
-			.unwrap_or_else(|| RpcReturnValueBuilder::new().build())
-			.encode();
+		let result = hex_encode(
+			self.maybe_result
+				.unwrap_or_else(|| RpcReturnValueBuilder::new().build())
+				.encode(),
+		);
 
-		RpcResponse { hex_encode(result), jsonrpc: json_rpc, id }
+		RpcResponse { result, jsonrpc: json_rpc, id }
 	}
 }

--- a/core/direct-rpc-server/src/builders/rpc_response_builder.rs
+++ b/core/direct-rpc-server/src/builders/rpc_response_builder.rs
@@ -55,11 +55,10 @@ impl RpcResponseBuilder {
 	pub fn build(self) -> RpcResponse {
 		let id = self.maybe_id.unwrap_or(1u32);
 		let json_rpc = self.maybe_json_rpc.unwrap_or(String::from("json_rpc"));
-		let result = hex_encode(
-			self.maybe_result
-				.unwrap_or_else(|| RpcReturnValueBuilder::new().build())
-				.encode(),
-		);
+		let result = self
+			.maybe_result
+			.unwrap_or_else(|| RpcReturnValueBuilder::new().build())
+			.to_hex();
 
 		RpcResponse { result, jsonrpc: json_rpc, id }
 	}

--- a/core/direct-rpc-server/src/builders/rpc_response_builder.rs
+++ b/core/direct-rpc-server/src/builders/rpc_response_builder.rs
@@ -59,6 +59,6 @@ impl RpcResponseBuilder {
 			.unwrap_or_else(|| RpcReturnValueBuilder::new().build())
 			.encode();
 
-		RpcResponse { result, jsonrpc: json_rpc, id }
+		RpcResponse { hex_encode(result), jsonrpc: json_rpc, id }
 	}
 }

--- a/core/direct-rpc-server/src/builders/rpc_response_builder.rs
+++ b/core/direct-rpc-server/src/builders/rpc_response_builder.rs
@@ -16,9 +16,8 @@
 */
 
 use crate::builders::rpc_return_value_builder::RpcReturnValueBuilder;
-use codec::Encode;
 use itp_types::{RpcResponse, RpcReturnValue};
-use itp_utils::hex_encode;
+use itp_utils::ToHexPrefixed;
 
 /// builder pattern for RpcResponse
 pub struct RpcResponseBuilder {

--- a/core/direct-rpc-server/src/rpc_connection_registry.rs
+++ b/core/direct-rpc-server/src/rpc_connection_registry.rs
@@ -119,10 +119,6 @@ pub mod tests {
 	}
 
 	fn dummy_rpc_response() -> RpcResponse {
-		RpcResponse {
-			jsonrpc: String::new(),
-			result: Vec::<u8>::new(), // encoded RpcReturnValue
-			id: 1u32,
-		}
+		RpcResponse { jsonrpc: String::new(), result: Default::default(), id: 1u32 }
 	}
 }

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -19,7 +19,6 @@ use crate::{
 	response_channel::ResponseChannel, DirectRpcError, DirectRpcResult, RpcConnectionRegistry,
 	RpcHash, SendRpcResponse,
 };
-use codec::Decode;
 use itp_types::{DirectRequestStatus, RpcResponse, RpcReturnValue, TrustedOperationStatus};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use log::*;
@@ -84,7 +83,7 @@ where
 
 		let mut new_response = rpc_response.clone();
 
-		let result = RpcReturnValue::from_hex(&rpc_response.result)
+		let mut result = RpcReturnValue::from_hex(&rpc_response.result)
 			.map_err(|e| DirectRpcError::Other(Box::new(e)))?;
 
 		let do_watch = continue_watching(&status_update);

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -149,6 +149,7 @@ pub mod tests {
 		mocks::response_channel_mock::ResponseChannelMock,
 		rpc_connection_registry::ConnectionRegistry,
 	};
+	use codec::Encode;
 	use std::assert_matches::assert_matches;
 
 	type TestConnectionToken = u64;

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -19,9 +19,9 @@ use crate::{
 	response_channel::ResponseChannel, DirectRpcError, DirectRpcResult, RpcConnectionRegistry,
 	RpcHash, SendRpcResponse,
 };
-use codec::{Decode, Encode};
+use codec::Decode;
 use itp_types::{DirectRequestStatus, RpcResponse, RpcReturnValue, TrustedOperationStatus};
-use itp_utils::{decode_hex, hex_encode};
+use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use log::*;
 use std::{boxed::Box, sync::Arc, vec::Vec};
 
@@ -84,17 +84,15 @@ where
 
 		let mut new_response = rpc_response.clone();
 
-		let response_result =
-			decode_hex(rpc_response.result).map_err(|e| DirectRpcError::Other(Box::new(e)))?;
-		let mut result = RpcReturnValue::decode(&mut response_result.as_slice())
-			.map_err(DirectRpcError::EncodingError)?;
+		let result = RpcReturnValue::from_hex(&rpc_response.result)
+			.map_err(|e| DirectRpcError::Other(Box::new(e)))?;
 
 		let do_watch = continue_watching(&status_update);
 
 		// update response
 		result.do_watch = do_watch;
 		result.status = DirectRequestStatus::TrustedOperationStatus(status_update);
-		new_response.result = hex_encode(result.encode());
+		new_response.result = result.to_hex();
 
 		self.encode_and_send_response(connection_token, &new_response)?;
 
@@ -122,7 +120,7 @@ where
 		let result = RpcReturnValue::new(state_encoded, false, submitted);
 
 		// update response
-		response.result = hex_encode(result.encode());
+		response.result = result.to_hex();
 
 		self.encode_and_send_response(connection_token, &response)?;
 

--- a/core/direct-rpc-server/src/rpc_watch_extractor.rs
+++ b/core/direct-rpc-server/src/rpc_watch_extractor.rs
@@ -52,7 +52,8 @@ where
 	type Hash = Hash;
 
 	fn must_be_watched(&self, rpc_response: &RpcResponse) -> DirectRpcResult<Option<Self::Hash>> {
-		let rpc_return_value = RpcReturnValue::decode(&mut rpc_response.result.as_slice())
+		let response_result = decode_hex(rpc_response.result)?;
+		let rpc_return_value = RpcReturnValue::decode(&mut response_result.as_slice())
 			.map_err(DirectRpcError::EncodingError)?;
 
 		if !rpc_return_value.do_watch {
@@ -84,7 +85,7 @@ pub mod tests {
 	fn invalid_rpc_response_returns_encoding_error() {
 		let watch_extractor = RpcWatchExtractor::<String>::new();
 		let rpc_response =
-			RpcResponse { id: 1u32, jsonrpc: String::from("json"), result: vec![1u8, 2u8, 3u8] };
+			RpcResponse { id: 1u32, jsonrpc: String::from("json"), result: "hello".to_string() };
 
 		assert_matches!(
 			watch_extractor.must_be_watched(&rpc_response),

--- a/core/direct-rpc-server/src/rpc_watch_extractor.rs
+++ b/core/direct-rpc-server/src/rpc_watch_extractor.rs
@@ -18,7 +18,7 @@
 use crate::{DetermineWatch, DirectRpcError, DirectRpcResult, RpcHash};
 use codec::Decode;
 use itp_types::{DirectRequestStatus, RpcResponse, RpcReturnValue};
-use itp_utils::decode_hex;
+use itp_utils::FromHexPrefixed;
 use std::{boxed::Box, marker::PhantomData};
 
 pub struct RpcWatchExtractor<Hash>
@@ -53,10 +53,8 @@ where
 	type Hash = Hash;
 
 	fn must_be_watched(&self, rpc_response: &RpcResponse) -> DirectRpcResult<Option<Self::Hash>> {
-		let response_result = decode_hex(rpc_response.result.clone())
+		let rpc_return_value = RpcReturnValue::from_hex(&rpc_response.result)
 			.map_err(|e| DirectRpcError::Other(Box::new(e)))?;
-		let rpc_return_value = RpcReturnValue::decode(&mut response_result.as_slice())
-			.map_err(DirectRpcError::EncodingError)?;
 
 		if !rpc_return_value.do_watch {
 			return Ok(None)

--- a/core/direct-rpc-server/src/rpc_ws_handler.rs
+++ b/core/direct-rpc-server/src/rpc_ws_handler.rs
@@ -218,9 +218,7 @@ pub mod tests {
 		ReturnValue: Encode + Send + Sync + 'static,
 	{
 		let mut io_handler = IoHandler::new();
-		io_handler.add_sync_method(method_name, move |_: Params| {
-			Ok(json!(hex_encode(return_value.encode())))
-		});
+		io_handler.add_sync_method(method_name, move |_: Params| Ok(json!(return_value.to_hex())));
 		io_handler
 	}
 }

--- a/core/direct-rpc-server/src/rpc_ws_handler.rs
+++ b/core/direct-rpc-server/src/rpc_ws_handler.rs
@@ -100,6 +100,7 @@ pub mod tests {
 	use codec::Encode;
 	use itc_tls_websocket_server::ConnectionToken;
 	use itp_types::{DirectRequestStatus, RpcReturnValue};
+	use itp_utils::hex_encode;
 	use jsonrpc_core::Params;
 	use serde_json::json;
 
@@ -222,7 +223,9 @@ pub mod tests {
 		ReturnValue: Encode + Send + Sync + 'static,
 	{
 		let mut io_handler = IoHandler::new();
-		io_handler.add_sync_method(method_name, move |_: Params| Ok(json!(return_value.encode())));
+		io_handler.add_sync_method(method_name, move |_: Params| {
+			Ok(json!(hex_encode(return_value.encode())))
+		});
 		io_handler
 	}
 }

--- a/core/direct-rpc-server/src/rpc_ws_handler.rs
+++ b/core/direct-rpc-server/src/rpc_ws_handler.rs
@@ -95,7 +95,7 @@ pub mod tests {
 	use codec::Encode;
 	use itc_tls_websocket_server::ConnectionToken;
 	use itp_types::{DirectRequestStatus, RpcReturnValue};
-	use itp_utils::hex_encode;
+	use itp_utils::ToHexPrefixed;
 	use jsonrpc_core::Params;
 	use serde_json::json;
 

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -21,7 +21,7 @@ use crate::error::Result;
 use codec::{Decode, Encode};
 use ita_stf::{AccountId, TrustedCallSigned};
 use itp_settings::node::{CALL_WORKER, SHIELD_FUNDS, TEEREX_MODULE};
-use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCrypto};
+use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCryptoDecrypt};
 use itp_stf_executor::traits::{StatePostProcessing, StfExecuteShieldFunds, StfExecuteTrustedCall};
 use itp_types::{CallWorkerFn, OpaqueCall, ShardIdentifier, ShieldFundsFn, H256};
 use log::*;
@@ -51,7 +51,8 @@ pub struct IndirectCallsExecutor<ShieldingKeyRepository, StfExecutor> {
 impl<ShieldingKeyRepository, StfExecutor> IndirectCallsExecutor<ShieldingKeyRepository, StfExecutor>
 where
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
+	<ShieldingKeyRepository as AccessKey>::KeyType:
+		ShieldingCryptoDecrypt<Error = itp_sgx_crypto::Error>,
 	StfExecutor: StfExecuteTrustedCall + StfExecuteShieldFunds,
 {
 	pub fn new(authority: Arc<ShieldingKeyRepository>, stf_executor: Arc<StfExecutor>) -> Self {
@@ -95,7 +96,8 @@ impl<ShieldingKeyRepository, StfExecutor> ExecuteIndirectCalls
 	for IndirectCallsExecutor<ShieldingKeyRepository, StfExecutor>
 where
 	ShieldingKeyRepository: AccessKey,
-	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCrypto<Error = itp_sgx_crypto::Error>,
+	<ShieldingKeyRepository as AccessKey>::KeyType:
+		ShieldingCryptoDecrypt<Error = itp_sgx_crypto::Error>,
 	StfExecutor: StfExecuteTrustedCall + StfExecuteShieldFunds,
 {
 	fn execute_indirect_calls_in_extrinsics<ParentchainBlock>(

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -20,6 +20,7 @@ ws = { version = "0.9.1", features = ["ssl"] }
 
 # local
 itp-types = { path = "../../core-primitives/types" }
+itp-utils = { path = "../../core-primitives/utils" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/core/rpc-client/src/direct_client.rs
+++ b/core/rpc-client/src/direct_client.rs
@@ -82,8 +82,10 @@ impl DirectApi for DirectClient {
 	}
 
 	fn get_rsa_pubkey(&self) -> Result<Rsa3072PubKey> {
-		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("author_getShieldingKey".to_string(), None);
+		let jsonrpc_call: String = RpcRequest::compose_jsonrpc_call(
+			"author_getShieldingKey".to_string(),
+			Default::default(),
+		)?;
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;
@@ -97,7 +99,7 @@ impl DirectApi for DirectClient {
 
 	fn get_mu_ra_url(&self) -> Result<String> {
 		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("author_getMuRaUrl".to_string(), None);
+			RpcRequest::compose_jsonrpc_call("author_getMuRaUrl".to_string(), Default::default())?;
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;
@@ -109,8 +111,10 @@ impl DirectApi for DirectClient {
 	}
 
 	fn get_untrusted_worker_url(&self) -> Result<String> {
-		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("author_getUntrustedUrl".to_string(), None);
+		let jsonrpc_call: String = RpcRequest::compose_jsonrpc_call(
+			"author_getUntrustedUrl".to_string(),
+			Default::default(),
+		)?;
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;
@@ -123,7 +127,7 @@ impl DirectApi for DirectClient {
 
 	fn get_state_metadata(&self) -> Result<RuntimeMetadataPrefixed> {
 		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("state_getMetadata".to_string(), None);
+			RpcRequest::compose_jsonrpc_call("state_getMetadata".to_string(), Default::default())?;
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;

--- a/core/rpc-client/src/direct_client.rs
+++ b/core/rpc-client/src/direct_client.rs
@@ -82,7 +82,7 @@ impl DirectApi for DirectClient {
 
 	fn get_rsa_pubkey(&self) -> Result<Rsa3072PubKey> {
 		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("author_getShieldingKey".to_string(), vec![]);
+			RpcRequest::compose_jsonrpc_call("author_getShieldingKey".to_string(), None);
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;
@@ -96,7 +96,7 @@ impl DirectApi for DirectClient {
 
 	fn get_mu_ra_url(&self) -> Result<String> {
 		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("author_getMuRaUrl".to_string(), vec![]);
+			RpcRequest::compose_jsonrpc_call("author_getMuRaUrl".to_string(), None);
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;
@@ -109,7 +109,7 @@ impl DirectApi for DirectClient {
 
 	fn get_untrusted_worker_url(&self) -> Result<String> {
 		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("author_getUntrustedUrl".to_string(), vec![]);
+			RpcRequest::compose_jsonrpc_call("author_getUntrustedUrl".to_string(), None);
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;
@@ -122,14 +122,15 @@ impl DirectApi for DirectClient {
 
 	fn get_state_metadata(&self) -> Result<RuntimeMetadataPrefixed> {
 		let jsonrpc_call: String =
-			RpcRequest::compose_jsonrpc_call("state_getMetadata".to_string(), vec![]);
+			RpcRequest::compose_jsonrpc_call("state_getMetadata".to_string(), None);
 
 		// Send json rpc call to ws server.
 		let response_str = self.get(&jsonrpc_call)?;
 
 		//Decode rpc response
 		let rpc_response: RpcResponse = serde_json::from_str(&response_str)?;
-		let rpc_return_value = RpcReturnValue::decode(&mut rpc_response.result.as_slice())?;
+		let response_result = decode_hex(rpc_response.result)?;
+		let rpc_return_value = RpcReturnValue::decode(&mut response_result.as_slice())?;
 
 		//Decode Metadata
 		let metadata = RuntimeMetadataPrefixed::decode(&mut rpc_return_value.value.as_slice())?;
@@ -145,7 +146,8 @@ impl DirectApi for DirectClient {
 
 fn decode_from_rpc_response(json_rpc_response: &str) -> Result<String> {
 	let rpc_response: RpcResponse = serde_json::from_str(json_rpc_response)?;
-	let rpc_return_value = RpcReturnValue::decode(&mut rpc_response.result.as_slice())?;
+	let response_result = decode_hex(rpc_response.result)?;
+	let rpc_return_value = RpcReturnValue::decode(&mut response_result.as_slice())?;
 	let response_message = String::decode(&mut rpc_return_value.value.as_slice())?;
 	match rpc_return_value.status {
 		DirectRequestStatus::Ok => Ok(response_message),

--- a/core/rpc-server/Cargo.toml
+++ b/core/rpc-server/Cargo.toml
@@ -16,6 +16,7 @@ parity-scale-codec = "3.0.0"
 # local
 itp-enclave-api = { path = "../../core-primitives/enclave-api" }
 itp-types = { path = "../../core-primitives/types" }
+itp-utils = { path = "../../core-primitives/utils" }
 its-peer-fetch = { path = "../../sidechain/peer-fetch" }
 its-primitives = { path = "../../sidechain/primitives" }
 its-storage = { path = "../../sidechain/storage" }

--- a/core/rpc-server/src/lib.rs
+++ b/core/rpc-server/src/lib.rs
@@ -17,7 +17,7 @@
 
 use itp_enclave_api::direct_request::DirectRequest;
 use itp_types::RpcRequest;
-use itp_utils::hex_encode;
+use itp_utils::ToHexPrefixed;
 use its_peer_fetch::block_fetch_server::BlockFetchServerModuleBuilder;
 use its_primitives::{constants::RPC_METHOD_NAME_IMPORT_BLOCKS, types::SignedBlock};
 use its_storage::interface::FetchBlocks;
@@ -26,7 +26,6 @@ use jsonrpsee::{
 	ws_server::{RpcModule, WsServerBuilder},
 };
 use log::debug;
-use parity_scale_codec::Encode;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::net::ToSocketAddrs;
 
@@ -55,7 +54,7 @@ where
 
 			let enclave_req = RpcRequest::compose_jsonrpc_call(
 				RPC_METHOD_NAME_IMPORT_BLOCKS.into(),
-				vec![hex_encode(params.one::<Vec<SignedBlock>>()?.encode())],
+				vec![params.one::<Vec<SignedBlock>>()?.to_hex()],
 			)
 			.unwrap();
 

--- a/core/rpc-server/src/lib.rs
+++ b/core/rpc-server/src/lib.rs
@@ -17,6 +17,7 @@
 
 use itp_enclave_api::direct_request::DirectRequest;
 use itp_types::RpcRequest;
+use itp_utils::hex_encode;
 use its_peer_fetch::block_fetch_server::BlockFetchServerModuleBuilder;
 use its_primitives::{constants::RPC_METHOD_NAME_IMPORT_BLOCKS, types::SignedBlock};
 use its_storage::interface::FetchBlocks;
@@ -54,7 +55,7 @@ where
 
 			let enclave_req = RpcRequest::compose_jsonrpc_call(
 				RPC_METHOD_NAME_IMPORT_BLOCKS.into(),
-				params.one::<Vec<SignedBlock>>()?.encode(),
+				Some(hex_encode(params.one::<Vec<SignedBlock>>()?.encode())),
 			);
 
 			enclave

--- a/core/rpc-server/src/lib.rs
+++ b/core/rpc-server/src/lib.rs
@@ -55,8 +55,9 @@ where
 
 			let enclave_req = RpcRequest::compose_jsonrpc_call(
 				RPC_METHOD_NAME_IMPORT_BLOCKS.into(),
-				Some(hex_encode(params.one::<Vec<SignedBlock>>()?.encode())),
-			);
+				vec![hex_encode(params.one::<Vec<SignedBlock>>()?.encode())],
+			)
+			.unwrap();
 
 			enclave
 				.rpc(enclave_req.as_bytes().to_vec())

--- a/core/rpc-server/src/mock.rs
+++ b/core/rpc-server/src/mock.rs
@@ -28,7 +28,12 @@ pub struct TestEnclave;
 
 impl DirectRequest for TestEnclave {
 	fn rpc(&self, _request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
-		Ok(RpcResponse { jsonrpc: "mock_response".into(), result: "null".encode(), id: 1 }.encode())
+		Ok(RpcResponse {
+			jsonrpc: "mock_response".into(),
+			result: hex_encode("null".encode()),
+			id: 1,
+		}
+		.encode())
 	}
 }
 

--- a/core/rpc-server/src/mock.rs
+++ b/core/rpc-server/src/mock.rs
@@ -17,6 +17,7 @@
 
 use itp_enclave_api::{direct_request::DirectRequest, EnclaveResult};
 use itp_types::RpcResponse;
+use itp_utils::hex_encode;
 use its_primitives::{
 	traits::ShardIdentifierFor,
 	types::{BlockHash, SignedBlock, SignedBlock as SignedSidechainBlock},

--- a/core/rpc-server/src/mock.rs
+++ b/core/rpc-server/src/mock.rs
@@ -17,7 +17,7 @@
 
 use itp_enclave_api::{direct_request::DirectRequest, EnclaveResult};
 use itp_types::RpcResponse;
-use itp_utils::hex_encode;
+use itp_utils::ToHexPrefixed;
 use its_primitives::{
 	traits::ShardIdentifierFor,
 	types::{BlockHash, SignedBlock, SignedBlock as SignedSidechainBlock},
@@ -29,12 +29,7 @@ pub struct TestEnclave;
 
 impl DirectRequest for TestEnclave {
 	fn rpc(&self, _request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
-		Ok(RpcResponse {
-			jsonrpc: "mock_response".into(),
-			result: hex_encode("null".encode()),
-			id: 1,
-		}
-		.encode())
+		Ok(RpcResponse { jsonrpc: "mock_response".into(), result: "null".to_hex(), id: 1 }.encode())
 	}
 }
 

--- a/docs/trusted-rpc-interface.md
+++ b/docs/trusted-rpc-interface.md
@@ -46,8 +46,8 @@ The current implementation of the [`TrustedCall`](https://github.com/integritee-
 
 #### RPC Methods
 The following rpc calls are available:
-  - `author_submitAndWatchExtrinsic`, params: `Vec<u8>`(encoded `Request`). Sends an extrinsic (`Call` or `Getter`). The server will keep the wss connection open and send status updates.
-  - `author_submitExtrinsic`, params: `Vec<u8>` (encoded `Request`). Sends an extrinsic (`Call` or `Getter`). The server will close the connection immediately after the first response.
+  - `author_submitAndWatchExtrinsic`, params: `Vec<String>`(hex encoded `Request`). Sends an extrinsic (`Call` or `Getter`). The server will keep the wss connection open and send status updates.
+  - `author_submitExtrinsic`, params: `Vec<String>` (hex encoded `Request`). Sends an extrinsic (`Call` or `Getter`). The server will close the connection immediately after the first response.
    - `author_pendingExtrinsics`, params: `Vec<String>` (Vector of base58 shards as strings). Returns all pending operations of the listed shards in the top pool.
 ## Rpc Response
 The server response is a json rpc response containing a [substrate codec](https://docs.substrate.io/v3/advanced/scale-codec/) encoded [`RpcReturnValue`](https://github.com/integritee-network/worker/blob/17e9776cbf09d0a1dd765546f27fc4d3c7bfefc4/core-primitives/types/src/rpc.rs#L8-L14) as param. It has the following parameters:

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
  "ac-primitives",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -31,8 +31,8 @@ source = "git+https://github.com/scs/substrate-api-client?branch=polkadot-v0.9.2
 dependencies = [
  "hex",
  "parity-scale-codec",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -532,7 +532,7 @@ dependencies = [
  "cid",
  "derive_more",
  "env_logger",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "hex",
  "httparse",
  "ipfs-unixfs",
@@ -559,6 +559,7 @@ dependencies = [
  "itp-top-pool",
  "itp-top-pool-author",
  "itp-types",
+ "itp-utils",
  "its-sidechain",
  "jsonrpc-core",
  "lazy_static",
@@ -587,11 +588,11 @@ dependencies = [
  "sgx_tstd",
  "sgx_tunittest",
  "sgx_types",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "substrate-api-client",
@@ -659,15 +660,15 @@ name = "frame-executive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -684,27 +685,65 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
 dependencies = [
  "bitflags",
  "frame-metadata",
- "frame-support-procedural",
+ "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "impl-trait-for-tuples",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "smallvec 1.8.0",
- "sp-arithmetic",
- "sp-core",
- "sp-core-hashing-proc-macro",
- "sp-inherents",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "tt-call",
+]
+
+[[package]]
+name = "frame-support"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
+dependencies = [
+ "bitflags",
+ "frame-metadata",
+ "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "impl-trait-for-tuples",
+ "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "smallvec 1.8.0",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-io",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "tt-call",
+]
+
+[[package]]
+name = "frame-support-procedural"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "Inflector",
+ "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "proc-macro2",
+ "quote 1.0.18",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -713,7 +752,19 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "Inflector",
- "frame-support-procedural-tools",
+ "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "proc-macro2",
+ "quote 1.0.18",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "frame-support-procedural-tools"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "proc-macro-crate",
  "proc-macro2",
  "quote 1.0.18",
  "syn 1.0.93",
@@ -724,8 +775,18 @@ name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support-procedural-tools-derive",
+ "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.18",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "frame-support-procedural-tools-derive"
+version = "3.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
  "proc-macro2",
  "quote 1.0.18",
  "syn 1.0.93",
@@ -746,13 +807,13 @@ name = "frame-system"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
 ]
@@ -1115,7 +1176,7 @@ version = "0.8.0"
 dependencies = [
  "derive_more",
  "env_logger",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "itp-settings",
  "itp-storage",
@@ -1128,10 +1189,10 @@ dependencies = [
  "sgx-externalities",
  "sgx-runtime",
  "sgx_tstd",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -1146,7 +1207,7 @@ dependencies = [
  "serde_json 1.0.81",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1169,7 +1230,7 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1189,7 +1250,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
  "tiny-keccak",
 ]
@@ -1210,8 +1271,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "thiserror 1.0.9",
 ]
@@ -1235,10 +1296,10 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-trie",
  "thiserror 1.0.9",
 ]
@@ -1288,7 +1349,7 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1320,8 +1381,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
  "thiserror 1.0.9",
 ]
@@ -1345,8 +1406,8 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1381,7 +1442,7 @@ dependencies = [
  "sgx_rand",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -1407,8 +1468,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1430,7 +1491,7 @@ dependencies = [
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1440,12 +1501,12 @@ version = "0.8.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "hash-db",
  "parity-scale-codec",
  "sgx_tstd",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-trie",
  "thiserror 1.0.9",
@@ -1478,8 +1539,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1508,9 +1569,9 @@ dependencies = [
  "serde 1.0.137",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1535,8 +1596,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1551,10 +1612,20 @@ dependencies = [
  "serde 1.0.137",
  "serde_json 1.0.81",
  "sgx_tstd",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
+]
+
+[[package]]
+name = "itp-utils"
+version = "0.8.0"
+dependencies = [
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "hex",
+ "sgx_tstd",
+ "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -1575,8 +1646,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1585,7 +1656,7 @@ name = "its-consensus-aura"
 version = "0.8.0"
 dependencies = [
  "finality-grandpa",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "ita-stf",
  "itc-parentchain-block-import-dispatcher",
  "itp-enclave-metrics",
@@ -1606,8 +1677,8 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -1624,7 +1695,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1644,7 +1715,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sp-consensus-slots",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -1652,8 +1723,8 @@ name = "its-primitives"
 version = "0.8.0"
 dependencies = [
  "parity-scale-codec",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1670,7 +1741,7 @@ dependencies = [
  "rust-base58",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -1692,7 +1763,7 @@ dependencies = [
 name = "its-state"
 version = "0.8.0"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "itp-storage",
  "its-primitives",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
@@ -1700,7 +1771,7 @@ dependencies = [
  "serde 1.0.137",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
@@ -1722,8 +1793,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
 ]
 
@@ -1732,14 +1803,14 @@ name = "its-validateer-fetch"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "itp-ocall-api",
  "itp-storage",
  "itp-teerex-storage",
  "itp-types",
  "parity-scale-codec",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
@@ -2100,14 +2171,14 @@ name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-consensus-aura",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2116,13 +2187,13 @@ name = "pallet-authorship"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-authorship",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2131,12 +2202,12 @@ name = "pallet-balances"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2145,20 +2216,20 @@ name = "pallet-grandpa"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-finality-grandpa",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-session",
- "sp-staking",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2167,14 +2238,14 @@ name = "pallet-parentchain"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.20#b97001102f9bd10a34b82878e9946074616b65c5"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2183,12 +2254,12 @@ name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2197,18 +2268,18 @@ name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "impl-trait-for-tuples",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-session",
- "sp-staking",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2217,12 +2288,12 @@ name = "pallet-sudo"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2231,13 +2302,13 @@ name = "pallet-timestamp"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -2247,14 +2318,14 @@ name = "pallet-transaction-payment"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "smallvec 1.8.0",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2266,7 +2337,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -2893,7 +2964,7 @@ version = "0.8.0"
 source = "git+https://github.com/integritee-network/sgx-runtime?branch=master#d131a9c98446edd3dfd812f87a484ab59c3b268f"
 dependencies = [
  "frame-executive",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-aura",
@@ -2910,10 +2981,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core",
- "sp-inherents",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-offchain",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-session",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-transaction-pool",
@@ -3214,8 +3285,8 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
 ]
@@ -3235,13 +3306,39 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-io",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+]
+
+[[package]]
+name = "sp-application-crypto"
+version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "integer-sqrt",
+ "num-traits 0.2.15",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3253,7 +3350,7 @@ dependencies = [
  "num-traits 0.2.15",
  "parity-scale-codec",
  "scale-info",
- "sp-debug-derive",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "static_assertions",
 ]
@@ -3264,8 +3361,8 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3276,8 +3373,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3289,10 +3386,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-consensus-slots",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -3304,10 +3401,34 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic",
- "sp-runtime",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
+]
+
+[[package]]
+name = "sp-core"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "bitflags",
+ "byteorder 1.4.3",
+ "hash-db",
+ "hash256-std-hasher",
+ "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "num-traits 0.2.15",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "primitive-types",
+ "scale-info",
+ "secrecy",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "ss58-registry",
+ "zeroize",
 ]
 
 [[package]]
@@ -3333,13 +3454,27 @@ dependencies = [
  "schnorrkel",
  "secp256k1",
  "secrecy",
- "sp-core-hashing",
- "sp-debug-derive",
- "sp-runtime-interface",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "ss58-registry",
  "zeroize",
+]
+
+[[package]]
+name = "sp-core-hashing"
+version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "blake2",
+ "byteorder 1.4.3",
+ "digest 0.10.3",
+ "sha2 0.10.2",
+ "sha3 0.10.1",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "twox-hash",
 ]
 
 [[package]]
@@ -3359,11 +3494,32 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.18",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "sp-core-hashing-proc-macro"
+version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.18",
- "sp-core-hashing",
+ "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "syn 1.0.93",
+]
+
+[[package]]
+name = "sp-debug-derive"
+version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.18",
  "syn 1.0.93",
 ]
 
@@ -3386,10 +3542,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -3399,7 +3566,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3416,11 +3583,11 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core",
- "sp-runtime-interface",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "tracing",
  "tracing-core",
 ]
@@ -3431,8 +3598,28 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-core",
- "sp-runtime",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-runtime"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "either",
+ "hash256-std-hasher",
+ "impl-trait-for-tuples",
+ "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "parity-scale-codec",
+ "parity-util-mem",
+ "paste",
+ "scale-info",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-io",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -3448,11 +3635,27 @@ dependencies = [
  "parity-util-mem",
  "paste",
  "scale-info",
- "sp-application-crypto",
- "sp-arithmetic",
- "sp-core",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-io",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-runtime-interface"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3463,12 +3666,24 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-runtime-interface-proc-macro",
+ "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage",
- "sp-tracing",
- "sp-wasm-interface",
+ "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "static_assertions",
+]
+
+[[package]]
+name = "sp-runtime-interface-proc-macro"
+version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "Inflector",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.18",
+ "syn 1.0.93",
 ]
 
 [[package]]
@@ -3491,9 +3706,20 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core",
- "sp-staking",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-staking"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -3503,7 +3729,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3515,7 +3741,23 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#d602397a
 [[package]]
 name = "sp-std"
 version = "4.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+
+[[package]]
+name = "sp-std"
+version = "4.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
+
+[[package]]
+name = "sp-storage"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "ref-cast",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+]
 
 [[package]]
 name = "sp-storage"
@@ -3524,7 +3766,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "ref-cast",
- "sp-debug-derive",
+ "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3535,9 +3777,20 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents",
- "sp-runtime",
+ "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "5.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "parity-scale-codec",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -3557,7 +3810,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-runtime",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
 [[package]]
@@ -3569,7 +3822,7 @@ dependencies = [
  "memory-db",
  "parity-scale-codec",
  "scale-info",
- "sp-core",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "trie-db",
  "trie-root",
@@ -3582,8 +3835,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core-hashing-proc-macro",
- "sp-runtime",
+ "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version-proc-macro",
 ]
@@ -3597,6 +3850,16 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.18",
  "syn 1.0.93",
+]
+
+[[package]]
+name = "sp-wasm-interface"
+version = "6.0.0"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
+dependencies = [
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -3643,12 +3906,12 @@ dependencies = [
  "ac-compose-macros",
  "ac-primitives",
  "frame-metadata",
- "frame-support",
+ "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "hex",
  "parity-scale-codec",
- "sp-application-crypto",
- "sp-core",
- "sp-runtime",
+ "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1737,6 +1737,7 @@ version = "0.8.0"
 dependencies = [
  "itp-top-pool-author",
  "itp-types",
+ "itp-utils",
  "its-primitives",
  "jsonrpc-core",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1590,6 +1590,7 @@ dependencies = [
  "itp-test",
  "itp-top-pool",
  "itp-types",
+ "itp-utils",
  "jsonrpc-core",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
@@ -1624,7 +1625,10 @@ version = "0.8.0"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "hex",
+ "parity-scale-codec",
+ "sgx_crypto_helper",
  "sgx_tstd",
+ "sgx_types",
  "thiserror 1.0.9",
 ]
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1431,8 +1431,10 @@ version = "0.8.0"
 dependencies = [
  "aes",
  "derive_more",
+ "hex",
  "itp-settings",
  "itp-sgx-io",
+ "itp-utils",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "ofb",
  "parity-scale-codec",
@@ -1625,7 +1627,6 @@ version = "0.8.0"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "hex",
- "itp-sgx-crypto",
  "parity-scale-codec",
  "sgx_tstd",
  "thiserror 1.0.9",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1625,10 +1625,9 @@ version = "0.8.0"
 dependencies = [
  "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
  "hex",
+ "itp-sgx-crypto",
  "parity-scale-codec",
- "sgx_crypto_helper",
  "sgx_tstd",
- "sgx_types",
  "thiserror 1.0.9",
 ]
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1201,6 +1201,7 @@ version = "0.8.0"
 dependencies = [
  "itc-tls-websocket-server",
  "itp-types",
+ "itp-utils",
  "jsonrpc-core",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -20,7 +20,7 @@ dependencies = [
  "ac-primitives",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -31,8 +31,8 @@ source = "git+https://github.com/scs/substrate-api-client?branch=polkadot-v0.9.2
 dependencies = [
  "hex",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -532,7 +532,7 @@ dependencies = [
  "cid",
  "derive_more",
  "env_logger",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "hex",
  "httparse",
  "ipfs-unixfs",
@@ -588,11 +588,11 @@ dependencies = [
  "sgx_tstd",
  "sgx_tunittest",
  "sgx_types",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-finality-grandpa",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
  "substrate-api-client",
@@ -660,15 +660,15 @@ name = "frame-executive"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -685,86 +685,36 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "bitflags",
- "frame-metadata",
- "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "impl-trait-for-tuples",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "smallvec 1.8.0",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "tt-call",
-]
-
-[[package]]
-name = "frame-support"
-version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "bitflags",
  "frame-metadata",
- "frame-support-procedural 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support-procedural",
  "impl-trait-for-tuples",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "paste",
  "scale-info",
  "smallvec 1.8.0",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-core-hashing-proc-macro",
+ "sp-inherents",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing",
  "tt-call",
 ]
 
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "Inflector",
- "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "proc-macro2",
- "quote 1.0.18",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "Inflector",
- "frame-support-procedural-tools 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "proc-macro2",
- "quote 1.0.18",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "proc-macro-crate",
+ "frame-support-procedural-tools",
  "proc-macro2",
  "quote 1.0.18",
  "syn 1.0.93",
@@ -775,18 +725,8 @@ name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support-procedural-tools-derive 3.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.18",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
  "proc-macro2",
  "quote 1.0.18",
  "syn 1.0.93",
@@ -807,13 +747,13 @@ name = "frame-system"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
 ]
@@ -1176,7 +1116,7 @@ version = "0.8.0"
 dependencies = [
  "derive_more",
  "env_logger",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "itp-settings",
  "itp-storage",
@@ -1189,10 +1129,10 @@ dependencies = [
  "sgx-externalities",
  "sgx-runtime",
  "sgx_tstd",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1208,7 +1148,7 @@ dependencies = [
  "serde_json 1.0.81",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1231,7 +1171,7 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1251,7 +1191,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.9",
  "tiny-keccak",
 ]
@@ -1272,8 +1212,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "substrate-api-client",
  "thiserror 1.0.9",
 ]
@@ -1297,10 +1237,10 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-finality-grandpa",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-trie",
  "thiserror 1.0.9",
 ]
@@ -1350,7 +1290,7 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1382,8 +1322,8 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "substrate-api-client",
  "thiserror 1.0.9",
 ]
@@ -1407,8 +1347,8 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1443,7 +1383,7 @@ dependencies = [
  "sgx_rand",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
 ]
 
 [[package]]
@@ -1469,8 +1409,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1492,7 +1432,7 @@ dependencies = [
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "thiserror 1.0.9",
 ]
 
@@ -1502,12 +1442,12 @@ version = "0.8.0"
 dependencies = [
  "derive_more",
  "frame-metadata",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "hash-db",
  "parity-scale-codec",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-trie",
  "thiserror 1.0.9",
@@ -1540,8 +1480,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1570,9 +1510,9 @@ dependencies = [
  "serde 1.0.137",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1598,8 +1538,8 @@ dependencies = [
  "sgx_tcrypto_helper",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1614,8 +1554,8 @@ dependencies = [
  "serde 1.0.137",
  "serde_json 1.0.81",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "substrate-api-client",
 ]
@@ -1624,7 +1564,7 @@ dependencies = [
 name = "itp-utils"
 version = "0.8.0"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "frame-support",
  "hex",
  "parity-scale-codec",
  "sgx_tstd",
@@ -1649,8 +1589,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1659,7 +1599,7 @@ name = "its-consensus-aura"
 version = "0.8.0"
 dependencies = [
  "finality-grandpa",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "ita-stf",
  "itc-parentchain-block-import-dispatcher",
  "itp-enclave-metrics",
@@ -1680,8 +1620,8 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1698,7 +1638,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1718,7 +1658,7 @@ dependencies = [
  "parity-scale-codec",
  "sgx_tstd",
  "sp-consensus-slots",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -1726,8 +1666,8 @@ name = "its-primitives"
 version = "0.8.0"
 dependencies = [
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -1745,7 +1685,7 @@ dependencies = [
  "rust-base58",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
 ]
 
 [[package]]
@@ -1767,7 +1707,7 @@ dependencies = [
 name = "its-state"
 version = "0.8.0"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "itp-storage",
  "its-primitives",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
@@ -1775,7 +1715,7 @@ dependencies = [
  "serde 1.0.137",
  "sgx-externalities",
  "sgx_tstd",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.9",
@@ -1797,8 +1737,8 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "thiserror 1.0.9",
 ]
 
@@ -1807,14 +1747,14 @@ name = "its-validateer-fetch"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "itp-ocall-api",
  "itp-storage",
  "itp-teerex-storage",
  "itp-types",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "thiserror 1.0.31",
 ]
@@ -2175,14 +2115,14 @@ name = "pallet-aura"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
  "sp-consensus-aura",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2191,13 +2131,13 @@ name = "pallet-authorship"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "sp-authorship",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2206,12 +2146,12 @@ name = "pallet-balances"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2220,20 +2160,20 @@ name = "pallet-grandpa"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
  "sp-finality-grandpa",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-session",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2242,14 +2182,14 @@ name = "pallet-parentchain"
 version = "0.9.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.20#b97001102f9bd10a34b82878e9946074616b65c5"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2258,12 +2198,12 @@ name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "safe-mix",
  "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2272,18 +2212,18 @@ name = "pallet-session"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-session",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2292,12 +2232,12 @@ name = "pallet-sudo"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2306,13 +2246,13 @@ name = "pallet-timestamp"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "scale-info",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -2322,14 +2262,14 @@ name = "pallet-transaction-payment"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
  "smallvec 1.8.0",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -2341,7 +2281,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "sp-api",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -2968,7 +2908,7 @@ version = "0.8.0"
 source = "git+https://github.com/integritee-network/sgx-runtime?branch=master#d131a9c98446edd3dfd812f87a484ab59c3b268f"
 dependencies = [
  "frame-executive",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-aura",
@@ -2985,10 +2925,10 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-inherents",
  "sp-offchain",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-session",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-transaction-pool",
@@ -3289,8 +3229,8 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "sp-api-proc-macro",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version",
 ]
@@ -3310,23 +3250,11 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-io",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-io",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
@@ -3334,27 +3262,13 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "integer-sqrt",
- "num-traits 0.2.15",
- "parity-scale-codec",
- "scale-info",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.15",
  "parity-scale-codec",
  "scale-info",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-debug-derive",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "static_assertions",
 ]
@@ -3365,8 +3279,8 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "parity-scale-codec",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3377,8 +3291,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3390,10 +3304,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
  "sp-consensus-slots",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
 ]
@@ -3405,34 +3319,10 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-arithmetic",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-timestamp",
-]
-
-[[package]]
-name = "sp-core"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "bitflags",
- "byteorder 1.4.3",
- "hash-db",
- "hash256-std-hasher",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
- "num-traits 0.2.15",
- "parity-scale-codec",
- "parity-util-mem",
- "primitive-types",
- "scale-info",
- "secrecy",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "ss58-registry",
- "zeroize",
 ]
 
 [[package]]
@@ -3458,11 +3348,11 @@ dependencies = [
  "schnorrkel",
  "secp256k1",
  "secrecy",
- "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core-hashing",
+ "sp-debug-derive",
+ "sp-runtime-interface",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-storage",
  "ss58-registry",
  "zeroize",
 ]
@@ -3470,20 +3360,6 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "blake2",
- "byteorder 1.4.3",
- "digest 0.10.3",
- "sha2 0.10.2",
- "sha3 0.10.1",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "twox-hash",
-]
-
-[[package]]
-name = "sp-core-hashing"
-version = "4.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "blake2",
@@ -3498,32 +3374,11 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "proc-macro2",
- "quote 1.0.18",
- "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "sp-core-hashing-proc-macro"
-version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.18",
- "sp-core-hashing 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "syn 1.0.93",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "proc-macro2",
- "quote 1.0.18",
+ "sp-core-hashing",
  "syn 1.0.93",
 ]
 
@@ -3546,21 +3401,10 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -3570,7 +3414,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3587,11 +3431,11 @@ dependencies = [
  "sgx-externalities",
  "sgx_tstd",
  "sgx_types",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-runtime-interface",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-tracing",
+ "sp-wasm-interface",
  "tracing",
  "tracing-core",
 ]
@@ -3602,28 +3446,8 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
- "parity-scale-codec",
- "parity-util-mem",
- "paste",
- "scale-info",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-io",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
+ "sp-core",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3639,27 +3463,11 @@ dependencies = [
  "parity-util-mem",
  "paste",
  "scale-info",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-arithmetic 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-core",
  "sp-io",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "primitive-types",
- "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "static_assertions",
 ]
 
 [[package]]
@@ -3670,24 +3478,12 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
- "sp-runtime-interface-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime-interface-proc-macro",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-storage 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-tracing 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-wasm-interface 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-storage",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "Inflector",
- "proc-macro-crate",
- "proc-macro2",
- "quote 1.0.18",
- "syn 1.0.93",
 ]
 
 [[package]]
@@ -3710,20 +3506,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-staking 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
+ "sp-staking",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-staking"
-version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -3733,7 +3518,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3745,23 +3530,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=master#d602397a
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-
-[[package]]
-name = "sp-std"
-version = "4.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
-
-[[package]]
-name = "sp-storage"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "parity-scale-codec",
- "ref-cast",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
-]
 
 [[package]]
 name = "sp-storage"
@@ -3770,7 +3539,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "ref-cast",
- "sp-debug-derive 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-debug-derive",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 
@@ -3781,20 +3550,9 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "sp-api",
- "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-inherents",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -3814,7 +3572,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20#563f4820d8f36d256ada7ea3fef46b2e94c4cd5a"
 dependencies = [
  "sp-api",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -3826,7 +3584,7 @@ dependencies = [
  "memory-db",
  "parity-scale-codec",
  "scale-info",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "trie-db",
  "trie-root",
@@ -3839,8 +3597,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "sp-core-hashing-proc-macro 5.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-core-hashing-proc-macro",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
  "sp-version-proc-macro",
 ]
@@ -3854,16 +3612,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.18",
  "syn 1.0.93",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19#174735ea1bb5fc4513519c45181d8df63d86f613"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.19)",
 ]
 
 [[package]]
@@ -3910,12 +3658,12 @@ dependencies = [
  "ac-compose-macros",
  "ac-primitives",
  "frame-metadata",
- "frame-support 4.0.0-dev (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "frame-support",
  "hex",
  "parity-scale-codec",
- "sp-application-crypto 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-core 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
- "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.20)",
 ]
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1431,10 +1431,8 @@ version = "0.8.0"
 dependencies = [
  "aes",
  "derive_more",
- "hex",
  "itp-settings",
  "itp-sgx-io",
- "itp-utils",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "ofb",
  "parity-scale-codec",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -105,6 +105,7 @@ itp-test = { path = "../core-primitives/test", default-features = false, optiona
 itp-top-pool = { path = "../core-primitives/top-pool", default-features = false, features = ["sgx"] }
 itp-top-pool-author = { path = "../core-primitives/top-pool-author", default-features = false, features = ["sgx"] }
 itp-types = { path = "../core-primitives/types", default-features = false, features = ["sgx"] }
+itp-utils = { path = "../core-primitives/utils", default-features = false, features = ["sgx"] }
 its-sidechain = { path = "../sidechain/sidechain-crate", default-features = false, features = ["sgx"] }
 
 # substrate deps

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -27,10 +27,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-	cert, io,
-	ocall::OcallApi,
-	utils::{hash_from_slice, write_slice_and_whitespace_pad},
-	Error as EnclaveError, Result as EnclaveResult,
+	cert, io, ocall::OcallApi, utils::hash_from_slice, Error as EnclaveError,
+	Result as EnclaveResult,
 };
 use codec::Encode;
 use core::default::Default;
@@ -42,6 +40,7 @@ use itp_settings::{
 };
 use itp_sgx_crypto::Ed25519Seal;
 use itp_sgx_io::StaticSealedIO;
+use itp_utils::write_slice_and_whitespace_pad;
 use log::*;
 use sgx_rand::*;
 use sgx_tcrypto::*;
@@ -547,7 +546,9 @@ pub unsafe extern "C" fn perform_ra(
 	let xt_hash = blake2_256(&xt_encoded);
 	debug!("    [Enclave] Encoded extrinsic ( len = {} B), hash {:?}", xt_encoded.len(), xt_hash);
 
-	write_slice_and_whitespace_pad(extrinsic_slice, xt_encoded);
+	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, xt_encoded) {
+		return EnclaveError::Other(Box::new(e)).into()
+	};
 
 	sgx_status_t::SGX_SUCCESS
 }

--- a/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -30,8 +30,8 @@ use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
 use sgx_runtime::Runtime;
 use std::{borrow::ToOwned, format, str, string::String, sync::Arc, vec::Vec};
 
-fn compute_encoded_return_error(error_msg: &str) -> Vec<u8> {
-	RpcReturnValue::from_error_message(error_msg).encode()
+fn compute_hex_encoded_return_error(error_msg: &str) -> String {
+	RpcReturnValue::from_error_message(error_msg).to_hex()
 }
 
 fn get_all_rpc_methods_string(io_handler: &IoHandler) -> String {
@@ -60,7 +60,7 @@ where
 			Ok(key) => key,
 			Err(status) => {
 				let error_msg: String = format!("Could not get rsa pubkey due to: {}", status);
-				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
+				return Ok(json!(compute_hex_encoded_return_error(error_msg.as_str())))
 			},
 		};
 
@@ -69,12 +69,12 @@ where
 			Err(x) => {
 				let error_msg: String =
 					format!("[Enclave] can't serialize rsa_pubkey {:?} {}", rsa_pubkey, x);
-				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
+				return Ok(json!(compute_hex_encoded_return_error(error_msg.as_str())))
 			},
 		};
 		let json_value =
 			RpcReturnValue::new(rsa_pubkey_json.encode(), false, DirectRequestStatus::Ok);
-		Ok(json!(hex_encode(json_value.encode())))
+		Ok(json!(json_value.to_hex()))
 	});
 
 	let mu_ra_url_name: &str = "author_getMuRaUrl";
@@ -83,12 +83,12 @@ where
 			Ok(url) => url,
 			Err(status) => {
 				let error_msg: String = format!("Could not get mu ra url due to: {}", status);
-				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
+				return Ok(json!(compute_hex_encoded_return_error(error_msg.as_str())))
 			},
 		};
 
 		let json_value = RpcReturnValue::new(url.encode(), false, DirectRequestStatus::Ok);
-		Ok(json!(hex_encode(json_value.encode())))
+		Ok(json!(json_value.to_hex()))
 	});
 
 	let untrusted_url_name: &str = "author_getUntrustedUrl";
@@ -97,12 +97,12 @@ where
 			Ok(url) => url,
 			Err(status) => {
 				let error_msg: String = format!("Could not get untrusted url due to: {}", status);
-				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
+				return Ok(json!(compute_hex_encoded_return_error(error_msg.as_str())))
 			},
 		};
 
 		let json_value = RpcReturnValue::new(url.encode(), false, DirectRequestStatus::Ok);
-		Ok(json!(hex_encode(json_value.encode())))
+		Ok(json!(json_value.to_hex()))
 	});
 
 	// chain_subscribeAllHeads
@@ -117,7 +117,7 @@ where
 	io.add_sync_method(state_get_metadata_name, |_: Params| {
 		let metadata = Runtime::metadata();
 		let json_value = RpcReturnValue::new(metadata.into(), false, DirectRequestStatus::Ok);
-		Ok(json!(hex_encode(json_value.encode())))
+		Ok(json!(json_value.to_hex()))
 	});
 
 	// state_getRuntimeVersion

--- a/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -21,7 +21,7 @@ use itp_primitives_cache::{GetPrimitives, GLOBAL_PRIMITIVES_CACHE};
 use itp_sgx_crypto::Rsa3072Seal;
 use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{DirectRequestStatus, RpcReturnValue, H256};
-use itp_utils::hex_encode;
+use itp_utils::ToHexPrefixed;
 use its_sidechain::{
 	primitives::types::SignedBlock,
 	rpc_handler::{direct_top_pool_api, import_block_api},

--- a/enclave-runtime/src/rpc/worker_api_direct.rs
+++ b/enclave-runtime/src/rpc/worker_api_direct.rs
@@ -21,6 +21,7 @@ use itp_primitives_cache::{GetPrimitives, GLOBAL_PRIMITIVES_CACHE};
 use itp_sgx_crypto::Rsa3072Seal;
 use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{DirectRequestStatus, RpcReturnValue, H256};
+use itp_utils::hex_encode;
 use its_sidechain::{
 	primitives::types::SignedBlock,
 	rpc_handler::{direct_top_pool_api, import_block_api},
@@ -59,7 +60,7 @@ where
 			Ok(key) => key,
 			Err(status) => {
 				let error_msg: String = format!("Could not get rsa pubkey due to: {}", status);
-				return Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
 			},
 		};
 
@@ -68,12 +69,12 @@ where
 			Err(x) => {
 				let error_msg: String =
 					format!("[Enclave] can't serialize rsa_pubkey {:?} {}", rsa_pubkey, x);
-				return Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
 			},
 		};
 		let json_value =
 			RpcReturnValue::new(rsa_pubkey_json.encode(), false, DirectRequestStatus::Ok);
-		Ok(json!(json_value.encode()))
+		Ok(json!(hex_encode(json_value.encode())))
 	});
 
 	let mu_ra_url_name: &str = "author_getMuRaUrl";
@@ -82,12 +83,12 @@ where
 			Ok(url) => url,
 			Err(status) => {
 				let error_msg: String = format!("Could not get mu ra url due to: {}", status);
-				return Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
 			},
 		};
 
 		let json_value = RpcReturnValue::new(url.encode(), false, DirectRequestStatus::Ok);
-		Ok(json!(json_value.encode()))
+		Ok(json!(hex_encode(json_value.encode())))
 	});
 
 	let untrusted_url_name: &str = "author_getUntrustedUrl";
@@ -96,12 +97,12 @@ where
 			Ok(url) => url,
 			Err(status) => {
 				let error_msg: String = format!("Could not get untrusted url due to: {}", status);
-				return Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+				return Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
 			},
 		};
 
 		let json_value = RpcReturnValue::new(url.encode(), false, DirectRequestStatus::Ok);
-		Ok(json!(json_value.encode()))
+		Ok(json!(hex_encode(json_value.encode())))
 	});
 
 	// chain_subscribeAllHeads
@@ -116,7 +117,7 @@ where
 	io.add_sync_method(state_get_metadata_name, |_: Params| {
 		let metadata = Runtime::metadata();
 		let json_value = RpcReturnValue::new(metadata.into(), false, DirectRequestStatus::Ok);
-		Ok(json!(json_value.encode()))
+		Ok(json!(hex_encode(json_value.encode())))
 	});
 
 	// state_getRuntimeVersion

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -32,7 +32,7 @@ use itc_parentchain::light_client::mocks::validator_access_mock::ValidatorAccess
 use itp_extrinsics_factory::mock::ExtrinsicsFactoryMock;
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_settings::sidechain::SLOT_DURATION;
-use itp_sgx_crypto::{Aes, ShieldingCrypto, StateCrypto};
+use itp_sgx_crypto::{Aes, ShieldingCryptoEncrypt, StateCrypto};
 use itp_stf_state_handler::handle_state::HandleState;
 use itp_test::{
 	builders::parentchain_header_builder::ParentchainHeaderBuilder,
@@ -202,7 +202,7 @@ pub fn produce_sidechain_block_and_import_it() {
 
 fn encrypted_trusted_operation_transfer_balance<
 	AttestationApi: EnclaveAttestationOCallApi,
-	ShieldingKey: ShieldingCrypto,
+	ShieldingKey: ShieldingCryptoEncrypt,
 >(
 	attestation_api: &AttestationApi,
 	shard_id: &ShardIdentifier,

--- a/enclave-runtime/src/tests.rs
+++ b/enclave-runtime/src/tests.rs
@@ -75,7 +75,7 @@ use its_sidechain::{
 use sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 use sgx_tunittest::*;
 use sgx_types::size_t;
-use sp_core::{crypto::Pair, ed25519 as spEd25519, hashing::blake2_256, H256};
+use sp_core::{crypto::Pair, ed25519 as spEd25519, H256};
 use sp_runtime::traits::Header as HeaderT;
 use std::{string::String, sync::Arc, vec::Vec};
 

--- a/enclave-runtime/src/utils.rs
+++ b/enclave-runtime/src/utils.rs
@@ -16,22 +16,13 @@
 */
 use crate::Hash;
 use codec::{Decode, Error, Input};
-use std::{slice, vec::Vec};
+use std::slice;
 
 pub fn hash_from_slice(hash_slize: &[u8]) -> Hash {
 	let mut g = [0; 32];
 	g.copy_from_slice(hash_slize);
 	Hash::from(&mut g)
 }
-
-pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) {
-	assert!(!data.len() > writable.len(), "Not enough bytes in output buffer for return value");
-	let (left, right) = writable.split_at_mut(data.len());
-	left.clone_from_slice(&data);
-	// fill the right side with whitespace
-	right.iter_mut().for_each(|x| *x = 0x20);
-}
-
 /// Helper trait to transform the sgx-ffi pointers to any type that implements
 /// `parity-scale-codec::Decode`
 pub unsafe trait DecodeRaw {

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -52,6 +52,7 @@ itp-settings = { path = "../core-primitives/settings" }
 itp-stf-state-handler = { path = "../core-primitives/stf-state-handler" }
 itp-test = { path = "../core-primitives/test" }
 itp-types = { path = "../core-primitives/types" }
+itp-utils = { path = "../core-primitives/utils" }
 its-consensus-slots = { path = "../sidechain/consensus/slots" }
 its-peer-fetch = { path = "../sidechain/peer-fetch" }
 its-primitives = { path = "../sidechain/primitives"}

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -42,8 +42,6 @@ pub enum Error {
 	ApplicationSetup,
 	#[error("No worker for shard {0} found on parentchain")]
 	NoWorkerForShardFound(ShardIdentifier),
-	#[error("Insufficient buffer size. Actual: {0}, required: {1}")]
-	InsufficientBufferSize(usize, usize),
 	#[error("Custom Error: {0}")]
 	Custom(Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/service/src/ocall_bridge/ffi/fetch_sidechain_blocks_from_peer.rs
+++ b/service/src/ocall_bridge/ffi/fetch_sidechain_blocks_from_peer.rs
@@ -16,10 +16,8 @@
 
 */
 
-use crate::{
-	ocall_bridge::bridge_api::{Bridge, SidechainBridge},
-	utils::write_slice_and_whitespace_pad,
-};
+use crate::ocall_bridge::bridge_api::{Bridge, SidechainBridge};
+use itp_utils::write_slice_and_whitespace_pad;
 use log::*;
 use sgx_types::sgx_status_t;
 use std::{slice, sync::Arc};

--- a/service/src/ocall_bridge/ffi/worker_request.rs
+++ b/service/src/ocall_bridge/ffi/worker_request.rs
@@ -16,9 +16,7 @@
 
 */
 
-use crate::{
-	ocall_bridge::bridge_api::{Bridge, WorkerOnChainBridge},
-};
+use crate::ocall_bridge::bridge_api::{Bridge, WorkerOnChainBridge};
 use itp_utils::write_slice_and_whitespace_pad;
 use log::*;
 use sgx_types::sgx_status_t;

--- a/service/src/ocall_bridge/ffi/worker_request.rs
+++ b/service/src/ocall_bridge/ffi/worker_request.rs
@@ -18,8 +18,8 @@
 
 use crate::{
 	ocall_bridge::bridge_api::{Bridge, WorkerOnChainBridge},
-	utils::write_slice_and_whitespace_pad,
 };
+use itp_utils::write_slice_and_whitespace_pad;
 use log::*;
 use sgx_types::sgx_status_t;
 use std::{slice, sync::Arc, vec::Vec};

--- a/service/src/ocall_bridge/worker_on_chain_ocall.rs
+++ b/service/src/ocall_bridge/worker_on_chain_ocall.rs
@@ -20,7 +20,7 @@ use crate::ocall_bridge::bridge_api::{OCallBridgeError, OCallBridgeResult, Worke
 use codec::{Decode, Encode};
 use itp_node_api_extensions::node_api_factory::CreateNodeApi;
 use itp_types::{WorkerRequest, WorkerResponse};
-use itp_utils::hex_encode;
+use itp_utils::ToHexPrefixed;
 use log::*;
 use sp_core::storage::StorageKey;
 use sp_runtime::OpaqueExtrinsic;
@@ -89,7 +89,7 @@ where
 		if !extrinsics.is_empty() {
 			debug!("Enclave wants to send {} extrinsics", extrinsics.len());
 			for call in extrinsics.into_iter() {
-				if let Err(e) = api.send_extrinsic(hex_encode(call.encode()), XtStatus::Ready) {
+				if let Err(e) = api.send_extrinsic(call.to_hex(), XtStatus::Ready) {
 					error!("Could not send extrsinic to node: {:?}", e);
 				}
 			}

--- a/service/src/ocall_bridge/worker_on_chain_ocall.rs
+++ b/service/src/ocall_bridge/worker_on_chain_ocall.rs
@@ -16,13 +16,11 @@
 
 */
 
-use crate::{
-	ocall_bridge::bridge_api::{OCallBridgeError, OCallBridgeResult, WorkerOnChainBridge},
-	utils::hex_encode,
-};
+use crate::ocall_bridge::bridge_api::{OCallBridgeError, OCallBridgeResult, WorkerOnChainBridge};
 use codec::{Decode, Encode};
 use itp_node_api_extensions::node_api_factory::CreateNodeApi;
 use itp_types::{WorkerRequest, WorkerResponse};
+use itp_utils::hex_encode;
 use log::*;
 use sp_core::storage::StorageKey;
 use sp_runtime::OpaqueExtrinsic;

--- a/service/src/utils.rs
+++ b/service/src/utils.rs
@@ -16,10 +16,8 @@
 
 */
 
-use crate::error::Error;
 use base58::{FromBase58, ToBase58};
 use clap::ArgMatches;
-use frame_support::ensure;
 use ita_stf::ShardIdentifier;
 use itp_enclave_api::enclave_base::EnclaveBase;
 use log::{debug, info};
@@ -41,46 +39,11 @@ pub fn extract_shard<E: EnclaveBase>(m: &ArgMatches<'_>, enclave_api: &E) -> Sha
 	}
 }
 
-pub fn hex_encode(data: Vec<u8>) -> String {
-	let mut hex_str = hex::encode(data);
-	hex_str.insert_str(0, "0x");
-	hex_str
-}
-
-pub fn write_slice_and_whitespace_pad(writable: &mut [u8], data: Vec<u8>) -> Result<(), Error> {
-	ensure!(
-		data.len() <= writable.len(),
-		Error::InsufficientBufferSize(writable.len(), data.len())
-	);
-	let (left, right) = writable.split_at_mut(data.len());
-	left.clone_from_slice(&data);
-	// fill the right side with whitespace
-	right.iter_mut().for_each(|x| *x = 0x20);
-	Ok(())
-}
-
 pub fn check_files() {
 	use itp_settings::files::{ENCLAVE_FILE, RA_API_KEY_FILE, RA_SPID_FILE};
 	debug!("*** Check files");
 	let files = vec![ENCLAVE_FILE, RA_SPID_FILE, RA_API_KEY_FILE];
 	for f in files.iter() {
 		assert!(Path::new(f).exists(), "File doesn't exist: {}", f);
-	}
-}
-
-#[cfg(test)]
-mod tests {
-
-	use super::*;
-	use std::assert_matches::assert_matches;
-
-	#[test]
-	fn write_slice_and_whitespace_pad_returns_error_if_buffer_too_small() {
-		let mut writable = vec![0; 32];
-		let data = vec![1; 33];
-		assert_matches!(
-			write_slice_and_whitespace_pad(&mut writable, data),
-			Err(Error::InsufficientBufferSize(_, _))
-		);
 	}
 }

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -11,6 +11,7 @@ default = ["std"]
 std = [
     "itp-top-pool-author/std",
     "itp-types/std",
+    "itp-utils/std",
     "its-primitives/std",
     "jsonrpc-core",
     "log/std",
@@ -20,6 +21,7 @@ sgx = [
     "sgx_tstd",
     "itp-top-pool-author/sgx",
     "itp-types/sgx",
+    "itp-utils/sgx",
     "jsonrpc-core_sgx",
     "rust-base58_sgx",
 ]
@@ -32,6 +34,7 @@ sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sd
 # local dependencies
 itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-features = false }
 itp-types = { path = "../../core-primitives/types", default-features = false }
+itp-utils = { path = "../../core-primitives/utils", default-features = false }
 its-primitives = { path = "../primitives", default-features = false }
 
 # sgx enabled external libraries

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -4,27 +4,6 @@ version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = [
-    "itp-top-pool-author/std",
-    "itp-types/std",
-    "itp-utils/std",
-    "its-primitives/std",
-    "jsonrpc-core",
-    "log/std",
-    "rust-base58",
-]
-sgx = [
-    "sgx_tstd",
-    "itp-top-pool-author/sgx",
-    "itp-types/sgx",
-    "itp-utils/sgx",
-    "jsonrpc-core_sgx",
-    "rust-base58_sgx",
-]
 
 [dependencies]
 # sgx dependencies
@@ -49,3 +28,23 @@ jsonrpc-core = { version = "18", optional = true }
 codec  = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
 sp-core = { version = "6.0.0", default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
+
+[features]
+default = ["std"]
+std = [
+    "itp-top-pool-author/std",
+    "itp-types/std",
+    "itp-utils/std",
+    "its-primitives/std",
+    "jsonrpc-core",
+    "log/std",
+    "rust-base58",
+]
+sgx = [
+    "sgx_tstd",
+    "itp-top-pool-author/sgx",
+    "itp-types/sgx",
+    "itp-utils/sgx",
+    "jsonrpc-core_sgx",
+    "rust-base58_sgx",
+]

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -126,8 +126,8 @@ fn decode_shard_from_base58(shard_base58: &str) -> Result<ShardIdentifier, Strin
 	Ok(shard)
 }
 
-fn compute_encoded_return_error(error_msg: &str) -> Vec<u8> {
-	RpcReturnValue::from_error_message(error_msg).encode()
+fn compute_hex_encoded_return_error(error_msg: &str) -> String {
+	RpcReturnValue::from_error_message(error_msg).to_hex()
 }
 
 fn author_submit_extrinsic_inner<R: AuthorApi<Hash, Hash> + Send + Sync + 'static>(

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -48,8 +48,8 @@ where
 	let author_submit_and_watch_extrinsic_name: &str = "author_submitAndWatchExtrinsic";
 	let submit_watch_author = top_pool_author.clone();
 	io_handler.add_sync_method(author_submit_and_watch_extrinsic_name, move |params: Params| {
-		match params.parse::<String>() {
-			Ok(hex_encoded_params) => match decode_hex(hex_encoded_params) {
+		match params.parse::<Vec<String>>() {
+			Ok(hex_encoded_params) => match decode_hex(hex_encoded_params[0].clone()) {
 				Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
 					Ok(request) => {
 						let shard: ShardIdentifier = request.shard;
@@ -72,7 +72,7 @@ where
 							Err(rpc_error) =>
 								compute_encoded_return_error(rpc_error.message.as_str()),
 						};
-						Ok(json!(json_value))
+						Ok(json!(hex_encode(json_value)))
 					},
 					Err(_) => Ok(json!(hex_encode(compute_encoded_return_error(
 						"Could not decode request"
@@ -94,8 +94,8 @@ where
 	let author_submit_extrinsic_name: &str = "author_submitExtrinsic";
 	let submit_author = top_pool_author.clone();
 	io_handler.add_sync_method(author_submit_extrinsic_name, move |params: Params| {
-		match params.parse::<String>() {
-			Ok(hex_encoded_params) => match decode_hex(hex_encoded_params) {
+		match params.parse::<Vec<String>>() {
+			Ok(hex_encoded_params) => match decode_hex(hex_encoded_params[0].clone()) {
 				Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
 					Ok(request) => {
 						let shard: ShardIdentifier = request.shard;

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -46,92 +46,38 @@ where
 {
 	// author_submitAndWatchExtrinsic
 	let author_submit_and_watch_extrinsic_name: &str = "author_submitAndWatchExtrinsic";
-	let submit_watch_author = top_pool_author.clone();
+	let watch_author = top_pool_author.clone();
 	io_handler.add_sync_method(author_submit_and_watch_extrinsic_name, move |params: Params| {
-		match params.parse::<Vec<String>>() {
-			Ok(hex_encoded_params) => match decode_hex(hex_encoded_params[0].clone()) {
-				Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
-					Ok(request) => {
-						let shard: ShardIdentifier = request.shard;
-						let encrypted_trusted_call: Vec<u8> = request.cyphertext;
-						let result = async {
-							submit_watch_author
-								.watch_top(encrypted_trusted_call.clone(), shard)
-								.await
-						};
-						let response: Result<Hash, RpcError> = executor::block_on(result);
-						let json_value = match response {
-							Ok(hash_value) => RpcReturnValue {
-								do_watch: true,
-								value: hash_value.encode(),
-								status: DirectRequestStatus::TrustedOperationStatus(
-									TrustedOperationStatus::Submitted,
-								),
-							}
-							.encode(),
-							Err(rpc_error) =>
-								compute_encoded_return_error(rpc_error.message.as_str()),
-						};
-						Ok(json!(hex_encode(json_value)))
-					},
-					Err(_) => Ok(json!(hex_encode(compute_encoded_return_error(
-						"Could not decode request"
-					)))),
-				},
-				Err(e) => {
-					let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-					Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
-				},
-			},
-			Err(e) => {
-				let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-				Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
-			},
-		}
+		let json_value = match author_submit_extrinsic_inner(watch_author.clone(), params) {
+			Ok(hash_value) => RpcReturnValue {
+				do_watch: true,
+				value: hash_value.encode(),
+				status: DirectRequestStatus::TrustedOperationStatus(
+					TrustedOperationStatus::Submitted,
+				),
+			}
+			.encode(),
+			Err(error) => compute_encoded_return_error(error.as_str()),
+		};
+		Ok(json!(hex_encode(json_value)))
 	});
 
 	// author_submitExtrinsic
 	let author_submit_extrinsic_name: &str = "author_submitExtrinsic";
 	let submit_author = top_pool_author.clone();
 	io_handler.add_sync_method(author_submit_extrinsic_name, move |params: Params| {
-		match params.parse::<Vec<String>>() {
-			Ok(hex_encoded_params) => match decode_hex(hex_encoded_params[0].clone()) {
-				Ok(encoded_params) => match Request::decode(&mut encoded_params.as_slice()) {
-					Ok(request) => {
-						let shard: ShardIdentifier = request.shard;
-						let encrypted_trusted_op: Vec<u8> = request.cyphertext;
-						let result = async {
-							submit_author.submit_top(encrypted_trusted_op.clone(), shard).await
-						};
-						let response: Result<Hash, RpcError> = executor::block_on(result);
-						let json_value = match response {
-							Ok(hash_value) => RpcReturnValue {
-								do_watch: false,
-								value: hash_value.encode(),
-								status: DirectRequestStatus::TrustedOperationStatus(
-									TrustedOperationStatus::Submitted,
-								),
-							}
-							.encode(),
-							Err(rpc_error) =>
-								compute_encoded_return_error(rpc_error.message.as_str()),
-						};
-						Ok(json!(hex_encode(json_value)))
-					},
-					Err(_) => Ok(json!(hex_encode(compute_encoded_return_error(
-						"Could not decode request"
-					)))),
-				},
-				Err(e) => {
-					let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-					Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
-				},
-			},
-			Err(e) => {
-				let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-				Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
-			},
-		}
+		let json_value = match author_submit_extrinsic_inner(submit_author.clone(), params) {
+			Ok(hash_value) => RpcReturnValue {
+				do_watch: false,
+				value: hash_value.encode(),
+				status: DirectRequestStatus::TrustedOperationStatus(
+					TrustedOperationStatus::Submitted,
+				),
+			}
+			.encode(),
+			Err(error) => compute_encoded_return_error(error.as_str()),
+		};
+		Ok(json!(hex_encode(json_value)))
 	});
 
 	// author_pendingExtrinsics
@@ -182,4 +128,24 @@ fn decode_shard_from_base58(shard_base58: &str) -> Result<ShardIdentifier, Strin
 
 fn compute_encoded_return_error(error_msg: &str) -> Vec<u8> {
 	RpcReturnValue::from_error_message(error_msg).encode()
+}
+
+fn author_submit_extrinsic_inner<R: AuthorApi<Hash, Hash> + Send + Sync + 'static>(
+	author: Arc<R>,
+	params: Params,
+) -> Result<Hash, String> {
+	let hex_encoded_params = params.parse::<Vec<String>>().map_err(|e| format!("{:?}", e))?;
+
+	let encoded_params =
+		decode_hex(hex_encoded_params[0].clone()).map_err(|e| format!("{:?}", e))?;
+
+	let request =
+		Request::decode(&mut encoded_params.as_slice()).map_err(|e| format!("{:?}", e))?;
+
+	let shard: ShardIdentifier = request.shard;
+	let encrypted_trusted_call: Vec<u8> = request.cyphertext;
+	let result = async { author.watch_top(encrypted_trusted_call, shard).await };
+	let response: Result<Hash, RpcError> = executor::block_on(result);
+
+	response.map_err(|e| format!("{:?}", e))
 }

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -29,6 +29,7 @@ use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{
 	DirectRequestStatus, Request, RpcReturnValue, ShardIdentifier, TrustedOperationStatus,
 };
+use itp_utils::hex_encode;
 use jsonrpc_core::{
 	futures::executor, serde_json::json, Error as RpcError, IoHandler, Params, Value,
 };
@@ -69,11 +70,12 @@ where
 					};
 					Ok(json!(json_value))
 				},
-				Err(_) => Ok(json!(compute_encoded_return_error("Could not decode request"))),
+				Err(_) =>
+					Ok(json!(hex_encode(compute_encoded_return_error("Could not decode request")))),
 			},
 			Err(e) => {
 				let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-				Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+				Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
 			},
 		}
 	});
@@ -102,13 +104,14 @@ where
 						.encode(),
 						Err(rpc_error) => compute_encoded_return_error(rpc_error.message.as_str()),
 					};
-					Ok(json!(json_value))
+					Ok(json!(hex_encode(json_value)))
 				},
-				Err(_) => Ok(json!(compute_encoded_return_error("Could not decode request"))),
+				Err(_) =>
+					Ok(json!(hex_encode(compute_encoded_return_error("Could not decode request")))),
 			},
 			Err(e) => {
 				let error_msg: String = format!("Could not submit trusted call due to: {}", e);
-				Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+				Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
 			},
 		}
 	});
@@ -134,11 +137,11 @@ where
 					value: retrieved_operations.encode(),
 					status: DirectRequestStatus::Ok,
 				};
-				Ok(json!(json_value.encode()))
+				Ok(json!(hex_encode(json_value.encode())))
 			},
 			Err(e) => {
 				let error_msg: String = format!("Could not retrieve pending calls due to: {}", e);
-				Ok(json!(compute_encoded_return_error(error_msg.as_str())))
+				Ok(json!(hex_encode(compute_encoded_return_error(error_msg.as_str()))))
 			},
 		}
 	});

--- a/sidechain/rpc-handler/src/import_block_api.rs
+++ b/sidechain/rpc-handler/src/import_block_api.rs
@@ -19,7 +19,7 @@
 use crate::sgx_reexport_prelude::*;
 
 use codec::Decode;
-use itp_utils::decode_hex;
+use itp_utils::FromHexPrefixed;
 use its_primitives::{constants::RPC_METHOD_NAME_IMPORT_BLOCKS, types::SignedBlock};
 use jsonrpc_core::{IoHandler, Params, Value};
 use log::*;
@@ -39,19 +39,13 @@ where
 
 		let hex_encoded_block_vec: Vec<String> = sidechain_blocks.parse()?;
 
-		let block_vec: Vec<u8> = decode_hex(&hex_encoded_block_vec[0]).map_err(|_| {
+		let blocks = Vec<SignedBlock>::from_hex(&hex_encoded_block_vec[0]).map_err(|_| {
 			jsonrpc_core::error::Error::invalid_params_with_details(
-				"Could not hex decode Vec<u8>",
+				"Could not decode Vec<SignedBlock>",
 				hex_encoded_block_vec,
 			)
 		})?;
 
-		let blocks: Vec<SignedBlock> = Decode::decode(&mut block_vec.as_slice()).map_err(|_| {
-			jsonrpc_core::error::Error::invalid_params_with_details(
-				"Could not decode Vec<SignedBlock>",
-				block_vec,
-			)
-		})?;
 		info!("{}. Blocks: {:?}", RPC_METHOD_NAME_IMPORT_BLOCKS, blocks);
 
 		for block in blocks {

--- a/sidechain/rpc-handler/src/import_block_api.rs
+++ b/sidechain/rpc-handler/src/import_block_api.rs
@@ -18,7 +18,6 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 use crate::sgx_reexport_prelude::*;
 
-use codec::Decode;
 use itp_utils::FromHexPrefixed;
 use its_primitives::{constants::RPC_METHOD_NAME_IMPORT_BLOCKS, types::SignedBlock};
 use jsonrpc_core::{IoHandler, Params, Value};
@@ -39,7 +38,7 @@ where
 
 		let hex_encoded_block_vec: Vec<String> = sidechain_blocks.parse()?;
 
-		let blocks = Vec<SignedBlock>::from_hex(&hex_encoded_block_vec[0]).map_err(|_| {
+		let blocks = Vec::<SignedBlock>::from_hex(&hex_encoded_block_vec[0]).map_err(|_| {
 			jsonrpc_core::error::Error::invalid_params_with_details(
 				"Could not decode Vec<SignedBlock>",
 				hex_encoded_block_vec,

--- a/sidechain/rpc-handler/src/import_block_api.rs
+++ b/sidechain/rpc-handler/src/import_block_api.rs
@@ -41,7 +41,7 @@ where
 
 		let block_vec: Vec<u8> = decode_hex(&hex_encoded_block_vec[0]).map_err(|_| {
 			jsonrpc_core::error::Error::invalid_params_with_details(
-				"Could not hex decode Vec<SignedBlock>",
+				"Could not hex decode Vec<u8>",
 				hex_encoded_block_vec,
 			)
 		})?;
@@ -87,7 +87,7 @@ pub mod tests {
 	#[test]
 	pub fn sidechain_import_block_is_ok() {
 		let io = io_handler();
-		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":[4,214,133,100,93,246,175,226,132,221,148,110,92,136,126,102,210,76,31,161,70,134,211,78,164,161,10,161,244,238,152,16,78,27,0,0,0,0,0,0,0,73,116,2,132,31,80,15,47,213,32,2,41,26,189,99,86,235,175,172,213,177,240,105,72,195,176,9,208,70,199,175,14,111,195,7,63,174,8,7,34,199,161,58,166,190,254,107,27,93,9,249,239,10,56,116,174,164,10,185,247,206,95,80,15,200,62,48,254,127,1,0,0,34,46,253,86,156,211,88,25,46,128,216,4,146,5,112,16,125,206,126,34,116,34,61,177,72,2,249,236,225,168,199,27,6,165,15,16,239,22,74,141,152,34,57,191,166,40,181,130,194,202,238,12,244,63,191,131,115,91,89,117,94,49,0,245,0,93,2,38,58,201,204,121,130,251,179,198,127,37,203,37,1,198,62,200,247,175,68,5,83,206,13,146,229,140,187,255,177,22,84,184,68,7,65,168,141,97,207,86,192,169,203,166,205,126,227,238,1,142,81,214,23,245,197,242,73,40,30,103,235,174,202,80,142,248,57,25,98,190,36,106,6,177,153,229,124,145,253,136,80,0,132,19,152,227,134,116,244,125,45,200,160,89,219,24,68,47,239,41,164,159,103,60,111,21,180,251,193,8,188,180,207,212,10,244,187,140,49,161,46,103,199,71,191,207,167,59,98,108,149,234,93,222,228,176,249,126,130,54,226,112,233,235,92,214,100,228,91,55,0,196,187,51,131,66,61,113,185,228,191,189,214,210,69,169,201,223,67,81,250,108,128,172,119,239,90,189,173,189,174,140,196,44,236,75,84,83,37,148,210,128,196,228,214,165,43,92,135,31,170,200,130,176,253,255,62,23,164,183,122,98,163,28,7],"id":1}"#;
+		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":["0x042aa533a21d26d94c29094a626ed08322d1f73fe95ff7b5d1edd129011441b5681a0000000000000096dbbe8c2ba45178c554d134096990f9f5dba477b008cbef4f1934a0bac306f84b9981cab5445b00773dc92d873850c6ee3bc48153af062aec2d1e1f549e5f801f72f2d180010000bc3070e3cc5beed3103c6d50b83dcb8888dc14d6baa4dc2f97543a61893a743329a5a289c17a355063e21136c9ebcad7d2228dcb2a2495a34e6e97ff1338f644005d023a6a5049e17c7358bc02cb474d65eb6f158b901009c2066ba8cc69c4da3e0195ee6ae9f3c7e38e7ed39830ade0015190a356173d275ffb18d229649e140b9f530a2ad74d70e3984267a78b568196c7433c9d1a88d0d18ea96d83c3b04c56e97af3d1eb1b7d134f79938218514ec2f9b485712a56d8d48f415dc952063fa0677dd7c1d5fda17d2883b363911da13dee66754693ff0ab8da0017a3670a93afdb90bf486bb884c134bb7503b9df4821738ce1e379d8f3b98fb03e48475581856b452a1eab1ea7a098473a74b9e08056523f8f2b522af65bc908"],"id":1}"#;
 
 		let response_string = io.handle_request_sync(enclave_req).unwrap();
 
@@ -97,23 +97,35 @@ pub mod tests {
 	#[test]
 	pub fn sidechain_import_block_returns_invalid_param_err() {
 		let io = io_handler();
-		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":["SophisticatedInvalidParam"],"id":1}"#;
+		let enclave_req =
+			r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":[4,214,133,100],"id":1}"#;
 
 		let response_string = io.handle_request_sync(enclave_req).unwrap();
 
-		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: invalid type: string \"SophisticatedInvalidParam\", expected u8."},"id":1}"#;
+		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params: invalid type: integer `4`, expected a string."},"id":1}"#;
 		assert_eq!(response_string, err_msg);
 	}
 
 	#[test]
-	pub fn sidechain_import_block_returns_decode_err() {
+	pub fn sidechain_import_block_returns_hex_decode_err() {
 		let io = io_handler();
-		let enclave_req =
-			r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":[2],"id":1}"#;
+		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":["SophisticatedInvalidParam"],"id":1}"#;
 
 		let response_string = io.handle_request_sync(enclave_req).unwrap();
 
-		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: Could not decode Vec<SignedBlock>","data":"[2]"},"id":1}"#;
+		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: Could not hex decode Vec<u8>","data":"[\"SophisticatedInvalidParam\"]"},"id":1}"#;
+		assert_eq!(response_string, err_msg);
+	}
+
+	pub fn sidechain_import_block_returns_decode_err() {
+		let io = io_handler();
+
+		let enclave_req =
+			r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params": ["0x11"],"id":1}"#;
+
+		let response_string = io.handle_request_sync(enclave_req).unwrap();
+
+		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: Could not decode Vec<SignedBlock>","data":"[17]"},"id":1}"#;
 		assert_eq!(response_string, err_msg);
 	}
 }

--- a/sidechain/rpc-handler/src/import_block_api.rs
+++ b/sidechain/rpc-handler/src/import_block_api.rs
@@ -100,17 +100,17 @@ pub mod tests {
 	}
 
 	#[test]
-	pub fn sidechain_import_block_returns_hex_decode_err() {
+	pub fn sidechain_import_block_returns_decode_err() {
 		let io = io_handler();
 		let enclave_req = r#"{"jsonrpc":"2.0","method":"sidechain_importBlock","params":["SophisticatedInvalidParam"],"id":1}"#;
 
 		let response_string = io.handle_request_sync(enclave_req).unwrap();
 
-		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: Could not hex decode Vec<u8>","data":"[\"SophisticatedInvalidParam\"]"},"id":1}"#;
+		let err_msg = r#"{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid parameters: Could not decode Vec<SignedBlock>","data":"[\"SophisticatedInvalidParam\"]"},"id":1}"#;
 		assert_eq!(response_string, err_msg);
 	}
 
-	pub fn sidechain_import_block_returns_decode_err() {
+	pub fn sidechain_import_block_returns_decode_err_for_valid_hex() {
 		let io = io_handler();
 
 		let enclave_req =


### PR DESCRIPTION
! Breaking change: RPC call values are now hex-encoded strings

- The `RpcReturnValue` result as well as the Rpc calls, previously simply uft8 encoded, are now hex encoded
- Added `itp-utils` crate and removed duplicate function definition of `write_slice_and_whitespace_pad`
- [CLI]: extract the shielding key retrieval into its own function and use the, previously only in sgx mode available, shielding key `encrypt` function (now also implemented for the public key)

closes #717 
