### PR TITLE
Bump rust-toolchain

### DIFF
--- a/enclave-runtime/rust-toolchain.toml
+++ b/enclave-runtime/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-11-10"
+channel = "nightly-2022-02-02"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2021-11-10"
+channel = "nightly-2022-02-02"
 targets = ["wasm32-unknown-unknown"]
 profile = "default" # include rustfmt, clippy


### PR DESCRIPTION
Updates the rust-toolchain to the same as the integritee-node: https://github.com/integritee-network/integritee-node/blob/master/rust-toolchain.toml#L2