### PR TITLE
Submit shield funds call into top pool

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,7 +29,7 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     container: "integritee/integritee-dev:0.1.9"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: init rust
         # enclave is not in the same workspace
         run: rustup show && cd enclave-runtime && rustup show
@@ -152,7 +152,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: init rust
         run: rustup show
 
@@ -187,9 +187,9 @@ jobs:
     env:
       BIN_DIR: bin
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         with:
           python-version: '3.7'
 
@@ -308,7 +308,7 @@ jobs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download Integritee Service
         uses: actions/download-artifact@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ version = "0.8.0"
 dependencies = [
  "ita-stf",
  "itp-ocall-api",
+ "itp-sgx-crypto",
  "itp-stf-state-handler",
  "itp-storage",
  "itp-test",
@@ -2633,6 +2634,7 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec",
  "sgx-externalities",
+ "sgx_crypto_helper",
  "sgx_tstd",
  "sgx_types",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,15 +969,6 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "git+https://github.com/mesalock-linux/env_logger-sgx#839ef5144497dd61e7a5dc99ace41c561b576f20"
-dependencies = [
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
- "sgx_tstd",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
@@ -2026,7 +2017,7 @@ dependencies = [
  "blake2-rfc",
  "chrono",
  "clap 3.1.18",
- "env_logger 0.9.0",
+ "env_logger",
  "frame-system",
  "geojson",
  "hex",
@@ -2111,7 +2102,7 @@ dependencies = [
  "cid",
  "clap 2.34.0",
  "dirs",
- "env_logger 0.9.0",
+ "env_logger",
  "frame-support",
  "frame-system",
  "futures 0.3.21",
@@ -2208,16 +2199,14 @@ dependencies = [
 name = "ita-stf"
 version = "0.8.0"
 dependencies = [
- "base58 0.1.0",
  "derive_more",
- "env_logger 0.7.1",
  "frame-support",
  "frame-system",
- "hex",
  "integritee-node-runtime",
  "itp-settings",
  "itp-storage",
  "itp-types",
+ "itp-utils",
  "its-primitives",
  "its-state",
  "log 0.4.17",
@@ -2307,7 +2296,7 @@ name = "itc-parentchain-indirect-calls-executor"
 version = "0.8.0"
 dependencies = [
  "bs58",
- "env_logger 0.9.0",
+ "env_logger",
  "futures 0.3.21",
  "futures 0.3.8",
  "ita-stf",
@@ -2382,7 +2371,7 @@ dependencies = [
 name = "itc-rpc-client"
 version = "0.8.0"
 dependencies = [
- "env_logger 0.9.0",
+ "env_logger",
  "itc-tls-websocket-server",
  "itp-types",
  "itp-utils",
@@ -2405,7 +2394,7 @@ name = "itc-rpc-server"
 version = "0.8.0"
 dependencies = [
  "anyhow",
- "env_logger 0.9.0",
+ "env_logger",
  "itp-enclave-api",
  "itp-types",
  "itp-utils",
@@ -2425,7 +2414,7 @@ dependencies = [
 name = "itc-tls-websocket-server"
 version = "0.8.0"
 dependencies = [
- "env_logger 0.9.0",
+ "env_logger",
  "log 0.4.17",
  "mio 0.6.21",
  "mio 0.6.23",
@@ -2821,6 +2810,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "sgx_tstd",
+ "sp-core",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
 ]
@@ -2853,7 +2843,7 @@ dependencies = [
 name = "its-consensus-aura"
 version = "0.8.0"
 dependencies = [
- "env_logger 0.9.0",
+ "env_logger",
  "finality-grandpa",
  "frame-support",
  "ita-stf",
@@ -2868,6 +2858,7 @@ dependencies = [
  "itp-test",
  "itp-time-utils",
  "itp-types",
+ "itp-utils",
  "its-block-composer",
  "its-consensus-common",
  "its-consensus-slots",

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -6,20 +6,18 @@ edition = "2018"
 
 [dependencies]
 # crates.io
-base58 = { version = "0.1", optional = true }
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 derive_more = { version = "0.99.5" }
-hex = { version = "0.4.2", optional = true }
 log = { version = "0.4", default-features = false }
 
 # sgx deps
 sgx_tstd = { branch = "master", features = ["untrusted_fs","net","backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx", default-features = false, features = ["mesalock_sgx"], optional = true }
 
 # local crates
 itp-settings = { path = "../../core-primitives/settings" }
 itp-storage = { default-features = false, path = "../../core-primitives/storage" }
 itp-types = {  default-features = false, path = "../../core-primitives/types" }
+itp-utils = { default-features = false, path = "../../core-primitives/utils" }
 its-primitives = { default-features = false, path = "../../sidechain/primitives" }
 its-state = { default-features = false, optional = true, path = "../../sidechain/state" }
 
@@ -48,21 +46,20 @@ sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "po
 default = ["std"]
 sgx = [
     "sgx_tstd",
-    "env_logger",
+    "its-state/sgx",
+    "itp-utils/sgx",
     "sp-io/sgx",
     "sgx-externalities/sgx",
     "sgx-runtime",
-    "its-state/sgx",
 ]
 std = [
     # crates.io
-    "base58",
     "codec/std",
-    "hex",
     "log/std",
     # local
     "itp-storage/std",
     "itp-types/std",
+    "itp-utils/std",
     "its-primitives/std",
     "its-state/std",
     # substrate

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -21,10 +21,6 @@ use codec::{Decode, Encode};
 use itp_storage::{storage_double_map_key, storage_map_key, storage_value_key, StorageHasher};
 use itp_utils::stringify::account_id_to_string;
 use log::*;
-use sp_core::{
-	ed25519::{Pair as Ed25519Pair, Signature},
-	Pair,
-};
 use std::prelude::v1::*;
 
 pub fn get_storage_value<V: Decode>(
@@ -79,15 +75,15 @@ pub fn get_storage_by_key_hash<V: Decode>(key: Vec<u8>) -> Option<V> {
 }
 
 // get the AccountInfo key where the account is stored
-pub(crate) fn account_key_hash(account: &AccountId) -> Vec<u8> {
+pub fn account_key_hash(account: &AccountId) -> Vec<u8> {
 	storage_map_key("System", "Account", account, &StorageHasher::Blake2_128Concat)
 }
 
-pub(crate) fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
+pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
 	get_storage_map("System", "Account", who, &StorageHasher::Blake2_128Concat)
 }
 
-pub(crate) fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
+pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 	// validate
 	let expected_nonce = get_account_info(who).map_or_else(|| 0, |acc| acc.nonce);
 	if expected_nonce == nonce {
@@ -97,7 +93,7 @@ pub(crate) fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 }
 
 /// increment nonce after a successful call execution
-pub(crate) fn increment_nonce(account: &AccountId) {
+pub fn increment_nonce(account: &AccountId) {
 	//FIXME: Proper error handling - should be taken into
 	// consideration after implementing pay fee check
 	if let Some(mut acc_info) = get_account_info(account) {
@@ -114,7 +110,7 @@ pub(crate) fn increment_nonce(account: &AccountId) {
 	}
 }
 
-pub(crate) fn account_nonce(account: &AccountId) -> Index {
+pub fn account_nonce(account: &AccountId) -> Index {
 	if let Some(info) = get_account_info(account) {
 		info.nonce
 	} else {
@@ -122,7 +118,7 @@ pub(crate) fn account_nonce(account: &AccountId) -> Index {
 	}
 }
 
-pub(crate) fn account_data(account: &AccountId) -> Option<AccountData> {
+pub fn account_data(account: &AccountId) -> Option<AccountData> {
 	if let Some(info) = get_account_info(account) {
 		Some(info.data)
 	} else {
@@ -130,35 +126,29 @@ pub(crate) fn account_data(account: &AccountId) -> Option<AccountData> {
 	}
 }
 
-pub(crate) fn root() -> AccountId {
+pub fn root() -> AccountId {
 	get_storage_value("Sudo", "Key").unwrap()
 }
 
-pub(crate) fn enclave_self_account() -> AccountId {
-	let enclave_key_pair: Ed25519Pair = get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap();
-	enclave_key_pair.public().into()
-}
-
-pub(crate) fn sign_with_enclave_account(payload: &[u8]) -> Signature {
-	let enclave_key_pair: Ed25519Pair = get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap();
-	enclave_key_pair.sign(payload)
+pub fn enclave_self_account() -> AccountId {
+	get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap()
 }
 
 // FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
-pub(crate) fn get_parentchain_blockhash() -> Option<H256> {
+pub fn get_parentchain_blockhash() -> Option<H256> {
 	get_storage_value("Parentchain", "BlockHash")
 }
 
 // FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
-pub(crate) fn get_parentchain_parenthash() -> Option<H256> {
+pub fn get_parentchain_parenthash() -> Option<H256> {
 	get_storage_value("Parentchain", "ParentHash")
 }
 
-pub(crate) fn get_parentchain_number() -> Option<BlockNumber> {
+pub fn get_parentchain_number() -> Option<BlockNumber> {
 	get_storage_value("Parentchain", "Number")
 }
 
-pub(crate) fn ensure_self(account: &AccountId) -> StfResult<()> {
+pub fn ensure_self(account: &AccountId) -> StfResult<()> {
 	let expected_enclave_account = enclave_self_account();
 	if &expected_enclave_account == account {
 		Ok(())
@@ -166,13 +156,13 @@ pub(crate) fn ensure_self(account: &AccountId) -> StfResult<()> {
 		error!(
 			"Expected enclave account {}, but found {}",
 			account_id_to_string(&expected_enclave_account),
-			account_id_to_string(&account)
+			account_id_to_string(account)
 		);
 		Err(StfError::RequireSelfEnclaveAccount)
 	}
 }
 
-pub(crate) fn ensure_root(account: AccountId) -> StfResult<()> {
+pub fn ensure_root(account: AccountId) -> StfResult<()> {
 	if root() == account {
 		Ok(())
 	} else {

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -127,6 +127,10 @@ pub fn root() -> AccountId {
 	get_storage_value("Sudo", "Key").unwrap()
 }
 
+pub fn enclave_self_account() -> AccountId {
+	get_storage_value("Sudo", "Enclave_Self_Key").unwrap()
+}
+
 // FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
 pub fn get_parentchain_blockhash() -> Option<H256> {
 	get_storage_value("Parentchain", "BlockHash")
@@ -139,6 +143,12 @@ pub fn get_parentchain_parenthash() -> Option<H256> {
 
 pub fn get_parentchain_number() -> Option<BlockNumber> {
 	get_storage_value("Parentchain", "Number")
+}
+
+pub fn ensure_self(account: AccountId) -> StfResult<()> {
+	if enclave_self_account() == account {
+		Ok(())
+	}
 }
 
 pub fn ensure_root(account: AccountId) -> StfResult<()> {

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -130,7 +130,7 @@ pub fn root() -> AccountId {
 	get_storage_value("Sudo", "Key").unwrap()
 }
 
-pub fn enclave_self_account() -> AccountId {
+pub fn enclave_signer_account() -> AccountId {
 	get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap()
 }
 
@@ -148,8 +148,9 @@ pub fn get_parentchain_number() -> Option<BlockNumber> {
 	get_storage_value("Parentchain", "Number")
 }
 
-pub fn ensure_self(account: &AccountId) -> StfResult<()> {
-	let expected_enclave_account = enclave_self_account();
+/// Ensures an account is a registered enclave account.
+pub fn ensure_registered_enclave(account: &AccountId) -> StfResult<()> {
+	let expected_enclave_account = enclave_signer_account();
 	if &expected_enclave_account == account {
 		Ok(())
 	} else {

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -14,7 +14,9 @@
 	limitations under the License.
 
 */
-use crate::{stf_sgx_primitives::types::*, AccountId, Index, StfError, StfResult, H256};
+use crate::{
+	stf_sgx_primitives::types::*, AccountId, Index, StfError, StfResult, ENCLAVE_ACCOUNT_KEY, H256,
+};
 use codec::{Decode, Encode};
 use itp_storage::{storage_double_map_key, storage_map_key, storage_value_key, StorageHasher};
 use log::*;
@@ -128,7 +130,7 @@ pub fn root() -> AccountId {
 }
 
 pub fn enclave_self_account() -> AccountId {
-	get_storage_value("Sudo", "Enclave_Self_Key").unwrap()
+	get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap()
 }
 
 // FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
@@ -148,6 +150,8 @@ pub fn get_parentchain_number() -> Option<BlockNumber> {
 pub fn ensure_self(account: AccountId) -> StfResult<()> {
 	if enclave_self_account() == account {
 		Ok(())
+	} else {
+		Err(StfError::RequireSelfEnclaveAccount)
 	}
 }
 

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -149,7 +149,7 @@ pub fn get_parentchain_number() -> Option<BlockNumber> {
 }
 
 /// Ensures an account is a registered enclave account.
-pub fn ensure_registered_enclave(account: &AccountId) -> StfResult<()> {
+pub fn ensure_enclave_signer_account(account: &AccountId) -> StfResult<()> {
 	let expected_enclave_account = enclave_signer_account();
 	if &expected_enclave_account == account {
 		Ok(())
@@ -159,7 +159,7 @@ pub fn ensure_registered_enclave(account: &AccountId) -> StfResult<()> {
 			account_id_to_string(&expected_enclave_account),
 			account_id_to_string(account)
 		);
-		Err(StfError::RequireSelfEnclaveAccount)
+		Err(StfError::RequireEnclaveSignerAccount)
 	}
 }
 

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -19,7 +19,12 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use itp_storage::{storage_double_map_key, storage_map_key, storage_value_key, StorageHasher};
+use itp_utils::stringify::account_id_to_string;
 use log::*;
+use sp_core::{
+	ed25519::{Pair as Ed25519Pair, Signature},
+	Pair,
+};
 use std::prelude::v1::*;
 
 pub fn get_storage_value<V: Decode>(
@@ -74,15 +79,15 @@ pub fn get_storage_by_key_hash<V: Decode>(key: Vec<u8>) -> Option<V> {
 }
 
 // get the AccountInfo key where the account is stored
-pub fn account_key_hash(account: &AccountId) -> Vec<u8> {
+pub(crate) fn account_key_hash(account: &AccountId) -> Vec<u8> {
 	storage_map_key("System", "Account", account, &StorageHasher::Blake2_128Concat)
 }
 
-pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
+pub(crate) fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
 	get_storage_map("System", "Account", who, &StorageHasher::Blake2_128Concat)
 }
 
-pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
+pub(crate) fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 	// validate
 	let expected_nonce = get_account_info(who).map_or_else(|| 0, |acc| acc.nonce);
 	if expected_nonce == nonce {
@@ -92,7 +97,7 @@ pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 }
 
 /// increment nonce after a successful call execution
-pub fn increment_nonce(account: &AccountId) {
+pub(crate) fn increment_nonce(account: &AccountId) {
 	//FIXME: Proper error handling - should be taken into
 	// consideration after implementing pay fee check
 	if let Some(mut acc_info) = get_account_info(account) {
@@ -109,7 +114,7 @@ pub fn increment_nonce(account: &AccountId) {
 	}
 }
 
-pub fn account_nonce(account: &AccountId) -> Index {
+pub(crate) fn account_nonce(account: &AccountId) -> Index {
 	if let Some(info) = get_account_info(account) {
 		info.nonce
 	} else {
@@ -117,7 +122,7 @@ pub fn account_nonce(account: &AccountId) -> Index {
 	}
 }
 
-pub fn account_data(account: &AccountId) -> Option<AccountData> {
+pub(crate) fn account_data(account: &AccountId) -> Option<AccountData> {
 	if let Some(info) = get_account_info(account) {
 		Some(info.data)
 	} else {
@@ -125,37 +130,49 @@ pub fn account_data(account: &AccountId) -> Option<AccountData> {
 	}
 }
 
-pub fn root() -> AccountId {
+pub(crate) fn root() -> AccountId {
 	get_storage_value("Sudo", "Key").unwrap()
 }
 
-pub fn enclave_self_account() -> AccountId {
-	get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap()
+pub(crate) fn enclave_self_account() -> AccountId {
+	let enclave_key_pair: Ed25519Pair = get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap();
+	enclave_key_pair.public().into()
+}
+
+pub(crate) fn sign_with_enclave_account(payload: &[u8]) -> Signature {
+	let enclave_key_pair: Ed25519Pair = get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).unwrap();
+	enclave_key_pair.sign(payload)
 }
 
 // FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
-pub fn get_parentchain_blockhash() -> Option<H256> {
+pub(crate) fn get_parentchain_blockhash() -> Option<H256> {
 	get_storage_value("Parentchain", "BlockHash")
 }
 
 // FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
-pub fn get_parentchain_parenthash() -> Option<H256> {
+pub(crate) fn get_parentchain_parenthash() -> Option<H256> {
 	get_storage_value("Parentchain", "ParentHash")
 }
 
-pub fn get_parentchain_number() -> Option<BlockNumber> {
+pub(crate) fn get_parentchain_number() -> Option<BlockNumber> {
 	get_storage_value("Parentchain", "Number")
 }
 
-pub fn ensure_self(account: AccountId) -> StfResult<()> {
-	if enclave_self_account() == account {
+pub(crate) fn ensure_self(account: &AccountId) -> StfResult<()> {
+	let expected_enclave_account = enclave_self_account();
+	if &expected_enclave_account == account {
 		Ok(())
 	} else {
+		error!(
+			"Expected enclave account {}, but found {}",
+			account_id_to_string(&expected_enclave_account),
+			account_id_to_string(&account)
+		);
 		Err(StfError::RequireSelfEnclaveAccount)
 	}
 }
 
-pub fn ensure_root(account: AccountId) -> StfResult<()> {
+pub(crate) fn ensure_root(account: AccountId) -> StfResult<()> {
 	if root() == account {
 		Ok(())
 	} else {

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -53,6 +53,8 @@ pub type StfResult<T> = Result<T, StfError>;
 pub enum StfError {
 	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
 	MissingPrivileges(AccountId),
+	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
+	RequireSelfEnclaveAccount,
 	#[display(fmt = "Error dispatching runtime call. {:?}", _0)]
 	Dispatch(String),
 	#[display(fmt = "Not enough funds to perform operation")]

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -26,8 +26,6 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-extern crate alloc;
-
 #[cfg(feature = "std")]
 pub use my_node_runtime::{Balance, Index};
 #[cfg(feature = "sgx")]
@@ -100,6 +98,8 @@ pub mod stf_sgx_primitives;
 
 #[cfg(feature = "sgx")]
 pub mod stf_sgx;
+#[cfg(all(feature = "test", feature = "sgx"))]
+pub mod stf_sgx_tests;
 #[cfg(all(feature = "test", feature = "sgx"))]
 pub mod test_genesis;
 

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -51,8 +51,8 @@ pub type StfResult<T> = Result<T, StfError>;
 pub enum StfError {
 	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
 	MissingPrivileges(AccountId),
-	#[display(fmt = "Enclave self account is required")]
-	RequireSelfEnclaveAccount,
+	#[display(fmt = "Valid enclave signer account is required")]
+	RequireEnclaveSignerAccount,
 	#[display(fmt = "Error dispatching runtime call. {:?}", _0)]
 	Dispatch(String),
 	#[display(fmt = "Not enough funds to perform operation")]

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -53,7 +53,7 @@ pub type StfResult<T> = Result<T, StfError>;
 pub enum StfError {
 	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
 	MissingPrivileges(AccountId),
-	#[display(fmt = "Insufficient privileges {:?}, are you sure you are root?", _0)]
+	#[display(fmt = "Enclave self account is required")]
 	RequireSelfEnclaveAccount,
 	#[display(fmt = "Error dispatching runtime call. {:?}", _0)]
 	Dispatch(String),
@@ -104,6 +104,8 @@ pub mod stf_sgx;
 pub mod test_genesis;
 
 pub use stf_sgx_primitives::types::*;
+
+pub(crate) const ENCLAVE_ACCOUNT_KEY: &str = "Enclave_Account_Key";
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]
 #[allow(non_camel_case_types)]

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -20,7 +20,7 @@ use crate::test_genesis::test_genesis_setup;
 
 use crate::{
 	helpers::{
-		account_data, account_nonce, enclave_signer_account, ensure_registered_enclave,
+		account_data, account_nonce, enclave_signer_account, ensure_enclave_signer_account,
 		ensure_root, get_account_info, increment_nonce, root, validate_nonce,
 	},
 	AccountData, AccountId, Getter, Index, ParentchainHeader, PublicGetter, ShardIdentifier, State,
@@ -183,7 +183,7 @@ impl Stf {
 					Ok(())
 				},
 				TrustedCall::balance_shield(enclave_account, who, value) => {
-					ensure_registered_enclave(&enclave_account)?;
+					ensure_enclave_signer_account(&enclave_account)?;
 					debug!("balance_shield({:x?}, {})", who.encode(), value);
 					Self::shield_funds(who, value)?;
 					Ok(())

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -20,8 +20,8 @@ use crate::test_genesis::test_genesis_setup;
 
 use crate::{
 	helpers::{
-		account_data, account_nonce, enclave_self_account, ensure_root, ensure_self,
-		get_account_info, increment_nonce, root, validate_nonce,
+		account_data, account_nonce, enclave_signer_account, ensure_registered_enclave,
+		ensure_root, get_account_info, increment_nonce, root, validate_nonce,
 	},
 	AccountData, AccountId, Getter, Index, ParentchainHeader, PublicGetter, ShardIdentifier, State,
 	StateTypeDiff, Stf, StfError, StfResult, TrustedCall, TrustedCallSigned, TrustedGetter,
@@ -183,7 +183,7 @@ impl Stf {
 					Ok(())
 				},
 				TrustedCall::balance_shield(enclave_account, who, value) => {
-					ensure_self(&enclave_account)?;
+					ensure_registered_enclave(&enclave_account)?;
 					debug!("balance_shield({:x?}, {})", who.encode(), value);
 					Self::shield_funds(who, value)?;
 					Ok(())
@@ -303,7 +303,7 @@ impl Stf {
 	}
 
 	pub fn get_enclave_account(ext: &mut impl SgxExternalitiesTrait) -> AccountId {
-		ext.execute_with(|| enclave_self_account())
+		ext.execute_with(|| enclave_signer_account())
 	}
 
 	pub fn account_nonce(ext: &mut impl SgxExternalitiesTrait, account: &AccountId) -> Index {

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -77,7 +77,7 @@ impl Stf {
 				&enclave_account.encode(),
 			);
 
-			if let Err(e) = Self::ensure_self_has_valid_account(&enclave_account) {
+			if let Err(e) = Self::create_enclave_self_account(&enclave_account) {
 				error!("Failed to initialize the enclave signer account: {:?}", e);
 			}
 		});
@@ -194,10 +194,9 @@ impl Stf {
 		})
 	}
 
-	/// Ensures that the enclave account has a valid account with a balance
-	/// that is above the existential deposit.
+	/// Creates valid enclave account with a balance that is above the existential deposit.
 	/// !! Requires a root to be set.
-	fn ensure_self_has_valid_account(enclave_account: &AccountId) -> StfResult<()> {
+	fn create_enclave_self_account(enclave_account: &AccountId) -> StfResult<()> {
 		sgx_runtime::BalancesCall::<Runtime>::set_balance {
 			who: MultiAddress::Id(enclave_account.clone()),
 			new_free: 1000,

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -21,7 +21,7 @@ use crate::test_genesis::test_genesis_setup;
 use crate::{
 	helpers::{
 		account_data, account_nonce, enclave_self_account, ensure_root, ensure_self,
-		get_account_info, increment_nonce, root, validate_nonce,
+		get_account_info, increment_nonce, root, sign_with_enclave_account, validate_nonce,
 	},
 	AccountData, AccountId, Getter, Index, ParentchainHeader, PublicGetter, ShardIdentifier, State,
 	StateTypeDiff, Stf, StfError, StfResult, TrustedCall, TrustedCallSigned, TrustedGetter,
@@ -31,20 +31,25 @@ use codec::Encode;
 use itp_settings::node::{TEEREX_MODULE, UNSHIELD_FUNDS};
 use itp_storage::storage_value_key;
 use itp_types::OpaqueCall;
+use itp_utils::stringify::account_id_to_string;
 use its_primitives::types::{BlockHash, BlockNumber as SidechainBlockNumber, Timestamp};
 use its_state::SidechainSystemExt;
 use log::*;
 use sgx_externalities::SgxExternalitiesTrait;
 use sgx_runtime::Runtime;
 use sgx_tstd as std;
+use sp_core::{
+	ed25519::{Pair as Ed25519Pair, Signature},
+	Pair,
+};
 use sp_io::hashing::blake2_256;
 use sp_runtime::MultiAddress;
 use std::{prelude::v1::*, vec};
 use support::traits::UnfilteredDispatchable;
 
 impl Stf {
-	pub fn init_state(enclave_account: AccountId) -> State {
-		debug!("initializing stf state");
+	pub fn init_state() -> State {
+		debug!("initializing stf state, account id {}", account_id_to_string(&enclave_account));
 		let mut ext = State::new();
 
 		ext.execute_with(|| {
@@ -69,9 +74,10 @@ impl Stf {
 		});
 
 		ext.execute_with(|| {
+			let (enclave_key_pair, _, _) = Ed25519Pair::generate_with_phrase(None);
 			sp_io::storage::set(
 				&storage_value_key("Sudo", ENCLAVE_ACCOUNT_KEY),
-				&enclave_account.encode(),
+				&enclave_key_pair.encode(),
 			);
 		});
 
@@ -287,6 +293,13 @@ impl Stf {
 
 	pub fn get_enclave_account(ext: &mut impl SgxExternalitiesTrait) -> AccountId {
 		ext.execute_with(|| enclave_self_account())
+	}
+
+	pub fn sign_with_enclave_account(
+		ext: &mut impl SgxExternalitiesTrait,
+		payload: &[u8],
+	) -> Signature {
+		ext.execute_with(|| sign_with_enclave_account(payload))
 	}
 
 	pub fn account_nonce(ext: &mut impl SgxExternalitiesTrait, account: &AccountId) -> Index {

--- a/app-libs/stf/src/stf_sgx_tests.rs
+++ b/app-libs/stf/src/stf_sgx_tests.rs
@@ -15,11 +15,50 @@
 
 */
 
-use crate::{AccountId, Stf};
+use crate::{AccountId, Signature, Stf, TrustedCall, TrustedCallSigned};
+use sp_core::{
+	ed25519::{Pair as Ed25519Pair, Signature as Ed25519Signature},
+	Pair,
+};
+use std::vec::Vec;
 
 pub fn enclave_account_initialization_works() {
 	let enclave_account = AccountId::new([2u8; 32]);
 	let mut state = Stf::init_state(enclave_account.clone());
+	let _root = Stf::get_root(&mut state);
+
+	let account_data = Stf::account_data(&mut state, &enclave_account).unwrap();
+
 	assert_eq!(0, Stf::account_nonce(&mut state, &enclave_account));
 	assert_eq!(enclave_account, Stf::get_enclave_account(&mut state));
+	assert_eq!(1000, account_data.free);
+}
+
+pub fn shield_funds_increments_signer_account_nonce() {
+	let enclave_call_signer = Ed25519Pair::from_seed(b"14672678901234567890123456789012");
+	let enclave_signer_account_id: AccountId = enclave_call_signer.public().into();
+
+	let mut state = Stf::init_state(enclave_signer_account_id.clone());
+
+	let shield_funds_call = TrustedCallSigned::new(
+		TrustedCall::balance_shield(
+			enclave_call_signer.public().into(),
+			AccountId::new([1u8; 32]),
+			500u128,
+		),
+		0,
+		Signature::Ed25519(Ed25519Signature([0u8; 64])),
+	);
+
+	Stf::execute(&mut state, shield_funds_call, &mut Vec::new()).unwrap();
+	assert_eq!(1, Stf::account_nonce(&mut state, &enclave_signer_account_id));
+}
+
+pub fn test_root_account_exists_after_initialization() {
+	let enclave_account = AccountId::new([2u8; 32]);
+	let mut state = Stf::init_state(enclave_account.clone());
+	let root_account = Stf::get_root(&mut state);
+
+	let account_data = Stf::account_data(&mut state, &root_account).unwrap();
+	assert!(account_data.free > 0);
 }

--- a/app-libs/stf/src/stf_sgx_tests.rs
+++ b/app-libs/stf/src/stf_sgx_tests.rs
@@ -1,0 +1,33 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::Stf;
+use sp_core::{ed25519::Pair as spEd25519Pair, Pair};
+use sp_runtime::traits::Verify;
+
+pub fn enclave_account_signing_works() {
+	let mut state = Stf::init_state();
+	let payload = [3u8; 45];
+
+	let enclave_account = Stf::get_enclave_account(&mut state).unwrap();
+	let enclave_account_nonce = Stf::account_nonce(&mut state, &enclave_account);
+
+	let payload_signature = Stf::sign_with_enclave_account(&mut state, &payload);
+
+	assert_eq!(0, enclave_account_nonce);
+	assert!(payload_signature.verify(&payload, sp_core::ed25519::Public::from_raw(enclave_account)));
+}

--- a/core-primitives/sgx/crypto/src/error.rs
+++ b/core-primitives/sgx/crypto/src/error.rs
@@ -15,6 +15,9 @@
 
 */
 
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+use crate::sgx_reexport_prelude::*;
+
 use derive_more::{Display, From};
 use sgx_types::sgx_status_t;
 use std::prelude::v1::Box;
@@ -24,6 +27,7 @@ pub enum Error {
 	IO(std::io::Error),
 	InvalidNonceKeyLength,
 	Codec(codec::Error),
+	Serialization(serde_json::Error),
 	LockPoisoning,
 	Other(Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/core-primitives/sgx/crypto/src/lib.rs
+++ b/core-primitives/sgx/crypto/src/lib.rs
@@ -35,6 +35,7 @@ pub mod sgx_reexport_prelude {
 
 pub mod aes;
 pub mod ed25519;
+pub mod ed25519_derivation;
 pub mod error;
 pub mod key_repository;
 pub mod rsa3072;

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -9,6 +9,7 @@ resolver = "2"
 # sgx dependencies
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
+sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false }
 
 # integritee dependencies
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
@@ -16,6 +17,7 @@ sgx-externalities = { default-features = false, git = "https://github.com/integr
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }
 itp-ocall-api = { path = "../ocall-api", default-features = false }
+itp-sgx-crypto = { path = "../sgx/crypto", default-features = false }
 itp-stf-state-handler = { path = "../stf-state-handler", default-features = false }
 itp-storage = { path = "../storage", default-features = false }
 itp-time-utils = { path = "../time-utils", default-features = false }
@@ -46,6 +48,7 @@ std = [
     # local
     "ita-stf/std",
     "itp-ocall-api/std",
+    "itp-sgx-crypto/std",
     "itp-stf-state-handler/std",
     "itp-storage/std",
     "itp-types/std",
@@ -61,6 +64,7 @@ std = [
 sgx = [
     "sgx_tstd",
     "ita-stf/sgx",
+    "itp-sgx-crypto/sgx",
     "itp-stf-state-handler/sgx",
     "itp-storage/sgx",
     "itp-time-utils/sgx",

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 # sgx dependencies
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
-sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false }
+sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
 
 # integritee dependencies
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
@@ -73,5 +73,6 @@ sgx = [
 ]
 test = [
     "itp-test",
+    "sgx-crypto-helper",
 ]
 mocks = []

--- a/core-primitives/stf-executor/src/enclave_signer.rs
+++ b/core-primitives/stf-executor/src/enclave_signer.rs
@@ -18,49 +18,61 @@
 use crate::{error::Result, traits::StfEnclaveSigning};
 use ita_stf::{AccountId, Index, KeyPair, Stf, TrustedCall, TrustedCallSigned};
 use itp_ocall_api::EnclaveAttestationOCallApi;
+use itp_sgx_crypto::{ed25519_derivation::DeriveEd25519, key_repository::AccessKey};
 use itp_stf_state_handler::handle_state::HandleState;
 use itp_types::ShardIdentifier;
 use sgx_externalities::SgxExternalitiesTrait;
 use sp_core::{ed25519::Pair as Ed25519Pair, Pair, H256};
 use std::sync::Arc;
 
-pub struct StfEnclaveSigner<OCallApi, StateHandler, SigningKey> {
+pub struct StfEnclaveSigner<OCallApi, StateHandler, ShieldingKeyRepository> {
 	state_handler: Arc<StateHandler>,
 	ocall_api: Arc<OCallApi>,
-	signer: SigningKey,
+	shielding_key_repo: Arc<ShieldingKeyRepository>,
 }
 
-impl<OCallApi, StateHandler> StfEnclaveSigner<OCallApi, StateHandler, Ed25519Pair>
+impl<OCallApi, StateHandler, ShieldingKeyRepository>
+	StfEnclaveSigner<OCallApi, StateHandler, ShieldingKeyRepository>
 where
 	OCallApi: EnclaveAttestationOCallApi,
 	StateHandler: HandleState<HashType = H256>,
 	StateHandler::StateT: SgxExternalitiesTrait,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: DeriveEd25519,
 {
 	pub fn new(
 		state_handler: Arc<StateHandler>,
 		ocall_api: Arc<OCallApi>,
-		signer: Ed25519Pair,
+		shielding_key_repo: Arc<ShieldingKeyRepository>,
 	) -> Self {
-		Self { state_handler, ocall_api, signer }
+		Self { state_handler, ocall_api, shielding_key_repo }
 	}
 
 	fn get_enclave_account_nonce(&self, shard: &ShardIdentifier) -> Result<Index> {
-		let enclave_account = self.get_enclave_account();
+		let enclave_account = self.get_enclave_account()?;
 		let mut state = self.state_handler.load(shard)?;
 		let nonce = Stf::account_nonce(&mut state, &enclave_account);
 		Ok(nonce)
 	}
+
+	fn get_enclave_call_signing_key(&self) -> Result<Ed25519Pair> {
+		let shielding_key = self.shielding_key_repo.retrieve_key()?;
+		shielding_key.derive_ed25519().map_err(|e| e.into())
+	}
 }
 
-impl<OCallApi, StateHandler> StfEnclaveSigning
-	for StfEnclaveSigner<OCallApi, StateHandler, Ed25519Pair>
+impl<OCallApi, StateHandler, ShieldingKeyRepository> StfEnclaveSigning
+	for StfEnclaveSigner<OCallApi, StateHandler, ShieldingKeyRepository>
 where
 	OCallApi: EnclaveAttestationOCallApi,
 	StateHandler: HandleState<HashType = H256>,
 	StateHandler::StateT: SgxExternalitiesTrait,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: DeriveEd25519,
 {
-	fn get_enclave_account(&self) -> AccountId {
-		self.signer.public().into()
+	fn get_enclave_account(&self) -> Result<AccountId> {
+		let enclave_call_signing_key = self.get_enclave_call_signing_key()?;
+		Ok(enclave_call_signing_key.public().into())
 	}
 
 	fn sign_call_with_self(
@@ -70,9 +82,10 @@ where
 	) -> Result<TrustedCallSigned> {
 		let mr_enclave = self.ocall_api.get_mrenclave_of_self()?;
 		let enclave_account_nonce = self.get_enclave_account_nonce(shard)?;
+		let enclave_call_signing_key = self.get_enclave_call_signing_key()?;
 
 		Ok(trusted_call.sign(
-			&KeyPair::Ed25519(self.signer.clone()),
+			&KeyPair::Ed25519(enclave_call_signing_key),
 			enclave_account_nonce,
 			&mr_enclave.m,
 			shard,

--- a/core-primitives/stf-executor/src/enclave_signer_tests.rs
+++ b/core-primitives/stf-executor/src/enclave_signer_tests.rs
@@ -21,20 +21,32 @@ use crate::{
 };
 use ita_stf::{AccountId, TrustedCall};
 use itp_ocall_api::EnclaveAttestationOCallApi;
+use itp_sgx_crypto::{ed25519_derivation::DeriveEd25519, mocks::KeyRepositoryMock};
 use itp_test::mock::{handle_state_mock::HandleStateMock, onchain_mock::OnchainMock};
+use sgx_crypto_helper::{rsa3072::Rsa3072KeyPair, RsaKeyPair};
 use sp_core::Pair;
 use std::sync::Arc;
+
+type ShieldingKeyRepositoryMock = KeyRepositoryMock<Rsa3072KeyPair>;
+
+pub fn derive_key_is_deterministic() {
+	let rsa_key = Rsa3072KeyPair::new().unwrap();
+
+	let first_ed_key = rsa_key.derive_ed25519().unwrap();
+	let second_ed_key = rsa_key.derive_ed25519().unwrap();
+	assert_eq!(first_ed_key.public(), second_ed_key.public());
+}
 
 pub fn enclave_signer_signatures_are_valid() {
 	let ocall_api = Arc::new(OnchainMock::default());
 	let state_handler = Arc::new(HandleStateMock::default());
-	let signer = sp_core::ed25519::Pair::from_seed(b"61345678901234567890123456789012");
+	let shielding_key_repo = Arc::new(ShieldingKeyRepositoryMock::default());
 	let (_, shard) = init_state_and_shard_with_state_handler(state_handler.as_ref());
 	let mr_enclave = ocall_api.get_mrenclave_of_self().unwrap();
 
-	let enclave_signer = StfEnclaveSigner::new(state_handler, ocall_api, signer);
+	let enclave_signer = StfEnclaveSigner::new(state_handler, ocall_api, shielding_key_repo);
 
-	let enclave_account = enclave_signer.get_enclave_account();
+	let enclave_account = enclave_signer.get_enclave_account().unwrap();
 	let trusted_call =
 		TrustedCall::balance_shield(enclave_account, AccountId::new([3u8; 32]), 200u128);
 

--- a/core-primitives/stf-executor/src/error.rs
+++ b/core-primitives/stf-executor/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
 	Stf(ita_stf::StfError),
 	#[error("Ocall Api error: {0}")]
 	OcallApi(itp_ocall_api::Error),
+	#[error("Crypto error: {0}")]
+	Crypto(itp_sgx_crypto::error::Error),
 	#[error(transparent)]
 	Other(#[from] Box<dyn std::error::Error + Sync + Send + 'static>),
 }
@@ -63,5 +65,11 @@ impl From<ita_stf::StfError> for Error {
 impl From<itp_ocall_api::Error> for Error {
 	fn from(error: itp_ocall_api::Error) -> Self {
 		Self::OcallApi(error)
+	}
+}
+
+impl From<itp_sgx_crypto::error::Error> for Error {
+	fn from(error: itp_sgx_crypto::error::Error) -> Self {
+		Self::Crypto(error)
 	}
 }

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -18,46 +18,43 @@
 use crate::{
 	error::{Error, Result},
 	traits::{
-		StatePostProcessing, StateUpdateProposer, StfExecuteGenericUpdate, StfExecuteShieldFunds,
-		StfExecuteTimedGettersBatch, StfExecuteTrustedCall, StfUpdateState,
+		StatePostProcessing, StateUpdateProposer, StfExecuteGenericUpdate,
+		StfExecuteTimedGettersBatch, StfUpdateState,
 	},
-	BatchExecutionResult, ExecutedOperation, ExecutionStatus,
+	BatchExecutionResult, ExecutedOperation,
 };
 use codec::{Decode, Encode};
 use ita_stf::{
 	hash::TrustedOperationOrHash,
 	stf_sgx::{shards_key_hash, storage_hashes_to_update_per_shard},
-	AccountId, ParentchainHeader, ShardIdentifier, StateTypeDiff, Stf, TrustedCall,
-	TrustedCallSigned, TrustedGetterSigned, TrustedOperation,
+	ParentchainHeader, ShardIdentifier, StateTypeDiff, Stf, TrustedGetterSigned, TrustedOperation,
 };
 use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
 use itp_stf_state_handler::{handle_state::HandleState, query_shard_state::QueryShardState};
 use itp_storage::StorageEntryVerified;
 use itp_time_utils::duration_now;
-use itp_types::{Amount, OpaqueCall, H256};
+use itp_types::{OpaqueCall, H256};
 use log::*;
 use sgx_externalities::SgxExternalitiesTrait;
-use sp_core::ed25519;
 use sp_runtime::{app_crypto::sp_core::blake2_256, traits::Header as HeaderTrait};
 use std::{
-	collections::BTreeMap, fmt::Debug, format, marker::PhantomData, result::Result as StdResult,
-	sync::Arc, time::Duration, vec::Vec,
+	collections::BTreeMap, fmt::Debug, format, result::Result as StdResult, sync::Arc,
+	time::Duration, vec::Vec,
 };
 
-pub struct StfExecutor<OCallApi, StateHandler, ExternalitiesT> {
+pub struct StfExecutor<OCallApi, StateHandler> {
 	ocall_api: Arc<OCallApi>,
 	state_handler: Arc<StateHandler>,
-	_phantom_externalities: PhantomData<ExternalitiesT>,
 }
 
-impl<OCallApi, StateHandler, ExternalitiesT> StfExecutor<OCallApi, StateHandler, ExternalitiesT>
+impl<OCallApi, StateHandler> StfExecutor<OCallApi, StateHandler>
 where
 	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi,
-	StateHandler: HandleState<StateT = ExternalitiesT, HashType = H256>,
-	ExternalitiesT: SgxExternalitiesTrait + Encode,
+	StateHandler: HandleState<HashType = H256>,
+	StateHandler::StateT: SgxExternalitiesTrait + Encode,
 {
 	pub fn new(ocall_api: Arc<OCallApi>, state_handler: Arc<StateHandler>) -> Self {
-		StfExecutor { ocall_api, state_handler, _phantom_externalities: Default::default() }
+		StfExecutor { ocall_api, state_handler }
 	}
 
 	/// Execute a trusted call on the STF
@@ -125,90 +122,11 @@ where
 	}
 }
 
-impl<OCallApi, StateHandler, ExternalitiesT> StfExecuteTrustedCall
-	for StfExecutor<OCallApi, StateHandler, ExternalitiesT>
+impl<OCallApi, StateHandler> StfUpdateState for StfExecutor<OCallApi, StateHandler>
 where
 	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi,
-	StateHandler: HandleState<StateT = ExternalitiesT, HashType = H256>,
-	ExternalitiesT: SgxExternalitiesTrait + Encode,
-{
-	fn execute_trusted_call<PH>(
-		&self,
-		calls: &mut Vec<OpaqueCall>,
-		stf_call_signed: &TrustedOperation,
-		header: &PH,
-		shard: &ShardIdentifier,
-		post_processing: StatePostProcessing,
-	) -> Result<Option<H256>>
-	where
-		PH: HeaderTrait<Hash = H256>,
-	{
-		// load state before executing any calls
-		let (state_lock, mut state) = self.state_handler.load_for_mutation(shard)?;
-
-		let executed_call = self.execute_trusted_call_on_stf(
-			&mut state,
-			stf_call_signed,
-			header,
-			shard,
-			post_processing,
-		)?;
-
-		let (maybe_call_hash, mut extrinsic_callbacks) = match executed_call.status {
-			ExecutionStatus::Success(call_hash, e) => (Some(call_hash), e),
-			ExecutionStatus::Failure => (None, Vec::new()),
-		};
-
-		calls.append(&mut extrinsic_callbacks);
-
-		trace!("Updating state of shard {:?}", shard);
-		self.state_handler.write_after_mutation(state, state_lock, shard)?;
-
-		Ok(maybe_call_hash)
-	}
-}
-
-impl<OCallApi, StateHandler, ExternalitiesT> StfExecuteShieldFunds
-	for StfExecutor<OCallApi, StateHandler, ExternalitiesT>
-where
-	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi,
-	StateHandler: HandleState<StateT = ExternalitiesT, HashType = H256>,
-	ExternalitiesT: SgxExternalitiesTrait + Encode,
-{
-	fn execute_shield_funds(
-		&self,
-		account: AccountId,
-		amount: Amount,
-		shard: &ShardIdentifier,
-	) -> Result<H256> {
-		let (state_lock, mut state) = self.state_handler.load_for_mutation(shard)?;
-
-		let root = Stf::get_root(&mut state);
-		let nonce = Stf::account_nonce(&mut state, &root);
-
-		let trusted_call = TrustedCallSigned::new(
-			TrustedCall::balance_shield(root, account, amount),
-			nonce,
-			ed25519::Signature::from_raw([0u8; 64]).into(), //don't care about signature here
-		);
-
-		debug!("Execute shield funds (nonce: {})", nonce);
-
-		Stf::execute(&mut state, trusted_call, &mut Vec::<OpaqueCall>::new())
-			.map_err::<Error, _>(|e| e.into())?;
-
-		self.state_handler
-			.write_after_mutation(state, state_lock, shard)
-			.map_err(|e| e.into())
-	}
-}
-
-impl<OCallApi, StateHandler, ExternalitiesT> StfUpdateState
-	for StfExecutor<OCallApi, StateHandler, ExternalitiesT>
-where
-	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi,
-	StateHandler: HandleState<StateT = ExternalitiesT, HashType = H256> + QueryShardState,
-	ExternalitiesT: SgxExternalitiesTrait + Encode,
+	StateHandler: HandleState<HashType = H256> + QueryShardState,
+	StateHandler::StateT: SgxExternalitiesTrait + Encode,
 {
 	fn update_states(&self, header: &ParentchainHeader) -> Result<()> {
 		debug!("Update STF storage upon block import!");
@@ -271,14 +189,13 @@ where
 	}
 }
 
-impl<OCallApi, StateHandler, ExternalitiesT> StateUpdateProposer
-	for StfExecutor<OCallApi, StateHandler, ExternalitiesT>
+impl<OCallApi, StateHandler> StateUpdateProposer for StfExecutor<OCallApi, StateHandler>
 where
 	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi,
-	StateHandler: HandleState<StateT = ExternalitiesT, HashType = H256>,
-	ExternalitiesT: SgxExternalitiesTrait + Encode,
+	StateHandler: HandleState<HashType = H256>,
+	StateHandler::StateT: SgxExternalitiesTrait + Encode,
 {
-	type Externalities = ExternalitiesT;
+	type Externalities = StateHandler::StateT;
 
 	fn propose_state_update<PH, F>(
 		&self,
@@ -332,14 +249,13 @@ where
 	}
 }
 
-impl<OCallApi, StateHandler, ExternalitiesT> StfExecuteTimedGettersBatch
-	for StfExecutor<OCallApi, StateHandler, ExternalitiesT>
+impl<OCallApi, StateHandler> StfExecuteTimedGettersBatch for StfExecutor<OCallApi, StateHandler>
 where
 	OCallApi: EnclaveAttestationOCallApi + EnclaveOnChainOCallApi,
-	StateHandler: HandleState<StateT = ExternalitiesT, HashType = H256>,
-	ExternalitiesT: SgxExternalitiesTrait + Encode,
+	StateHandler: HandleState<HashType = H256>,
+	StateHandler::StateT: SgxExternalitiesTrait + Encode,
 {
-	type Externalities = ExternalitiesT;
+	type Externalities = StateHandler::StateT;
 
 	fn execute_timed_getters_batch<F>(
 		&self,
@@ -379,13 +295,12 @@ where
 	}
 }
 
-impl<OCallApi, StateHandler, ExternalitiesT> StfExecuteGenericUpdate
-	for StfExecutor<OCallApi, StateHandler, ExternalitiesT>
+impl<OCallApi, StateHandler> StfExecuteGenericUpdate for StfExecutor<OCallApi, StateHandler>
 where
-	StateHandler: HandleState<StateT = ExternalitiesT, HashType = H256>,
-	ExternalitiesT: SgxExternalitiesTrait + Encode,
+	StateHandler: HandleState<HashType = H256>,
+	StateHandler::StateT: SgxExternalitiesTrait + Encode,
 {
-	type Externalities = ExternalitiesT;
+	type Externalities = StateHandler::StateT;
 
 	fn execute_update<F, ResultT, ErrorT>(
 		&self,

--- a/core-primitives/stf-executor/src/executor_tests.rs
+++ b/core-primitives/stf-executor/src/executor_tests.rs
@@ -287,7 +287,7 @@ pub fn upon_false_signature_get_stf_state_errs() {
 
 // Helper Functions
 fn stf_executor(
-) -> (StfExecutor<OnchainMock, HandleStateMock, State>, Arc<OnchainMock>, Arc<HandleStateMock>) {
+) -> (StfExecutor<OnchainMock, HandleStateMock>, Arc<OnchainMock>, Arc<HandleStateMock>) {
 	let ocall_api = Arc::new(OnchainMock::default());
 	let state_handler = Arc::new(HandleStateMock::default());
 	let executor = StfExecutor::new(ocall_api.clone(), state_handler.clone());

--- a/core-primitives/stf-executor/src/executor_tests.rs
+++ b/core-primitives/stf-executor/src/executor_tests.rs
@@ -301,7 +301,7 @@ fn test_state() -> State {
 }
 
 /// Returns a test setup initialized `State` with the corresponding `ShardIdentifier`.
-fn init_state_and_shard_with_state_handler<S: HandleState<StateT = State>>(
+pub(crate) fn init_state_and_shard_with_state_handler<S: HandleState<StateT = State>>(
 	state_handler: &S,
 ) -> (State, ShardIdentifier) {
 	let shard = ShardIdentifier::default();

--- a/core-primitives/stf-executor/src/lib.rs
+++ b/core-primitives/stf-executor/src/lib.rs
@@ -42,13 +42,13 @@ pub mod traits;
 pub mod executor;
 
 #[cfg(feature = "sgx")]
-pub mod root_operator;
+pub mod enclave_signer;
 
 #[cfg(all(feature = "sgx", feature = "test"))]
 pub mod executor_tests;
 
 #[cfg(all(feature = "sgx", feature = "test"))]
-pub mod root_operator_tests;
+pub mod enclave_signer_tests;
 
 #[cfg(feature = "mocks")]
 pub mod mocks;

--- a/core-primitives/stf-executor/src/lib.rs
+++ b/core-primitives/stf-executor/src/lib.rs
@@ -47,6 +47,9 @@ pub mod root_operator;
 #[cfg(all(feature = "sgx", feature = "test"))]
 pub mod executor_tests;
 
+#[cfg(all(feature = "sgx", feature = "test"))]
+pub mod root_operator_tests;
+
 #[cfg(feature = "mocks")]
 pub mod mocks;
 

--- a/core-primitives/stf-executor/src/lib.rs
+++ b/core-primitives/stf-executor/src/lib.rs
@@ -28,6 +28,7 @@ use ita_stf::hash::TrustedOperationOrHash;
 use itp_types::{OpaqueCall, H256};
 use sgx_externalities::SgxExternalitiesTrait;
 use std::vec::Vec;
+
 // re-export module to properly feature gate sgx and regular std environment
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 pub mod sgx_reexport_prelude {
@@ -40,10 +41,13 @@ pub mod traits;
 #[cfg(feature = "sgx")]
 pub mod executor;
 
+#[cfg(feature = "sgx")]
+pub mod root_operator;
+
 #[cfg(all(feature = "sgx", feature = "test"))]
 pub mod executor_tests;
 
-//#[cfg(feature = "mocks")]
+#[cfg(feature = "mocks")]
 pub mod mocks;
 
 /// Execution status of a trusted operation

--- a/core-primitives/stf-executor/src/mocks.rs
+++ b/core-primitives/stf-executor/src/mocks.rs
@@ -15,50 +15,13 @@
 
 */
 
-use crate::{
-	error::Result,
-	traits::{
-		StatePostProcessing, StfExecuteShieldFunds, StfExecuteTrustedCall, StfRootOperations,
-	},
-};
-use ita_stf::{
-	AccountId, KeyPair, ShardIdentifier, TrustedCall, TrustedCallSigned, TrustedOperation,
-};
-use itp_types::{Amount, OpaqueCall};
-use sp_core::{Pair, H256};
-use sp_runtime::traits::Header as HeaderTrait;
-use std::vec::Vec;
+use crate::{error::Result, traits::StfRootOperations};
+use ita_stf::{AccountId, KeyPair, ShardIdentifier, TrustedCall, TrustedCallSigned};
+use sp_core::Pair;
 
 /// Mock for the StfExecutor.
 #[derive(Default)]
 pub struct StfExecutorMock;
-
-impl StfExecuteTrustedCall for StfExecutorMock {
-	fn execute_trusted_call<PH>(
-		&self,
-		_calls: &mut Vec<OpaqueCall>,
-		_stf_call_signed: &TrustedOperation,
-		_header: &PH,
-		_shard: &ShardIdentifier,
-		_post_processing: StatePostProcessing,
-	) -> Result<Option<H256>>
-	where
-		PH: HeaderTrait<Hash = H256>,
-	{
-		todo!()
-	}
-}
-
-impl StfExecuteShieldFunds for StfExecutorMock {
-	fn execute_shield_funds(
-		&self,
-		_account: AccountId,
-		_amount: Amount,
-		_shard: &ShardIdentifier,
-	) -> Result<H256> {
-		todo!()
-	}
-}
 
 #[derive(Default)]
 pub struct StfRootOperationsMock;

--- a/core-primitives/stf-executor/src/mocks.rs
+++ b/core-primitives/stf-executor/src/mocks.rs
@@ -23,8 +23,21 @@ use sp_core::Pair;
 #[derive(Default)]
 pub struct StfExecutorMock;
 
-#[derive(Default)]
-pub struct StfRootOperationsMock;
+pub struct StfRootOperationsMock {
+	mr_enclave: [u8; 32],
+}
+
+impl StfRootOperationsMock {
+	pub fn new(mr_enclave: [u8; 32]) -> Self {
+		Self { mr_enclave }
+	}
+}
+
+impl Default for StfRootOperationsMock {
+	fn default() -> Self {
+		Self::new([0u8; 32])
+	}
+}
 
 impl StfRootOperations for StfRootOperationsMock {
 	fn get_root_account(&self, _shard: &ShardIdentifier) -> Result<AccountId> {
@@ -40,6 +53,6 @@ impl StfRootOperations for StfRootOperationsMock {
 		const TEST_SEED: Seed = *b"42345678901234567890123456789012";
 		let signer = sp_core::ed25519::Pair::from_seed(&TEST_SEED);
 
-		Ok(trusted_call.sign(&KeyPair::Ed25519(signer), 1, &[0u8; 32], shard))
+		Ok(trusted_call.sign(&KeyPair::Ed25519(signer), 1, &self.mr_enclave, shard))
 	}
 }

--- a/core-primitives/stf-executor/src/mocks.rs
+++ b/core-primitives/stf-executor/src/mocks.rs
@@ -44,8 +44,8 @@ impl Default for StfEnclaveSignerMock {
 }
 
 impl StfEnclaveSigning for StfEnclaveSignerMock {
-	fn get_enclave_account(&self) -> AccountId {
-		self.signer.public().into()
+	fn get_enclave_account(&self) -> Result<AccountId> {
+		Ok(self.signer.public().into())
 	}
 
 	fn sign_call_with_self(

--- a/core-primitives/stf-executor/src/mocks.rs
+++ b/core-primitives/stf-executor/src/mocks.rs
@@ -17,11 +17,15 @@
 
 use crate::{
 	error::Result,
-	traits::{StatePostProcessing, StfExecuteShieldFunds, StfExecuteTrustedCall},
+	traits::{
+		StatePostProcessing, StfExecuteShieldFunds, StfExecuteTrustedCall, StfRootOperations,
+	},
 };
-use ita_stf::{AccountId, ShardIdentifier, TrustedOperation};
+use ita_stf::{
+	AccountId, KeyPair, ShardIdentifier, TrustedCall, TrustedCallSigned, TrustedOperation,
+};
 use itp_types::{Amount, OpaqueCall};
-use sp_core::H256;
+use sp_core::{Pair, H256};
 use sp_runtime::traits::Header as HeaderTrait;
 use std::vec::Vec;
 
@@ -53,5 +57,26 @@ impl StfExecuteShieldFunds for StfExecutorMock {
 		_shard: &ShardIdentifier,
 	) -> Result<H256> {
 		todo!()
+	}
+}
+
+#[derive(Default)]
+pub struct StfRootOperationsMock;
+
+impl StfRootOperations for StfRootOperationsMock {
+	fn get_root_account(&self, _shard: &ShardIdentifier) -> Result<AccountId> {
+		Ok(AccountId::new([42u8; 32]))
+	}
+
+	fn sign_call_with_root(
+		&self,
+		trusted_call: &TrustedCall,
+		shard: &ShardIdentifier,
+	) -> Result<TrustedCallSigned> {
+		type Seed = [u8; 32];
+		const TEST_SEED: Seed = *b"42345678901234567890123456789012";
+		let signer = sp_core::ed25519::Pair::from_seed(&TEST_SEED);
+
+		Ok(trusted_call.sign(&KeyPair::Ed25519(signer), 1, &[0u8; 32], shard))
 	}
 }

--- a/core-primitives/stf-executor/src/root_operator.rs
+++ b/core-primitives/stf-executor/src/root_operator.rs
@@ -1,0 +1,77 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{error::Result, traits::StfRootOperations};
+use ita_stf::{AccountId, Index, KeyPair, Stf, TrustedCall, TrustedCallSigned};
+use itp_ocall_api::EnclaveAttestationOCallApi;
+use itp_stf_state_handler::handle_state::HandleState;
+use itp_types::ShardIdentifier;
+use sgx_externalities::SgxExternalitiesTrait;
+use sp_core::{ed25519::Pair, H256};
+use std::sync::Arc;
+
+pub struct StfRootOperator<OCallApi, StateHandler, Signer> {
+	state_handler: Arc<StateHandler>,
+	ocall_api: Arc<OCallApi>,
+	signer: Signer,
+}
+
+impl<OCallApi, StateHandler> StfRootOperator<OCallApi, StateHandler, Pair>
+where
+	OCallApi: EnclaveAttestationOCallApi,
+	StateHandler: HandleState<HashType = H256>,
+	StateHandler::StateT: SgxExternalitiesTrait,
+{
+	pub fn new(state_handler: Arc<StateHandler>, ocall_api: Arc<OCallApi>, signer: Pair) -> Self {
+		Self { state_handler, ocall_api, signer }
+	}
+
+	fn get_root_nonce(&self, shard: &ShardIdentifier) -> Result<Index> {
+		let mut state = self.state_handler.load(shard)?;
+		let root = Stf::get_root(&mut state);
+		let nonce = Stf::account_nonce(&mut state, &root);
+		Ok(nonce)
+	}
+}
+
+impl<OCallApi, StateHandler> StfRootOperations for StfRootOperator<OCallApi, StateHandler, Pair>
+where
+	OCallApi: EnclaveAttestationOCallApi,
+	StateHandler: HandleState<HashType = H256>,
+	StateHandler::StateT: SgxExternalitiesTrait,
+{
+	fn get_root_account(&self, shard: &ShardIdentifier) -> Result<AccountId> {
+		let mut state = self.state_handler.load(shard)?;
+		Ok(Stf::get_root(&mut state))
+	}
+
+	fn sign_call_with_root(
+		&self,
+		trusted_call: &TrustedCall,
+		shard: &ShardIdentifier,
+	) -> Result<TrustedCallSigned> {
+		let mr_enclave = self.ocall_api.get_mrenclave_of_self()?;
+		let root_nonce = self.get_root_nonce(shard)?;
+
+		Ok(trusted_call.sign(
+			&KeyPair::Ed25519(self.signer.clone()),
+			root_nonce,
+			&mr_enclave.m,
+			shard,
+		))
+	}
+}

--- a/core-primitives/stf-executor/src/root_operator_tests.rs
+++ b/core-primitives/stf-executor/src/root_operator_tests.rs
@@ -1,0 +1,44 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	executor_tests::init_state_and_shard_with_state_handler, root_operator::StfRootOperator,
+	traits::StfRootOperations,
+};
+use ita_stf::{AccountId, ShardIdentifier, TrustedCall};
+use itp_ocall_api::EnclaveAttestationOCallApi;
+use itp_stf_state_handler::handle_state::HandleState;
+use itp_test::mock::{handle_state_mock::HandleStateMock, onchain_mock::OnchainMock};
+use sp_core::Pair;
+use std::sync::Arc;
+
+pub fn root_operator_signatures_are_valid() {
+	let ocall_api = Arc::new(OnchainMock::default());
+	let state_handler = Arc::new(HandleStateMock::default());
+	let signer = sp_core::ed25519::Pair::from_seed(b"61345678901234567890123456789012");
+	let (_, shard) = init_state_and_shard_with_state_handler(state_handler.as_ref());
+	let mr_enclave = ocall_api.get_mrenclave_of_self().unwrap();
+
+	let root_operator = StfRootOperator::new(state_handler, ocall_api, signer);
+
+	let root_account = root_operator.get_root_account(&shard).unwrap();
+	let trusted_call =
+		TrustedCall::balance_shield(root_account, AccountId::new([3u8; 32]), 200u128);
+
+	let trusted_call_signed = root_operator.sign_call_with_root(&trusted_call, &shard).unwrap();
+	assert!(trusted_call_signed.verify_signature(&mr_enclave.m, &shard));
+}

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -18,7 +18,8 @@
 use crate::{error::Result, BatchExecutionResult};
 use codec::Encode;
 use ita_stf::{
-	AccountId, ParentchainHeader, ShardIdentifier, TrustedGetterSigned, TrustedOperation,
+	AccountId, ParentchainHeader, ShardIdentifier, TrustedCall, TrustedCallSigned,
+	TrustedGetterSigned, TrustedOperation,
 };
 use itp_types::{Amount, OpaqueCall, H256};
 use sgx_externalities::SgxExternalitiesTrait;
@@ -39,6 +40,17 @@ pub trait StfExecuteShieldFunds {
 		amount: Amount,
 		shard: &ShardIdentifier,
 	) -> Result<H256>;
+}
+
+/// Operations as STF root.
+pub trait StfRootOperations {
+	fn get_root_account(&self, shard: &ShardIdentifier) -> Result<AccountId>;
+
+	fn sign_call_with_root(
+		&self,
+		trusted_call: &TrustedCall,
+		shard: &ShardIdentifier,
+	) -> Result<TrustedCallSigned>;
 }
 
 /// Execute a trusted call on the STF

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -21,7 +21,7 @@ use ita_stf::{
 	AccountId, ParentchainHeader, ShardIdentifier, TrustedCall, TrustedCallSigned,
 	TrustedGetterSigned, TrustedOperation,
 };
-use itp_types::{Amount, OpaqueCall, H256};
+use itp_types::H256;
 use sgx_externalities::SgxExternalitiesTrait;
 use sp_runtime::traits::Header as HeaderTrait;
 use std::{fmt::Debug, result::Result as StdResult, time::Duration, vec::Vec};
@@ -30,16 +30,6 @@ use std::{fmt::Debug, result::Result as StdResult, time::Duration, vec::Vec};
 pub enum StatePostProcessing {
 	None,
 	Prune,
-}
-
-/// Execute shield funds on the STF
-pub trait StfExecuteShieldFunds {
-	fn execute_shield_funds(
-		&self,
-		account: AccountId,
-		amount: Amount,
-		shard: &ShardIdentifier,
-	) -> Result<H256>;
 }
 
 /// Operations as STF root.
@@ -51,20 +41,6 @@ pub trait StfRootOperations {
 		trusted_call: &TrustedCall,
 		shard: &ShardIdentifier,
 	) -> Result<TrustedCallSigned>;
-}
-
-/// Execute a trusted call on the STF
-pub trait StfExecuteTrustedCall {
-	fn execute_trusted_call<PH>(
-		&self,
-		calls: &mut Vec<OpaqueCall>,
-		stf_call_signed: &TrustedOperation,
-		header: &PH,
-		shard: &ShardIdentifier,
-		post_processing: StatePostProcessing,
-	) -> Result<Option<H256>>
-	where
-		PH: HeaderTrait<Hash = H256>;
 }
 
 /// Proposes a state update to `Externalities`.

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -32,7 +32,7 @@ pub enum StatePostProcessing {
 	Prune,
 }
 
-/// Operations as STF root.
+/// Allows signing of a trusted call with the enclave account that is registered in the STF.
 pub trait StfEnclaveSigning {
 	fn get_enclave_account(&self) -> AccountId;
 

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -34,7 +34,7 @@ pub enum StatePostProcessing {
 
 /// Allows signing of a trusted call with the enclave account that is registered in the STF.
 pub trait StfEnclaveSigning {
-	fn get_enclave_account(&self) -> AccountId;
+	fn get_enclave_account(&self) -> Result<AccountId>;
 
 	fn sign_call_with_self(
 		&self,

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -33,6 +33,8 @@ pub enum StatePostProcessing {
 }
 
 /// Allows signing of a trusted call with the enclave account that is registered in the STF.
+///
+/// The signing key is derived from the shielding key, which guarantees that all enclaves sign the same key.
 pub trait StfEnclaveSigning {
 	fn get_enclave_account(&self) -> Result<AccountId>;
 

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -33,10 +33,10 @@ pub enum StatePostProcessing {
 }
 
 /// Operations as STF root.
-pub trait StfRootOperations {
-	fn get_root_account(&self, shard: &ShardIdentifier) -> Result<AccountId>;
+pub trait StfEnclaveSigning {
+	fn get_enclave_account(&self) -> AccountId;
 
-	fn sign_call_with_root(
+	fn sign_call_with_self(
 		&self,
 		trusted_call: &TrustedCall,
 		shard: &ShardIdentifier,

--- a/core-primitives/stf-state-handler/src/file_io.rs
+++ b/core-primitives/stf-state-handler/src/file_io.rs
@@ -91,7 +91,7 @@ pub mod sgx {
 	use crate::error::Error;
 	use base58::FromBase58;
 	use codec::Decode;
-	use ita_stf::{State as StfState, StateType as StfStateType, Stf};
+	use ita_stf::{AccountId, State as StfState, StateType as StfStateType, Stf};
 	use itp_sgx_crypto::{key_repository::AccessKey, StateCrypto};
 	use itp_sgx_io::{read as io_read, write as io_write};
 	use itp_types::H256;
@@ -102,6 +102,7 @@ pub mod sgx {
 	/// SGX state file I/O.
 	pub struct SgxStateFileIo<StateKeyRepository> {
 		state_key_repository: Arc<StateKeyRepository>,
+		enclave_account: AccountId,
 	}
 
 	impl<StateKeyRepository> SgxStateFileIo<StateKeyRepository>
@@ -109,8 +110,11 @@ pub mod sgx {
 		StateKeyRepository: AccessKey,
 		<StateKeyRepository as AccessKey>::KeyType: StateCrypto,
 	{
-		pub fn new(state_key_repository: Arc<StateKeyRepository>) -> Self {
-			SgxStateFileIo { state_key_repository }
+		pub fn new(
+			state_key_repository: Arc<StateKeyRepository>,
+			enclave_account: AccountId,
+		) -> Self {
+			SgxStateFileIo { state_key_repository, enclave_account }
 		}
 
 		fn read(&self, path: &Path) -> Result<Vec<u8>> {
@@ -204,7 +208,7 @@ pub mod sgx {
 			state_id: StateId,
 		) -> Result<Self::HashType> {
 			init_shard(&shard_identifier)?;
-			let state = Stf::init_state();
+			let state = Stf::init_state(self.enclave_account.clone());
 			self.write(shard_identifier, state_id, state)
 		}
 

--- a/core-primitives/stf-state-handler/src/file_io.rs
+++ b/core-primitives/stf-state-handler/src/file_io.rs
@@ -102,6 +102,7 @@ pub mod sgx {
 	/// SGX state file I/O.
 	pub struct SgxStateFileIo<StateKeyRepository> {
 		state_key_repository: Arc<StateKeyRepository>,
+		enclave_account: AccountId,
 	}
 
 	impl<StateKeyRepository> SgxStateFileIo<StateKeyRepository>
@@ -109,8 +110,11 @@ pub mod sgx {
 		StateKeyRepository: AccessKey,
 		<StateKeyRepository as AccessKey>::KeyType: StateCrypto,
 	{
-		pub fn new(state_key_repository: Arc<StateKeyRepository>) -> Self {
-			SgxStateFileIo { state_key_repository }
+		pub fn new(
+			state_key_repository: Arc<StateKeyRepository>,
+			enclave_account: AccountId,
+		) -> Self {
+			SgxStateFileIo { state_key_repository, enclave_account }
 		}
 
 		fn read(&self, path: &Path) -> Result<Vec<u8>> {
@@ -204,7 +208,7 @@ pub mod sgx {
 			state_id: StateId,
 		) -> Result<Self::HashType> {
 			init_shard(&shard_identifier)?;
-			let state = Stf::init_state();
+			let state = Stf::init_state(self.enclave_account.clone());
 			self.write(shard_identifier, state_id, state)
 		}
 

--- a/core-primitives/stf-state-handler/src/file_io.rs
+++ b/core-primitives/stf-state-handler/src/file_io.rs
@@ -102,7 +102,6 @@ pub mod sgx {
 	/// SGX state file I/O.
 	pub struct SgxStateFileIo<StateKeyRepository> {
 		state_key_repository: Arc<StateKeyRepository>,
-		enclave_account: AccountId,
 	}
 
 	impl<StateKeyRepository> SgxStateFileIo<StateKeyRepository>
@@ -110,11 +109,8 @@ pub mod sgx {
 		StateKeyRepository: AccessKey,
 		<StateKeyRepository as AccessKey>::KeyType: StateCrypto,
 	{
-		pub fn new(
-			state_key_repository: Arc<StateKeyRepository>,
-			enclave_account: AccountId,
-		) -> Self {
-			SgxStateFileIo { state_key_repository, enclave_account }
+		pub fn new(state_key_repository: Arc<StateKeyRepository>) -> Self {
+			SgxStateFileIo { state_key_repository }
 		}
 
 		fn read(&self, path: &Path) -> Result<Vec<u8>> {
@@ -208,7 +204,7 @@ pub mod sgx {
 			state_id: StateId,
 		) -> Result<Self::HashType> {
 			init_shard(&shard_identifier)?;
-			let state = Stf::init_state(self.enclave_account.clone());
+			let state = Stf::init_state();
 			self.write(shard_identifier, state_id, state)
 		}
 

--- a/core-primitives/stf-state-handler/src/test/sgx_tests.rs
+++ b/core-primitives/stf-state-handler/src/test/sgx_tests.rs
@@ -29,7 +29,7 @@ use crate::{
 	state_snapshot_repository_loader::StateSnapshotRepositoryLoader,
 };
 use codec::{Decode, Encode};
-use ita_stf::{State as StfState, StateType as StfStateType};
+use ita_stf::{AccountId, State as StfState, StateType as StfStateType};
 use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes, AesSeal, StateCrypto};
 use itp_sgx_io::{write, StaticSealedIO};
 use itp_types::{ShardIdentifier, H256};
@@ -235,7 +235,7 @@ pub fn test_file_io_get_state_hash_works() {
 	let state_key_access =
 		Arc::new(StateKeyRepositoryMock::new(AesSeal::unseal_from_static_file().unwrap()));
 
-	let file_io = TestStateFileIo::new(state_key_access);
+	let file_io = TestStateFileIo::new(state_key_access, AccountId::new([1u8; 32]));
 
 	let state_id = 1234u128;
 	let state_hash = file_io.create_initialized(&shard, state_id).unwrap();
@@ -279,7 +279,7 @@ pub fn test_list_state_ids_ignores_files_not_matching_the_pattern() {
 	let state_key_access =
 		Arc::new(StateKeyRepositoryMock::new(AesSeal::unseal_from_static_file().unwrap()));
 
-	let file_io = TestStateFileIo::new(state_key_access);
+	let file_io = TestStateFileIo::new(state_key_access, AccountId::new([1u8; 32]));
 
 	let mut invalid_state_file_path = shard_path(&shard);
 	invalid_state_file_path.push("invalid-state.bin");
@@ -300,7 +300,7 @@ fn initialize_state_handler_with_directory_handle(
 fn initialize_state_handler() -> Arc<TestStateHandler> {
 	let state_key_access =
 		Arc::new(StateKeyRepositoryMock::new(AesSeal::unseal_from_static_file().unwrap()));
-	let file_io = Arc::new(TestStateFileIo::new(state_key_access));
+	let file_io = Arc::new(TestStateFileIo::new(state_key_access, AccountId::new([1u8; 32])));
 	let state_repository_loader = TestStateRepositoryLoader::new(file_io);
 	let state_snapshot_repository = state_repository_loader
 		.load_snapshot_repository(STATE_SNAPSHOTS_CACHE_SIZE)

--- a/core-primitives/test/src/mock/handle_state_mock.rs
+++ b/core-primitives/test/src/mock/handle_state_mock.rs
@@ -122,7 +122,7 @@ pub mod tests {
 	use ita_stf::Stf;
 	use itp_types::ShardIdentifier;
 	use sgx_externalities::{SgxExternalitiesTrait, SgxExternalitiesType};
-	use sp_core::blake2_256;
+	use sp_core::{blake2_256, crypto::AccountId32};
 
 	pub fn initialized_shards_list_is_empty() {
 		let state_handler = HandleStateMock::default();
@@ -173,7 +173,7 @@ pub mod tests {
 		state_handler.initialize_shard(shard).unwrap();
 
 		let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();
-		let initial_state = Stf::init_state();
+		let initial_state = Stf::init_state(AccountId32::new([0u8; 32]));
 		let state_hash_before_execution = hash_of(&initial_state.state);
 		state_handler.write_after_mutation(initial_state, lock, &shard).unwrap();
 
@@ -184,7 +184,7 @@ pub mod tests {
 	}
 
 	pub fn ensure_encode_and_encrypt_does_not_affect_state_hash() {
-		let state = Stf::init_state();
+		let state = Stf::init_state(AccountId32::new([0u8; 32]));
 		let state_hash_before_execution = hash_of(&state.state);
 
 		let encoded_state = state.state.encode();

--- a/core-primitives/test/src/mock/handle_state_mock.rs
+++ b/core-primitives/test/src/mock/handle_state_mock.rs
@@ -173,7 +173,7 @@ pub mod tests {
 		state_handler.initialize_shard(shard).unwrap();
 
 		let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();
-		let initial_state = Stf::init_state(AccountId32::new([0u8; 32]));
+		let initial_state = Stf::init_state();
 		let state_hash_before_execution = hash_of(&initial_state.state);
 		state_handler.write_after_mutation(initial_state, lock, &shard).unwrap();
 
@@ -184,7 +184,7 @@ pub mod tests {
 	}
 
 	pub fn ensure_encode_and_encrypt_does_not_affect_state_hash() {
-		let state = Stf::init_state(AccountId32::new([0u8; 32]));
+		let state = Stf::init_state();
 		let state_hash_before_execution = hash_of(&state.state);
 
 		let encoded_state = state.state.encode();

--- a/core-primitives/test/src/mock/handle_state_mock.rs
+++ b/core-primitives/test/src/mock/handle_state_mock.rs
@@ -173,7 +173,7 @@ pub mod tests {
 		state_handler.initialize_shard(shard).unwrap();
 
 		let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();
-		let initial_state = Stf::init_state();
+		let initial_state = Stf::init_state(AccountId32::new([0u8; 32]));
 		let state_hash_before_execution = hash_of(&initial_state.state);
 		state_handler.write_after_mutation(initial_state, lock, &shard).unwrap();
 
@@ -184,7 +184,7 @@ pub mod tests {
 	}
 
 	pub fn ensure_encode_and_encrypt_does_not_affect_state_hash() {
-		let state = Stf::init_state();
+		let state = Stf::init_state(AccountId32::new([0u8; 32]));
 		let state_hash_before_execution = hash_of(&state.state);
 
 		let encoded_state = state.state.encode();

--- a/core-primitives/test/src/mock/shielding_crypto_mock.rs
+++ b/core-primitives/test/src/mock/shielding_crypto_mock.rs
@@ -15,8 +15,11 @@
 
 */
 
-use itp_sgx_crypto::{ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
+use itp_sgx_crypto::{
+	ed25519_derivation::DeriveEd25519, ShieldingCryptoDecrypt, ShieldingCryptoEncrypt,
+};
 use sgx_crypto_helper::{rsa3072::Rsa3072KeyPair, RsaKeyPair};
+use sp_core::ed25519::Pair as Ed25519Pair;
 use std::vec::Vec;
 
 /// Crypto key mock
@@ -49,5 +52,11 @@ impl ShieldingCryptoDecrypt for ShieldingCryptoMock {
 
 	fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, Self::Error> {
 		self.key.decrypt(data)
+	}
+}
+
+impl DeriveEd25519 for ShieldingCryptoMock {
+	fn derive_ed25519(&self) -> Result<Ed25519Pair, itp_sgx_crypto::error::Error> {
+		self.key.derive_ed25519()
 	}
 }

--- a/core-primitives/utils/Cargo.toml
+++ b/core-primitives/utils/Cargo.toml
@@ -25,8 +25,9 @@ thiserror = { version = "1.0", optional = true }
 default = ["std"]
 std = [
     "codec/std",
-    "hex/std",
     "frame-support/std",
+    "hex/std",
+    "sp-core/std",
     "thiserror",
 ]
 sgx = [

--- a/core-primitives/utils/Cargo.toml
+++ b/core-primitives/utils/Cargo.toml
@@ -11,6 +11,7 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 
 # substrate
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
+sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 
 # teaclave
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/core-primitives/utils/src/lib.rs
+++ b/core-primitives/utils/src/lib.rs
@@ -34,6 +34,7 @@ pub mod sgx_reexport_prelude {
 pub mod buffer;
 pub mod error;
 pub mod hex;
+pub mod stringify;
 
 // Public re-exports.
 pub use self::{

--- a/core-primitives/utils/src/stringify.rs
+++ b/core-primitives/utils/src/stringify.rs
@@ -1,0 +1,33 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Utility methods to stringify certain types that don't have a working
+//! `Debug` implementation on `sgx`.
+
+use codec::Encode;
+use sp_core::{crypto::AccountId32, hexdisplay::HexDisplay, Public};
+use std::{format, string::String};
+
+/// Convert a sp_core public type to string.
+pub fn public_to_string<T: Public>(t: &T) -> String {
+	let crypto_pair = t.to_public_crypto_pair();
+	format!("{}", HexDisplay::from(&crypto_pair.1))
+}
+
+pub fn account_id_to_string(account: &AccountId32) -> String {
+	format!("{}", HexDisplay::from(&account.encode()))
+}

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -272,12 +272,12 @@ mod test {
 		mr_enclave: [u8; 32],
 	) -> (TestIndirectCallExecutor, Arc<TestTopPoolAuthor>, Arc<TestShieldingKeyRepo>) {
 		let shielding_key_repo = Arc::new(TestShieldingKeyRepo::default());
-		let stf_root_operator = Arc::new(TestStfEnclaveSigner::new(mr_enclave));
+		let stf_enclave_signer = Arc::new(TestStfEnclaveSigner::new(mr_enclave));
 		let top_pool_author = Arc::new(TestTopPoolAuthor::default());
 
 		let executor = IndirectCallsExecutor::new(
 			shielding_key_repo.clone(),
-			stf_root_operator,
+			stf_enclave_signer,
 			top_pool_author.clone(),
 		);
 

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -83,7 +83,7 @@ where
 
 		let account = AccountId::decode(&mut account_vec.as_slice())?;
 
-		let enclave_account_id = self.stf_enclave_signer.get_enclave_account();
+		let enclave_account_id = self.stf_enclave_signer.get_enclave_account()?;
 		let trusted_call = TrustedCall::balance_shield(enclave_account_id, account, amount);
 		let signed_trusted_call =
 			self.stf_enclave_signer.sign_call_with_self(&trusted_call, &shard)?;

--- a/core/parentchain/indirect-calls-executor/src/lib.rs
+++ b/core/parentchain/indirect-calls-executor/src/lib.rs
@@ -17,6 +17,7 @@
 //! Indirect calls execution logic.
 #![feature(trait_alias)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");

--- a/core/tls-websocket-server/src/stream_state.rs
+++ b/core/tls-websocket-server/src/stream_state.rs
@@ -91,7 +91,7 @@ impl StreamState {
 			Err(e) => match e {
 				// I/O would block our handshake attempt. Need to re-try.
 				HandshakeError::Interrupted(mhs) => {
-					warn!("Web-socket handshake interrupted");
+					info!("Web-socket handshake interrupted");
 					Self::WebSocketHandshake(mhs)
 				},
 				HandshakeError::Failure(e) => {

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1094,12 +1094,12 @@ name = "ita-stf"
 version = "0.8.0"
 dependencies = [
  "derive_more",
- "env_logger",
  "frame-support",
  "frame-system",
  "itp-settings",
  "itp-storage",
  "itp-types",
+ "itp-utils",
  "its-primitives",
  "its-state",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
@@ -1549,6 +1549,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "sgx_tstd",
+ "sp-core",
  "thiserror 1.0.9",
 ]
 
@@ -1591,6 +1592,7 @@ dependencies = [
  "itp-stf-state-handler",
  "itp-time-utils",
  "itp-types",
+ "itp-utils",
  "its-block-composer",
  "its-consensus-common",
  "its-consensus-slots",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1380,6 +1380,7 @@ version = "0.8.0"
 dependencies = [
  "ita-stf",
  "itp-ocall-api",
+ "itp-sgx-crypto",
  "itp-stf-state-handler",
  "itp-storage",
  "itp-test",
@@ -1388,6 +1389,7 @@ dependencies = [
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "parity-scale-codec",
  "sgx-externalities",
+ "sgx_crypto_helper",
  "sgx_tstd",
  "sgx_types",
  "sp-core",

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -73,7 +73,8 @@ pub type EnclaveStateSnapshotRepository =
 pub type EnclaveStateHandler = StateHandler<EnclaveStateSnapshotRepository>;
 pub type EnclaveOCallApi = OcallApi;
 pub type EnclaveStfExecutor = StfExecutor<EnclaveOCallApi, EnclaveStateHandler>;
-pub type EnclaveStfEnclaveSigner = StfEnclaveSigner<EnclaveOCallApi, EnclaveStateHandler, Pair>;
+pub type EnclaveStfEnclaveSigner =
+	StfEnclaveSigner<EnclaveOCallApi, EnclaveStateHandler, EnclaveShieldingKeyRepository>;
 pub type EnclaveExtrinsicsFactory = ExtrinsicsFactory<Pair, NonceCache>;
 pub type EnclaveIndirectCallsExecutor = IndirectCallsExecutor<
 	EnclaveShieldingKeyRepository,

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -72,7 +72,7 @@ pub type EnclaveStateSnapshotRepository =
 	StateSnapshotRepository<EnclaveStateFileIo, StfState, H256>;
 pub type EnclaveStateHandler = StateHandler<EnclaveStateSnapshotRepository>;
 pub type EnclaveOCallApi = OcallApi;
-pub type EnclaveStfExecutor = StfExecutor<EnclaveOCallApi, EnclaveStateHandler, SgxExternalities>;
+pub type EnclaveStfExecutor = StfExecutor<EnclaveOCallApi, EnclaveStateHandler>;
 pub type EnclaveStfRootOperator = StfRootOperator<EnclaveOCallApi, EnclaveStateHandler, Pair>;
 pub type EnclaveExtrinsicsFactory = ExtrinsicsFactory<Pair, NonceCache>;
 pub type EnclaveIndirectCallsExecutor = IndirectCallsExecutor<

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -39,7 +39,7 @@ use itp_component_container::ComponentContainer;
 use itp_extrinsics_factory::ExtrinsicsFactory;
 use itp_nonce_cache::NonceCache;
 use itp_sgx_crypto::{key_repository::KeyRepository, Aes, AesSeal, Rsa3072Seal};
-use itp_stf_executor::executor::StfExecutor;
+use itp_stf_executor::{executor::StfExecutor, root_operator::StfRootOperator};
 use itp_stf_state_handler::{
 	file_io::sgx::SgxStateFileIo, state_snapshot_repository::StateSnapshotRepository, StateHandler,
 };
@@ -73,9 +73,13 @@ pub type EnclaveStateSnapshotRepository =
 pub type EnclaveStateHandler = StateHandler<EnclaveStateSnapshotRepository>;
 pub type EnclaveOCallApi = OcallApi;
 pub type EnclaveStfExecutor = StfExecutor<EnclaveOCallApi, EnclaveStateHandler, SgxExternalities>;
+pub type EnclaveStfRootOperator = StfRootOperator<EnclaveOCallApi, EnclaveStateHandler, Pair>;
 pub type EnclaveExtrinsicsFactory = ExtrinsicsFactory<Pair, NonceCache>;
-pub type EnclaveIndirectCallsExecutor =
-	IndirectCallsExecutor<EnclaveShieldingKeyRepository, EnclaveStfExecutor, EnclaveTopPoolAuthor>;
+pub type EnclaveIndirectCallsExecutor = IndirectCallsExecutor<
+	EnclaveShieldingKeyRepository,
+	EnclaveStfRootOperator,
+	EnclaveTopPoolAuthor,
+>;
 pub type EnclaveValidatorAccessor = ValidatorAccessor<ParentchainBlock>;
 pub type EnclaveParentChainBlockImporter = ParentchainBlockImporter<
 	ParentchainBlock,

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -39,7 +39,7 @@ use itp_component_container::ComponentContainer;
 use itp_extrinsics_factory::ExtrinsicsFactory;
 use itp_nonce_cache::NonceCache;
 use itp_sgx_crypto::{key_repository::KeyRepository, Aes, AesSeal, Rsa3072Seal};
-use itp_stf_executor::{executor::StfExecutor, root_operator::StfRootOperator};
+use itp_stf_executor::{enclave_signer::StfEnclaveSigner, executor::StfExecutor};
 use itp_stf_state_handler::{
 	file_io::sgx::SgxStateFileIo, state_snapshot_repository::StateSnapshotRepository, StateHandler,
 };
@@ -73,11 +73,11 @@ pub type EnclaveStateSnapshotRepository =
 pub type EnclaveStateHandler = StateHandler<EnclaveStateSnapshotRepository>;
 pub type EnclaveOCallApi = OcallApi;
 pub type EnclaveStfExecutor = StfExecutor<EnclaveOCallApi, EnclaveStateHandler>;
-pub type EnclaveStfRootOperator = StfRootOperator<EnclaveOCallApi, EnclaveStateHandler, Pair>;
+pub type EnclaveStfEnclaveSigner = StfEnclaveSigner<EnclaveOCallApi, EnclaveStateHandler, Pair>;
 pub type EnclaveExtrinsicsFactory = ExtrinsicsFactory<Pair, NonceCache>;
 pub type EnclaveIndirectCallsExecutor = IndirectCallsExecutor<
 	EnclaveShieldingKeyRepository,
-	EnclaveStfRootOperator,
+	EnclaveStfEnclaveSigner,
 	EnclaveTopPoolAuthor,
 >;
 pub type EnclaveValidatorAccessor = ValidatorAccessor<ParentchainBlock>;

--- a/enclave-runtime/src/initialization.rs
+++ b/enclave-runtime/src/initialization.rs
@@ -92,7 +92,7 @@ pub(crate) fn init_enclave(mu_ra_url: String, untrusted_worker_url: String) -> E
 	let shielding_key = Rsa3072Seal::unseal_from_static_file()?;
 
 	let shielding_key_repository =
-		Arc::new(EnclaveShieldingKeyRepository::new(shielding_key.clone(), Arc::new(Rsa3072Seal)));
+		Arc::new(EnclaveShieldingKeyRepository::new(shielding_key, Arc::new(Rsa3072Seal)));
 	GLOBAL_SHIELDING_KEY_REPOSITORY_COMPONENT.initialize(shielding_key_repository.clone());
 
 	// Create the aes key that is used for state encryption such that a key is always present in tests.

--- a/enclave-runtime/src/initialization.rs
+++ b/enclave-runtime/src/initialization.rs
@@ -232,11 +232,11 @@ pub(crate) fn init_light_client(params: LightClientInitParams<Header>) -> Enclav
 
 	GLOBAL_EXTRINSICS_FACTORY_COMPONENT.initialize(extrinsics_factory.clone());
 
-	let stf_root_operator =
+	let stf_enclave_signer =
 		Arc::new(EnclaveStfEnclaveSigner::new(state_handler, ocall_api.clone(), signer));
 	let indirect_calls_executor = Arc::new(IndirectCallsExecutor::new(
 		shielding_key_repository,
-		stf_root_operator,
+		stf_enclave_signer,
 		top_pool_author,
 	));
 	let parentchain_block_importer = ParentchainBlockImporter::new(

--- a/enclave-runtime/src/test/fixtures/initialize_test_state.rs
+++ b/enclave-runtime/src/test/fixtures/initialize_test_state.rs
@@ -16,7 +16,7 @@
 
 */
 
-use ita_stf::{State, Stf};
+use ita_stf::{AccountId, State, Stf};
 use itp_stf_state_handler::handle_state::HandleState;
 use itp_types::ShardIdentifier;
 use sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
@@ -24,13 +24,14 @@ use sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 /// Returns an empty `State` with the corresponding `ShardIdentifier`.
 pub fn init_state<S: HandleState<StateT = SgxExternalities>>(
 	state_handler: &S,
+	enclave_account: AccountId,
 ) -> (State, ShardIdentifier) {
 	let shard = ShardIdentifier::default();
 
 	let _hash = state_handler.initialize_shard(shard).unwrap();
 	let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();
 
-	let mut state = Stf::init_state();
+	let mut state = Stf::init_state(enclave_account);
 	state.prune_state_diff();
 
 	state_handler.write_after_mutation(state.clone(), lock, &shard).unwrap();

--- a/enclave-runtime/src/test/fixtures/initialize_test_state.rs
+++ b/enclave-runtime/src/test/fixtures/initialize_test_state.rs
@@ -24,14 +24,13 @@ use sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 /// Returns an empty `State` with the corresponding `ShardIdentifier`.
 pub fn init_state<S: HandleState<StateT = SgxExternalities>>(
 	state_handler: &S,
-	enclave_account: AccountId,
 ) -> (State, ShardIdentifier) {
 	let shard = ShardIdentifier::default();
 
 	let _hash = state_handler.initialize_shard(shard).unwrap();
 	let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();
 
-	let mut state = Stf::init_state(enclave_account);
+	let mut state = Stf::init_state();
 	state.prune_state_diff();
 
 	state_handler.write_after_mutation(state.clone(), lock, &shard).unwrap();

--- a/enclave-runtime/src/test/fixtures/initialize_test_state.rs
+++ b/enclave-runtime/src/test/fixtures/initialize_test_state.rs
@@ -24,13 +24,14 @@ use sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 /// Returns an empty `State` with the corresponding `ShardIdentifier`.
 pub fn init_state<S: HandleState<StateT = SgxExternalities>>(
 	state_handler: &S,
+	enclave_account: AccountId,
 ) -> (State, ShardIdentifier) {
 	let shard = ShardIdentifier::default();
 
 	let _hash = state_handler.initialize_shard(shard).unwrap();
 	let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();
 
-	let mut state = Stf::init_state();
+	let mut state = Stf::init_state(enclave_account);
 	state.prune_state_diff();
 
 	state_handler.write_after_mutation(state.clone(), lock, &shard).unwrap();

--- a/enclave-runtime/src/test/mocks/types.rs
+++ b/enclave-runtime/src/test/mocks/types.rs
@@ -61,7 +61,7 @@ pub type TestOCallApi = OnchainMock;
 pub type TestParentchainBlockImportTrigger =
 	TriggerParentchainBlockImportMock<SignedParentchainBlock>;
 
-pub type TestStfExecutor = StfExecutor<TestOCallApi, TestStateHandler, SgxExternalities>;
+pub type TestStfExecutor = StfExecutor<TestOCallApi, TestStateHandler>;
 
 pub type TestRpcResponder = RpcResponderMock<H256>;
 

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -78,7 +78,7 @@ pub fn produce_sidechain_block_and_import_it() {
 
 	info!("Initializing state and shard..");
 	let state_handler = Arc::new(TestStateHandler::default());
-	let (_, shard_id) = init_state(state_handler.as_ref());
+	let (_, shard_id) = init_state(state_handler.as_ref(), signer.public().into());
 	let shards = vec![shard_id];
 
 	let stf_executor = Arc::new(TestStfExecutor::new(ocall_api.clone(), state_handler.clone()));

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -25,6 +25,7 @@ use crate::{
 			initialize_test_state::init_state,
 		},
 		mocks::{propose_to_import_call_mock::ProposeToImportOCallApi, types::*},
+		tests_main::enclave_call_signer,
 	},
 	top_pool_execution::{exec_aura_on_slot, send_blocks_and_extrinsics},
 };
@@ -78,7 +79,8 @@ pub fn produce_sidechain_block_and_import_it() {
 
 	info!("Initializing state and shard..");
 	let state_handler = Arc::new(TestStateHandler::default());
-	let (_, shard_id) = init_state(state_handler.as_ref(), signer.public().into());
+	let enclave_call_signer = enclave_call_signer(&shielding_key);
+	let (_, shard_id) = init_state(state_handler.as_ref(), enclave_call_signer.public().into());
 	let shards = vec![shard_id];
 
 	let stf_executor = Arc::new(TestStfExecutor::new(ocall_api.clone(), state_handler.clone()));

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -80,7 +80,7 @@ use std::{string::String, sync::Arc, vec::Vec};
 type TestRpcResponder = RpcResponderMock<ExtrinsicHash<SidechainApi<Block>>>;
 type TestTopPool = BasicPool<SidechainApi<Block>, Block, TestRpcResponder>;
 type TestShieldingKeyRepo = KeyRepositoryMock<ShieldingCryptoMock>;
-type TestStfExecutor = StfExecutor<OcallApi, HandleStateMock, SgxExternalities>;
+type TestStfExecutor = StfExecutor<OcallApi, HandleStateMock>;
 type TestTopPoolAuthor = Author<
 	TestTopPool,
 	AllowAllTopsFilter,

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -99,6 +99,8 @@ pub extern "C" fn test_main_entrance() -> size_t {
 	rsgx_unit_tests!(
 		attestation::tests::decode_spid_works,
 		stf_sgx_tests::enclave_account_initialization_works,
+		stf_sgx_tests::shield_funds_increments_signer_account_nonce,
+		stf_sgx_tests::test_root_account_exists_after_initialization,
 		itp_stf_state_handler::test::sgx_tests::test_write_and_load_state_works,
 		itp_stf_state_handler::test::sgx_tests::test_sgx_state_decode_encode_works,
 		itp_stf_state_handler::test::sgx_tests::test_encrypt_decrypt_state_type_works,

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -44,9 +44,8 @@ use itp_settings::{
 };
 use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes, StateCrypto};
 use itp_stf_executor::{
-	executor::StfExecutor, executor_tests as stf_executor_tests,
-	root_operator_tests as stf_root_operator_tests, traits::StateUpdateProposer,
-	BatchExecutionResult,
+	enclave_signer_tests as stf_root_operator_tests, executor::StfExecutor,
+	executor_tests as stf_executor_tests, traits::StateUpdateProposer, BatchExecutionResult,
 };
 use itp_stf_state_handler::handle_state::HandleState;
 use itp_test::mock::{
@@ -142,7 +141,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		stf_executor_tests::propose_state_update_always_executes_preprocessing_step,
 		stf_executor_tests::propose_state_update_executes_only_one_trusted_call_given_not_enough_time,
 		stf_executor_tests::propose_state_update_executes_all_calls_given_enough_time,
-		stf_root_operator_tests::root_operator_signatures_are_valid,
+		stf_root_operator_tests::enclave_signer_signatures_are_valid,
 		// sidechain integration tests
 		sidechain_aura_tests::produce_sidechain_block_and_import_it,
 		top_pool_tests::process_indirect_call_in_top_pool,
@@ -591,7 +590,7 @@ pub fn test_setup() -> (
 	Arc<HandleStateMock>,
 ) {
 	let state_handler = Arc::new(HandleStateMock::default());
-	let (state, shard) = init_state(state_handler.as_ref());
+	let (state, shard) = init_state(state_handler.as_ref(), AccountId::new([0u8; 32]));
 	let top_pool = test_top_pool();
 	let mrenclave = OcallApi.get_mrenclave_of_self().unwrap().m;
 

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -44,7 +44,7 @@ use itp_settings::{
 };
 use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes, StateCrypto};
 use itp_stf_executor::{
-	enclave_signer_tests as stf_root_operator_tests, executor::StfExecutor,
+	enclave_signer_tests as stf_enclave_signer_tests, executor::StfExecutor,
 	executor_tests as stf_executor_tests, traits::StateUpdateProposer, BatchExecutionResult,
 };
 use itp_stf_state_handler::handle_state::HandleState;
@@ -141,7 +141,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		stf_executor_tests::propose_state_update_always_executes_preprocessing_step,
 		stf_executor_tests::propose_state_update_executes_only_one_trusted_call_given_not_enough_time,
 		stf_executor_tests::propose_state_update_executes_all_calls_given_enough_time,
-		stf_root_operator_tests::enclave_signer_signatures_are_valid,
+		stf_enclave_signer_tests::enclave_signer_signatures_are_valid,
 		// sidechain integration tests
 		sidechain_aura_tests::produce_sidechain_block_and_import_it,
 		top_pool_tests::process_indirect_call_in_top_pool,

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -44,7 +44,8 @@ use itp_settings::{
 };
 use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes, StateCrypto};
 use itp_stf_executor::{
-	executor::StfExecutor, executor_tests as stf_executor_tests, traits::StateUpdateProposer,
+	executor::StfExecutor, executor_tests as stf_executor_tests,
+	root_operator_tests as stf_root_operator_tests, traits::StateUpdateProposer,
 	BatchExecutionResult,
 };
 use itp_stf_state_handler::handle_state::HandleState;
@@ -141,9 +142,11 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		stf_executor_tests::propose_state_update_always_executes_preprocessing_step,
 		stf_executor_tests::propose_state_update_executes_only_one_trusted_call_given_not_enough_time,
 		stf_executor_tests::propose_state_update_executes_all_calls_given_enough_time,
+		stf_root_operator_tests::root_operator_signatures_are_valid,
 		// sidechain integration tests
 		sidechain_aura_tests::produce_sidechain_block_and_import_it,
 		top_pool_tests::process_indirect_call_in_top_pool,
+		top_pool_tests::submit_shielding_call_to_top_pool,
 		// tls_ra unit tests
 		tls_ra::seal_handler::test::seal_shielding_key_works,
 		tls_ra::seal_handler::test::seal_shielding_key_fails_for_invalid_key,

--- a/enclave-runtime/src/test/top_pool_tests.rs
+++ b/enclave-runtime/src/test/top_pool_tests.rs
@@ -105,8 +105,11 @@ pub fn submit_shielding_call_to_top_pool() {
 		Arc::new(MetricsOCallMock {}),
 	));
 
-	let enclave_signer =
-		Arc::new(StfEnclaveSigner::new(state_handler.clone(), ocall_api.clone(), signer.clone()));
+	let enclave_signer = Arc::new(StfEnclaveSigner::new(
+		state_handler.clone(),
+		ocall_api.clone(),
+		shielding_key_repo.clone(),
+	));
 	let indirect_calls_executor =
 		IndirectCallsExecutor::new(shielding_key_repo, enclave_signer, top_pool_author.clone());
 

--- a/enclave-runtime/src/test/top_pool_tests.rs
+++ b/enclave-runtime/src/test/top_pool_tests.rs
@@ -36,7 +36,7 @@ use itc_parentchain::indirect_calls_executor::{ExecuteIndirectCalls, IndirectCal
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_settings::node::{SHIELD_FUNDS, TEEREX_MODULE};
 use itp_sgx_crypto::ShieldingCryptoEncrypt;
-use itp_stf_executor::root_operator::StfRootOperator;
+use itp_stf_executor::enclave_signer::StfEnclaveSigner;
 use itp_test::{
 	builders::parentchain_block_builder::ParentchainBlockBuilder,
 	mock::metrics_ocall_mock::MetricsOCallMock,
@@ -62,7 +62,7 @@ pub fn process_indirect_call_in_top_pool() {
 	let ocall_api = create_ocall_api(&signer);
 
 	let state_handler = Arc::new(TestStateHandler::default());
-	let (_, shard_id) = init_state(state_handler.as_ref());
+	let (_, shard_id) = init_state(state_handler.as_ref(), signer.public().into());
 
 	let top_pool = create_top_pool();
 
@@ -93,7 +93,7 @@ pub fn submit_shielding_call_to_top_pool() {
 	let mr_enclave = ocall_api.get_mrenclave_of_self().unwrap();
 
 	let state_handler = Arc::new(TestStateHandler::default());
-	let (_, shard_id) = init_state(state_handler.as_ref());
+	let (_, shard_id) = init_state(state_handler.as_ref(), signer.public().into());
 
 	let top_pool = create_top_pool();
 
@@ -105,10 +105,10 @@ pub fn submit_shielding_call_to_top_pool() {
 		Arc::new(MetricsOCallMock {}),
 	));
 
-	let root_operator =
-		Arc::new(StfRootOperator::new(state_handler.clone(), ocall_api.clone(), signer.clone()));
+	let enclave_signer =
+		Arc::new(StfEnclaveSigner::new(state_handler.clone(), ocall_api.clone(), signer.clone()));
 	let indirect_calls_executor =
-		IndirectCallsExecutor::new(shielding_key_repo, root_operator, top_pool_author.clone());
+		IndirectCallsExecutor::new(shielding_key_repo, enclave_signer, top_pool_author.clone());
 
 	let block_with_shielding_call = create_shielding_call_extrinsic(shard_id, &shielding_key);
 

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -28,6 +28,7 @@ itp-stf-executor = { path = "../../../core-primitives/stf-executor", default-fea
 itp-stf-state-handler = { path = "../../../core-primitives/stf-state-handler", default-features = false }
 itp-time-utils = { path = "../../../core-primitives/time-utils", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
+itp-utils = { path = "../../../core-primitives/utils", default-features = false }
 its-block-composer = { path = "../../block-composer", default-features = false }
 its-consensus-common = { path = "../common", default-features = false }
 its-consensus-slots = { path = "../slots", default-features = false }
@@ -58,6 +59,7 @@ std = [
    "itp-stf-state-handler/std",
    "itp-time-utils/std",
    "itp-types/std",
+   "itp-utils/std",
    "its-block-composer/std",
    "its-consensus-common/std",
    "its-consensus-slots/std",
@@ -77,6 +79,7 @@ sgx = [
    "itp-stf-executor/sgx",
    "itp-stf-state-handler/sgx",
    "itp-time-utils/sgx",
+   "itp-utils/sgx",
    "its-block-composer/sgx",
    "its-consensus-common/sgx",
    "its-consensus-slots/sgx",

--- a/sidechain/consensus/aura/src/verifier.rs
+++ b/sidechain/consensus/aura/src/verifier.rs
@@ -18,6 +18,7 @@
 use crate::{authorities, slot_author, EnclaveOnChainOCallApi};
 use core::marker::PhantomData;
 use frame_support::ensure;
+use itp_utils::stringify::public_to_string;
 use its_consensus_common::{Error as ConsensusError, Verifier};
 use its_consensus_slots::{slot_from_timestamp_and_duration, Slot};
 use its_primitives::{
@@ -30,12 +31,11 @@ use its_primitives::{
 use its_state::LastBlockExt;
 use its_validateer_fetch::ValidateerFetch;
 use log::*;
-use sp_core::{hexdisplay::HexDisplay, Public};
 use sp_runtime::{
 	app_crypto::Pair,
 	traits::{Block as ParentchainBlockTrait, Header as ParentchainHeaderTrait},
 };
-use std::{fmt::Debug, string::String, time::Duration};
+use std::{fmt::Debug, time::Duration};
 
 #[derive(Default)]
 pub struct AuraVerifier<AuthorityPair, ParentchainBlock, SidechainBlock, SidechainState, Context> {
@@ -144,17 +144,12 @@ where
 		expected_author == block.block_data().block_author(),
 		ConsensusError::InvalidAuthority(format!(
 			"Expected author: {}, author found in block: {}",
-			to_string(expected_author),
-			to_string(block.block_data().block_author())
+			public_to_string(expected_author),
+			public_to_string(block.block_data().block_author())
 		))
 	);
 
 	Ok(())
-}
-
-fn to_string<T: Public>(t: &T) -> String {
-	let crypto_pair = t.to_public_crypto_pair();
-	format!("{}", HexDisplay::from(&crypto_pair.1))
 }
 
 fn verify_block_ancestry<SidechainBlock: SidechainBlockTrait>(


### PR DESCRIPTION
Shield funds calls are also submitted to TOP pool:
* The indirect calls executor will create a `TrustedOperation` with a shielding call, signed by the enclave account
* Introduced a new 'Enclave Account' into the STF. This enclave account is used to signed the shield funds call.

- [x] Merge #748 first, then rebase this branch onto master

Closes #755 