### PR TITLE
Solve potential endless loop in WS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Please see our [Integritee Book](https://book.integritee.network/howto_worker.ht
 To start multiple worker and a node with one simple command: Check out [this README](local-setup/README.md).
 
 ## Tests
-### environment
+### Environment
 Unit tests within the enclave can't be run by `cargo test`. All unit and integration tests can be run by the worker binary
 
 first, you should run ipfs daemon because it is needed for testing
@@ -27,7 +27,7 @@ worker/bin$ rm sealed_stf_state.bin
 worker/bin$ touch sealed_stf_state.bin
 ```
 
-### execute tests
+### Execute tests
 Run these with
 ```
 integritee-service/bin$ ./integritee-service test --all
@@ -64,3 +64,8 @@ now bootstrap a new bot community
 ```
 
 now you should see the community growing from 10 to hundreds, increasing with every ceremony
+
+## Direct calls scalability
+
+For direct calls, a worker runs a web-socket server inside the enclave. An important factor for scalability is the transaction throughput of a single worker instance, which is in part defined by the maximum number of concurrent socket connections possible. On Linux by default, a process can have a maximum of `1024` concurrent file descriptors (show by `ulimit -n`).
+If the web-socket server hits that limit, incoming connections will be declined until one of the established connections is closed. Permanently changing the `ulimit -n` value can be done in the `/etc/security/limits.conf` configuration file. See [this](https://linuxhint.com/permanently_set_ulimit_value/) guide for more information.

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -76,9 +76,11 @@ fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: &TrustedOperation) -
 							"[Error] {}",
 							String::decode(&mut return_value.value.as_slice()).unwrap()
 						);
+						direct_api.close().unwrap();
 						return None
 					}
 					if !return_value.do_watch {
+						direct_api.close().unwrap();
 						return match Option::decode(&mut return_value.value.as_slice()) {
 							Ok(value_opt) => value_opt,
 							Err(_) => panic!("Error when decoding response"),
@@ -86,7 +88,10 @@ fn get_state(cli: &Cli, trusted_args: &TrustedArgs, getter: &TrustedOperation) -
 					}
 				};
 			},
-			Err(_) => return None,
+			Err(_) => {
+				direct_api.close().unwrap();
+				return None
+			},
 		};
 	}
 }

--- a/core/direct-rpc-server/src/lib.rs
+++ b/core/direct-rpc-server/src/lib.rs
@@ -77,7 +77,7 @@ impl<T: std::hash::Hash + traits::Member + Encode> RpcHash for T {}
 /// Registry for RPC connections (i.e. connections that are kept alive to send updates).
 pub trait RpcConnectionRegistry: Send + Sync {
 	type Hash: RpcHash;
-	type Connection: Copy;
+	type Connection: Copy + Debug;
 
 	fn store(&self, hash: Self::Hash, connection: Self::Connection, rpc_response: RpcResponse);
 

--- a/core/direct-rpc-server/src/rpc_connection_registry.rs
+++ b/core/direct-rpc-server/src/rpc_connection_registry.rs
@@ -23,14 +23,14 @@ use std::sync::RwLock;
 
 use crate::{RpcConnectionRegistry, RpcHash};
 use itp_types::RpcResponse;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 
 type HashMapLock<K, V> = RwLock<HashMap<K, V>>;
 
 pub struct ConnectionRegistry<Hash, Token>
 where
 	Hash: RpcHash,
-	Token: Copy + Send + Sync,
+	Token: Copy + Send + Sync + Debug,
 {
 	connection_map: HashMapLock<<Self as RpcConnectionRegistry>::Hash, (Token, RpcResponse)>,
 }
@@ -38,7 +38,7 @@ where
 impl<Hash, Token> ConnectionRegistry<Hash, Token>
 where
 	Hash: RpcHash,
-	Token: Copy + Send + Sync,
+	Token: Copy + Send + Sync + Debug,
 {
 	pub fn new() -> Self {
 		Self::default()
@@ -53,7 +53,7 @@ where
 impl<Hash, Token> Default for ConnectionRegistry<Hash, Token>
 where
 	Hash: RpcHash,
-	Token: Copy + Send + Sync,
+	Token: Copy + Send + Sync + Debug,
 {
 	fn default() -> Self {
 		ConnectionRegistry { connection_map: RwLock::new(HashMap::default()) }
@@ -63,7 +63,7 @@ where
 impl<Hash, Token> RpcConnectionRegistry for ConnectionRegistry<Hash, Token>
 where
 	Hash: RpcHash,
-	Token: Copy + Send + Sync,
+	Token: Copy + Send + Sync + Debug,
 {
 	type Hash = Hash;
 	type Connection = Token;

--- a/core/rpc-client/src/direct_client.rs
+++ b/core/rpc-client/src/direct_client.rs
@@ -164,14 +164,14 @@ fn decode_from_rpc_response(json_rpc_response: &str) -> Result<String> {
 mod tests {
 	use super::*;
 	use itc_tls_websocket_server::{test::fixtures::test_server::create_server, WebSocketServer};
-	use std::collections::VecDeque;
+	use std::vec;
 
 	#[test]
 	fn watch_works_and_closes_connection_on_demand() {
 		let _ = env_logger::builder().is_test(true).try_init();
 
 		const END_MESSAGE: &str = "End of service.";
-		let responses = VecDeque::from([END_MESSAGE.to_string()]);
+		let responses = vec![END_MESSAGE.to_string()];
 
 		let port = 22334;
 		let (server, handler) = create_server(responses, port);
@@ -218,7 +218,7 @@ mod tests {
 		let _ = env_logger::builder().is_test(true).try_init();
 
 		let server_response = "response 1".to_string();
-		let responses = VecDeque::from([server_response.clone()]);
+		let responses = vec![server_response.clone()];
 
 		let port = 22335;
 		let (server, handler) = create_server(responses, port);

--- a/core/tls-websocket-server/src/connection.rs
+++ b/core/tls-websocket-server/src/connection.rs
@@ -181,7 +181,7 @@ where
 			Message::Close(_) => {
 				debug!("Received close frame, driving web-socket connection to close");
 				if let StreamState::EstablishedWebsocket(web_socket) = &mut self.stream_state {
-					// We need to call write_pending until it returns an error that connection is closed.
+					// Send a close frame back and then flush the send queue.
 					if let Err(e) = web_socket.close(None) {
 						match e {
 							tungstenite::Error::ConnectionClosed
@@ -192,7 +192,6 @@ where
 							),
 						}
 					}
-
 					match web_socket.write_pending() {
 						Ok(_) => {},
 						Err(e) => match e {

--- a/core/tls-websocket-server/src/connection.rs
+++ b/core/tls-websocket-server/src/connection.rs
@@ -76,10 +76,14 @@ where
 				},
 			Err(err) => {
 				if let std::io::ErrorKind::WouldBlock = err.kind() {
-					debug!("TLS session is blocked");
+					debug!("TLS session is blocked (connection {})", self.connection_token.0);
 					return ConnectionState::Blocked
 				}
-				warn!("I/O error after reading TLS data: {:?}", err);
+				warn!(
+					"I/O error after reading TLS data (connection {}): {:?}",
+					self.connection_token.0, err
+				);
+				return ConnectionState::Closing
 			},
 		}
 
@@ -105,14 +109,14 @@ where
 
 		match tls_stream.sess.write_tls(&mut tls_stream.sock) {
 			Ok(_) => {
-				trace!("TLS write successful, connection is alive");
+				trace!("TLS write successful, connection {} is alive", self.connection_token.0);
 				if tls_stream.sess.is_handshaking() {
 					return ConnectionState::TlsHandshake
 				}
 				ConnectionState::Alive
 			},
 			Err(e) => {
-				error!("TLS write error: {:?}", e);
+				error!("TLS write error (connection {}): {:?}", self.connection_token.0, e);
 				ConnectionState::Closing
 			},
 		}
@@ -123,23 +127,33 @@ where
 	/// Returns a boolean 'connection should be closed'.
 	fn read_or_initialize_websocket(&mut self) -> WebSocketResult<bool> {
 		if let StreamState::EstablishedWebsocket(web_socket) = &mut self.stream_state {
+			debug!("Read message for connection {}", self.connection_token.0);
 			match web_socket.read_message() {
 				Ok(m) =>
 					if let Err(e) = self.handle_message(m) {
-						error!("Failed to handle web-socket message: {:?}", e);
+						error!(
+							"Failed to handle web-socket message (connection {}): {:?}",
+							self.connection_token.0, e
+						);
 					},
 				Err(e) => match e {
 					tungstenite::Error::ConnectionClosed => return Ok(true),
 					tungstenite::Error::AlreadyClosed => return Ok(true),
-					_ => error!("Failed to read message from web-socket: {:?}", e),
+					_ => error!(
+						"Failed to read message from web-socket (connection {}): {:?}",
+						self.connection_token.0, e
+					),
 				},
 			}
+			debug!("Read successful for connection {}", self.connection_token.0);
 		} else {
+			debug!("Initialize connection {}", self.connection_token.0);
 			self.stream_state = std::mem::take(&mut self.stream_state).attempt_handshake();
 			if self.stream_state.is_invalid() {
 				warn!("Web-socket connection ({:?}) failed, closing", self.connection_token);
 				return Ok(true)
 			}
+			debug!("Initialized connection {} successfully", self.connection_token.0);
 		}
 
 		Ok(false)
@@ -153,9 +167,12 @@ where
 					.connection_handler
 					.handle_message(self.connection_token.into(), string_message)?
 				{
-					trace!("Handling message yielded a reply, sending it now..");
+					debug!(
+						"Handling message yielded a reply, sending it now to connection {}..",
+						self.connection_token.0
+					);
 					self.write_message(reply)?;
-					trace!("Reply sent successfully");
+					debug!("Reply sent successfully to connection {}", self.connection_token.0);
 				}
 			},
 			Message::Binary(_) => {
@@ -165,16 +182,27 @@ where
 				debug!("Received close frame, driving web-socket connection to close");
 				if let StreamState::EstablishedWebsocket(web_socket) = &mut self.stream_state {
 					// We need to call write_pending until it returns an error that connection is closed.
-					loop {
-						if let Err(e) = web_socket.write_pending() {
-							match e {
-								tungstenite::Error::ConnectionClosed
-								| tungstenite::Error::AlreadyClosed => break,
-								_ => {},
-							}
+					if let Err(e) = web_socket.close(None) {
+						match e {
+							tungstenite::Error::ConnectionClosed
+							| tungstenite::Error::AlreadyClosed => {},
+							_ => warn!(
+								"Failed to send close frame (connection {}): {:?}",
+								self.connection_token.0, e
+							),
 						}
 					}
+
+					match web_socket.write_pending() {
+						Ok(_) => {},
+						Err(e) => match e {
+							tungstenite::Error::ConnectionClosed
+							| tungstenite::Error::AlreadyClosed => {},
+							_ => warn!("Failed to write pending frames after closing (connection {}): {:?}", self.connection_token.0, e),
+						},
+					}
 				}
+				debug!("Successfully closed connection {}", self.connection_token.0);
 			},
 			_ => {},
 		}

--- a/core/tls-websocket-server/src/lib.rs
+++ b/core/tls-websocket-server/src/lib.rs
@@ -20,7 +20,6 @@
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
 
-extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
@@ -62,7 +61,7 @@ pub mod ws_server;
 pub mod test;
 
 /// Connection token alias.
-#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug, Hash)]
 pub struct ConnectionToken(pub usize);
 
 impl From<ConnectionToken> for Token {

--- a/core/tls-websocket-server/src/test/fixtures/test_server.rs
+++ b/core/tls-websocket-server/src/test/fixtures/test_server.rs
@@ -22,12 +22,12 @@ use crate::{
 	},
 	TungsteniteWsServer,
 };
-use std::{collections::VecDeque, string::String, sync::Arc};
+use std::{string::String, sync::Arc};
 
 pub type TestServer = TungsteniteWsServer<WebSocketHandlerMock, TestServerConfigProvider>;
 
 pub fn create_server(
-	handler_responses: VecDeque<String>,
+	handler_responses: Vec<String>,
 	port: u16,
 ) -> (Arc<TestServer>, Arc<WebSocketHandlerMock>) {
 	let config_provider = Arc::new(TestServerConfigProvider {});

--- a/core/tls-websocket-server/src/ws_server.rs
+++ b/core/tls-websocket-server/src/ws_server.rs
@@ -315,7 +315,7 @@ mod tests {
 
 	#[test]
 	fn server_handles_multiple_connections() {
-		let _ = env_logger::builder().is_test(false).try_init();
+		let _ = env_logger::builder().is_test(true).try_init();
 
 		let expected_answer = "websocket server response bidibibup".to_string();
 		let port: u16 = 21777;

--- a/core/tls-websocket-server/src/ws_server.rs
+++ b/core/tls-websocket-server/src/ws_server.rs
@@ -292,7 +292,7 @@ mod tests {
 
 	#[test]
 	fn server_handles_multiple_connections() {
-		let _ = env_logger::builder().is_test(true).try_init();
+		let _ = env_logger::builder().is_test(false).try_init();
 
 		let expected_answer = "websocket server response bidibibup".to_string();
 		let port: u16 = 21777;


### PR DESCRIPTION
As reported in #752 and the benchmarking done by @Niederb, the web-socket server could get stuck in an endless loop under certain conditions. This has been fixed in this PR, and also extended the unit tests to cover that case.

* A deadlock between two threads was responsible for the freezing. The web-socket thread and top-pool executor thread both held locks on the top pool and web-socket connections. This is solved by removing the need for a connection lock when sending an RPC response. The action of sending a response is now added to the main event loop of the web-socket server.

Closes #752 #751 