### PR TITLE
Relax threshold for timing unit test

### DIFF
--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -193,7 +193,7 @@ mod tests {
 	use std::{fmt::Debug, thread, time::SystemTime};
 
 	const SLOT_DURATION: Duration = Duration::from_millis(1000);
-	const ALLOWED_THRESHOLD: Duration = Duration::from_millis(5);
+	const ALLOWED_THRESHOLD: Duration = Duration::from_millis(2);
 
 	struct LastSlotSealMock;
 

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -193,7 +193,7 @@ mod tests {
 	use std::{fmt::Debug, thread, time::SystemTime};
 
 	const SLOT_DURATION: Duration = Duration::from_millis(1000);
-	const ALLOWED_THRESHOLD: Duration = Duration::from_millis(1);
+	const ALLOWED_THRESHOLD: Duration = Duration::from_millis(5);
 
 	struct LastSlotSealMock;
 
@@ -288,7 +288,12 @@ mod tests {
 		let difference_of_ends_at =
 			(slot_one.ends_at.as_millis()).abs_diff(slot_two.ends_at.as_millis());
 
-		assert!(difference_of_ends_at < ALLOWED_THRESHOLD.as_millis());
+		assert!(
+			difference_of_ends_at < ALLOWED_THRESHOLD.as_millis(),
+			"Diff in ends at timestamp: {}, tolerance: {}",
+			difference_of_ends_at,
+			ALLOWED_THRESHOLD
+		);
 	}
 
 	#[test]

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -290,9 +290,9 @@ mod tests {
 
 		assert!(
 			difference_of_ends_at < ALLOWED_THRESHOLD.as_millis(),
-			"Diff in ends at timestamp: {}, tolerance: {}",
+			"Diff in ends at timestamp: {} ms, tolerance: {} ms",
 			difference_of_ends_at,
-			ALLOWED_THRESHOLD
+			ALLOWED_THRESHOLD.as_millis()
 		);
 	}
 


### PR DESCRIPTION
We seem to have a flaky unit test now, with the timing of slots. E.g. [here](https://github.com/integritee-network/worker/actions/runs/2453556246) the build on master failed.

Relax the threshold to hopefully reduce the flakiness of the test.