### PR TITLE
Explicitly set the ends_at time and compute it from the slot directly…

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -112,6 +112,9 @@ jobs:
       - name: init rust
         run: rustup show
 
+      - name: ls sidechain primitives
+        run: ls ./sidechain/primitives/
+
       - name: Worker & Client
         run: cargo fmt --all -- --check
       - name: Enclave # Enclave is separate as it's not in the workspace

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -112,9 +112,6 @@ jobs:
       - name: init rust
         run: rustup show
 
-      - name: ls sidechain primitives
-        run: ls ./sidechain/primitives/
-
       - name: Worker & Client
         run: cargo fmt --all -- --check
       - name: Enclave # Enclave is separate as it's not in the workspace

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,35 +36,10 @@ jobs:
         with:
           buildkitd-flags: --debug
 
-#      - name: Set up Actions Cache
-#        uses: actions/cache@v3
-#        with:
-#          path: /tmp/.buildx-cache
-#          key: ${{ runner.os }}-buildx-${{ github.sha }}
-#          restore-keys: |
-#            ${{ runner.os }}-buildx-
-
-#      - name: Build Worker Source
-#        run: docker buildx build --target=builder --tag integritee-worker-builder-${{ github.sha }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new -f build.Dockerfile .
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: .
-#          file: build.Dockerfile
-#          target: builder
-#          load: true
-#          tags: integritee-worker-builder-${{ github.sha }}
-
       - name: Build Enclave Test Image
         env:
           DOCKER_BUILDKIT: 1
         run: docker build -t integritee-worker-enclave-test-${{ github.sha }} --target enclave-test -f build.Dockerfile .
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: .
-#          file: build.Dockerfile
-#          target: enclave-test
-#          load: true
-#          tags: integritee-worker-enclave-test-${{ github.sha }}
 
       - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
         run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-enclave-test-${{ github.sha }}
@@ -73,13 +48,6 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run:  docker build -t integritee-worker-ctest-${{ github.sha }} --target cargo-test -f build.Dockerfile .
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: .
-#          file: build.Dockerfile
-#          target: cargo-test
-#          load: true
-#          tags: integritee-worker-ctest-${{ github.sha }}
 
       - name: Run Cargo Test
         run: docker run --rm integritee-worker-ctest-${{ github.sha }}
@@ -88,13 +56,6 @@ jobs:
         env:
           DOCKER_BUILDKIT: 1
         run: docker build --output=type=tar,dest=/tmp/integritee-worker.tar --target=deployed-worker -f build.Dockerfile .
-#        uses: docker/build-push-action@v2
-#        with:
-#          context: .
-#          file: build.Dockerfile
-#          target: cargo-test
-#          tags: integritee-worker-${{ github.sha }}
-#          outputs: type=docker,dest=/tmp/integritee-worker.tar
       
       - name: Copy artifacts from container
         run: |
@@ -125,11 +86,6 @@ jobs:
         with:
           name: integritee-worker-image-${{ github.sha }}
           path: /tmp/integritee-worker.tar
-
-#      - name: Clean docker layer cache
-#        run: |
-#          rm -rf /tmp/.buildx-cache
-#          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ dependencies = [
  "futures-timer",
  "itp-settings",
  "itp-sgx-io",
+ "itp-test",
  "itp-time-utils",
  "itp-types",
  "its-consensus-common",

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -83,7 +83,7 @@ pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
 	let maybe_storage_map =
 		get_storage_map("System", "Account", who, &StorageHasher::Blake2_128Concat);
 	if maybe_storage_map.is_none() {
-		warn!("Failed to get account info for account {}", account_id_to_string(who));
+		info!("Failed to get account info for account {}", account_id_to_string(who));
 	}
 	maybe_storage_map
 }
@@ -131,7 +131,7 @@ pub fn account_nonce(account: &AccountId) -> Index {
 	if let Some(info) = get_account_info(account) {
 		info.nonce
 	} else {
-		warn!("Attempted to get nonce of non-existent account: {}", account_id_to_string(account));
+		info!("Attempted to get nonce of non-existent account: {}", account_id_to_string(account));
 		0_u32
 	}
 }
@@ -140,7 +140,7 @@ pub fn account_data(account: &AccountId) -> Option<AccountData> {
 	if let Some(info) = get_account_info(account) {
 		Some(info.data)
 	} else {
-		warn!(
+		info!(
 			"Attempted to get account data of non-existent account: {}",
 			account_id_to_string(account)
 		);

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -92,7 +92,7 @@ pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 	// validate
 	let expected_nonce = get_account_info(who).map_or_else(
 		|| {
-			warn!(
+			info!(
 				"Attempted to validate account nonce of non-existent account: {}",
 				account_id_to_string(who)
 			);

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -69,7 +69,7 @@ pub fn get_storage_by_key_hash<V: Decode>(key: Vec<u8>) -> Option<V> {
 			None
 		}
 	} else {
-		error!("key not found in state {:x?}", key);
+		info!("key not found in state {:x?}", key);
 		None
 	}
 }
@@ -80,12 +80,26 @@ pub fn account_key_hash(account: &AccountId) -> Vec<u8> {
 }
 
 pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
-	get_storage_map("System", "Account", who, &StorageHasher::Blake2_128Concat)
+	let maybe_storage_map =
+		get_storage_map("System", "Account", who, &StorageHasher::Blake2_128Concat);
+	if maybe_storage_map.is_none() {
+		warn!("Failed to get account info for account {}", account_id_to_string(who));
+	}
+	maybe_storage_map
 }
 
 pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 	// validate
-	let expected_nonce = get_account_info(who).map_or_else(|| 0, |acc| acc.nonce);
+	let expected_nonce = get_account_info(who).map_or_else(
+		|| {
+			warn!(
+				"Attempted to validate account nonce of non-existent account: {}",
+				account_id_to_string(who)
+			);
+			0
+		},
+		|acc| acc.nonce,
+	);
 	if expected_nonce == nonce {
 		return Ok(())
 	}
@@ -101,12 +115,15 @@ pub fn increment_nonce(account: &AccountId) {
 		acc_info.nonce += 1;
 		sp_io::storage::set(&account_key_hash(account), &acc_info.encode());
 		debug!(
-			"updated account {:?} nonce: {:?}",
-			account.encode(),
+			"updated account {} nonce: {:?}",
+			account_id_to_string(account),
 			get_account_info(account).unwrap().nonce
 		);
 	} else {
-		error!("tried to increment nonce of a non-existent account")
+		error!(
+			"tried to increment nonce of a non-existent account: {}",
+			account_id_to_string(account)
+		)
 	}
 }
 
@@ -114,6 +131,7 @@ pub fn account_nonce(account: &AccountId) -> Index {
 	if let Some(info) = get_account_info(account) {
 		info.nonce
 	} else {
+		warn!("Attempted to get nonce of non-existent account: {}", account_id_to_string(account));
 		0_u32
 	}
 }
@@ -122,6 +140,10 @@ pub fn account_data(account: &AccountId) -> Option<AccountData> {
 	if let Some(info) = get_account_info(account) {
 		Some(info.data)
 	} else {
+		warn!(
+			"Attempted to get account data of non-existent account: {}",
+			account_id_to_string(account)
+		);
 		None
 	}
 }

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -90,16 +90,16 @@ pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
 
 pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 	// validate
-	let expected_nonce = get_account_info(who).map_or_else(
-		|| {
+	let expected_nonce = match get_account_info(who) {
+		None => {
 			info!(
 				"Attempted to validate account nonce of non-existent account: {}",
 				account_id_to_string(who)
 			);
 			0
 		},
-		|acc| acc.nonce,
-	);
+		Some(account_info) => account_info.nonce,
+	};
 	if expected_nonce == nonce {
 		return Ok(())
 	}

--- a/cli/src/trusted_commands.rs
+++ b/cli/src/trusted_commands.rs
@@ -147,6 +147,7 @@ fn new_account(trusted_args: &TrustedArgs) {
 	let store = LocalKeystore::open(get_keystore_path(trusted_args), None).unwrap();
 	let key: sr25519::AppPair = store.generate().unwrap();
 	drop(store);
+	info!("new account {}", key.public().to_ss58check());
 	println!("{}", key.public().to_ss58check());
 }
 

--- a/cli/src/trusted_commands.rs
+++ b/cli/src/trusted_commands.rs
@@ -177,6 +177,7 @@ fn transfer(cli: &Cli, trusted_args: &TrustedArgs, arg_from: &str, arg_to: &str,
 		.sign(&KeyPair::Sr25519(from), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
 	let _ = perform_operation(cli, trusted_args, &top);
+	info!("trusted call transfer executed");
 }
 
 fn set_balance(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str, amount: &Balance) {

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -118,7 +118,7 @@ fn send_request(
 	let block_hash =
 		_chain_api.send_extrinsic(xt.hex_encode(), XtStatus::InBlock).unwrap().unwrap();
 	info!(
-		"Trusted call extrinsic sent and sucessfully included in parentchain block with hash {:?}.",
+		"Trusted call extrinsic sent and successfully included in parentchain block with hash {:?}.",
 		block_hash
 	);
 	info!("Waiting for execution confirmation from enclave...");

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -156,6 +156,8 @@ where
 			warn!("Failed to update metric for top pool size: {:?}", e);
 		}
 
+		debug!("Submitting trusted operation to TOP pool");
+
 		match submission_mode {
 			TopSubmissionMode::Submit => Box::pin(
 				self.top_pool

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -156,7 +156,9 @@ where
 			warn!("Failed to update metric for top pool size: {:?}", e);
 		}
 
-		debug!("Submitting trusted operation to TOP pool");
+		if let Some(trusted_call_signed) = trusted_operation.to_call() {
+			debug!("Submitting trusted call to TOP pool: {:?}", trusted_call_signed.call);
+		}
 
 		match submission_mode {
 			TopSubmissionMode::Submit => Box::pin(

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -157,7 +157,19 @@ where
 		}
 
 		if let Some(trusted_call_signed) = trusted_operation.to_call() {
-			debug!("Submitting trusted call to TOP pool: {:?}", trusted_call_signed.call);
+			debug!(
+				"Submitting trusted call to TOP pool: {:?}, TOP hash: {:?}",
+				trusted_call_signed.call,
+				self.hash_of(&trusted_operation)
+			);
+		} else if let TrustedOperation::get(Getter::trusted(ref trusted_getter_signed)) =
+			trusted_operation
+		{
+			debug!(
+				"Submitting trusted getter to TOP pool: {:?}, TOP hash: {:?}",
+				trusted_getter_signed.getter,
+				self.hash_of(&trusted_operation)
+			);
 		}
 
 		match submission_mode {

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -148,6 +148,7 @@ where
 			else if let Ok(xt) = ParentchainUncheckedExtrinsic::<CallWorkerFn>::decode(
 				&mut xt_opaque.encode().as_slice(),
 			) {
+				debug!("Found trusted call extrinsic, submitting it to the top pool");
 				if xt.function.0 == [TEEREX_MODULE, CALL_WORKER] {
 					let (_, request) = xt.function;
 					let (shard, cypher_text) = (request.shard, request.cyphertext);

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -123,13 +123,18 @@ where
 	where
 		ParentchainBlock: ParentchainBlockTrait<Hash = H256>,
 	{
-		debug!("Scanning block {:?} for relevant xt", block.header().number());
+		let block_number = *block.header().number();
+		debug!("Scanning block {:?} for relevant xt", block_number);
 		let mut executed_shielding_calls = Vec::<H256>::new();
 		for xt_opaque in block.extrinsics().iter() {
+			let mut shield_funds_decoded = false;
+			let mut call_worker_decoded = false;
+
 			// Found ShieldFunds extrinsic in block.
 			if let Ok(xt) = ParentchainUncheckedExtrinsic::<ShieldFundsFn>::decode(
 				&mut xt_opaque.encode().as_slice(),
 			) {
+				trace!("Found ShieldFundsFn extrinsics in parentchain block {:?}", block_number);
 				if xt.function.0 == [TEEREX_MODULE, SHIELD_FUNDS] {
 					let hash_of_xt = hash_of(&xt);
 
@@ -143,17 +148,27 @@ where
 						},
 					}
 				}
+				shield_funds_decoded = true;
 			}
+
 			// Found CallWorker extrinsic in block.
-			else if let Ok(xt) = ParentchainUncheckedExtrinsic::<CallWorkerFn>::decode(
+			if let Ok(xt) = ParentchainUncheckedExtrinsic::<CallWorkerFn>::decode(
 				&mut xt_opaque.encode().as_slice(),
 			) {
+				trace!("Found CallWorkerFn extrinsics in parentchain block {:?}", block_number);
 				if xt.function.0 == [TEEREX_MODULE, CALL_WORKER] {
 					let (_, request) = xt.function;
 					let (shard, cypher_text) = (request.shard, request.cyphertext);
 					debug!("Found trusted call extrinsic, submitting it to the top pool");
 					self.submit_trusted_call(shard, cypher_text);
 				}
+				call_worker_decoded = true;
+			}
+
+			if shield_funds_decoded && call_worker_decoded {
+				debug!(
+					"Found BOTH shield_funds and call_worker function in the same opaque extrinsic"
+				);
 			}
 		}
 		Ok(executed_shielding_calls)

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -129,10 +129,11 @@ where
 		for xt_opaque in block.extrinsics().iter() {
 			let mut shield_funds_decoded = false;
 			let mut call_worker_decoded = false;
+			let encoded_xt_opaque = xt_opaque.encode();
 
 			// Found ShieldFunds extrinsic in block.
 			if let Ok(xt) = ParentchainUncheckedExtrinsic::<ShieldFundsFn>::decode(
-				&mut xt_opaque.encode().as_slice(),
+				&mut encoded_xt_opaque.as_slice(),
 			) {
 				trace!("Found ShieldFundsFn extrinsics in parentchain block {:?}", block_number);
 				if xt.function.0 == [TEEREX_MODULE, SHIELD_FUNDS] {
@@ -152,8 +153,9 @@ where
 			}
 
 			// Found CallWorker extrinsic in block.
+			// No else-if here! Because the same opaque extrinsic can contain multiple Fns at once (this lead to intermittent M6 failures)
 			if let Ok(xt) = ParentchainUncheckedExtrinsic::<CallWorkerFn>::decode(
-				&mut xt_opaque.encode().as_slice(),
+				&mut encoded_xt_opaque.as_slice(),
 			) {
 				trace!("Found CallWorkerFn extrinsics in parentchain block {:?}", block_number);
 				if xt.function.0 == [TEEREX_MODULE, CALL_WORKER] {
@@ -166,7 +168,7 @@ where
 			}
 
 			if shield_funds_decoded && call_worker_decoded {
-				debug!(
+				trace!(
 					"Found BOTH shield_funds and call_worker function in the same opaque extrinsic"
 				);
 			}

--- a/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/indirect_calls_executor.rs
@@ -148,10 +148,10 @@ where
 			else if let Ok(xt) = ParentchainUncheckedExtrinsic::<CallWorkerFn>::decode(
 				&mut xt_opaque.encode().as_slice(),
 			) {
-				debug!("Found trusted call extrinsic, submitting it to the top pool");
 				if xt.function.0 == [TEEREX_MODULE, CALL_WORKER] {
 					let (_, request) = xt.function;
 					let (shard, cypher_text) = (request.shard, request.cyphertext);
+					debug!("Found trusted call extrinsic, submitting it to the top pool");
 					self.submit_trusted_call(shard, cypher_text);
 				}
 			}

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -142,7 +142,9 @@ pub fn produce_sidechain_block_and_import_it() {
 	let parentchain_header = ParentchainHeaderBuilder::default().build();
 	let timestamp = duration_now();
 	let slot = slot_from_timestamp_and_duration(duration_now(), SLOT_DURATION);
-	let slot_info = SlotInfo::new(slot, timestamp, SLOT_DURATION, parentchain_header.clone());
+	let ends_at = timestamp + SLOT_DURATION;
+	let slot_info =
+		SlotInfo::new(slot, timestamp, SLOT_DURATION, ends_at, parentchain_header.clone());
 
 	info!("Test setup is done.");
 

--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -260,7 +260,7 @@ where
 		proposer_environment,
 	)
 	.with_claim_strategy(SlotClaimStrategy::RoundRobin)
-	.with_allow_delayed_proposal(true);
+	.with_allow_delayed_proposal(false);
 
 	let (blocks, xts): (Vec<_>, Vec<_>) =
 		PerShardSlotWorkerScheduler::on_slot(&mut aura, slot, shards)

--- a/local-setup/py/worker.py
+++ b/local-setup/py/worker.py
@@ -160,7 +160,7 @@ class Worker:
         """
 
         # Todo: make this configurable
-        env = dict(os.environ, RUST_LOG='warn,ws=warn,sp_io=warn,'
+        env = dict(os.environ, RUST_LOG='warn,ws=warn,sp_io=error,'
                                         'substrate_api_client=warn,'
                                         'jsonrpsee_ws_client=warn,'
                                         'jsonrpsee_ws_server=warn,'

--- a/local-setup/py/worker.py
+++ b/local-setup/py/worker.py
@@ -166,11 +166,6 @@ class Worker:
                                         'jsonrpsee_ws_server=warn,'
                                         'enclave_runtime=warn,'
                                         'integritee_service=warn,'
-                                        'itp_stf_executor::executor=debug,'
-                                        'itc_parentchain_indirect_calls_executor::indirect_calls_executor=debug,'
-                                        'itp_top_pool_author::author=debug,'
-                                        'its_consensus_aura::slot_proposer=debug,'
-                                        'its_rpc_handler::direct_top_pool_api=debug,'
                                         'ita_stf=debug')
 
         return Popen(

--- a/local-setup/py/worker.py
+++ b/local-setup/py/worker.py
@@ -168,6 +168,7 @@ class Worker:
                                         'integritee_service=warn,'
                                         'itp_stf_executor::executor=debug,'
                                         'itc_parentchain_indirect_calls_executor::indirect_calls_executor=debug,'
+                                        'itp_top_pool_author::author=debug,'
                                         'ita_stf=debug')
 
         return Popen(

--- a/local-setup/py/worker.py
+++ b/local-setup/py/worker.py
@@ -170,6 +170,7 @@ class Worker:
                                         'itc_parentchain_indirect_calls_executor::indirect_calls_executor=debug,'
                                         'itp_top_pool_author::author=debug,'
                                         'its_consensus_aura::slot_proposer=debug,'
+                                        'its_rpc_handler::direct_top_pool_api=debug,'
                                         'ita_stf=debug')
 
         return Popen(

--- a/local-setup/py/worker.py
+++ b/local-setup/py/worker.py
@@ -166,6 +166,8 @@ class Worker:
                                         'jsonrpsee_ws_server=warn,'
                                         'enclave_runtime=warn,'
                                         'integritee_service=warn,'
+                                        'itp_stf_executor::executor=debug,'
+                                        'itc_parentchain_indirect_calls_executor::indirect_calls_executor=debug,'
                                         'ita_stf=debug')
 
         return Popen(

--- a/local-setup/py/worker.py
+++ b/local-setup/py/worker.py
@@ -169,6 +169,7 @@ class Worker:
                                         'itp_stf_executor::executor=debug,'
                                         'itc_parentchain_indirect_calls_executor::indirect_calls_executor=debug,'
                                         'itp_top_pool_author::author=debug,'
+                                        'its_consensus_aura::slot_proposer=debug,'
                                         'ita_stf=debug')
 
         return Popen(

--- a/scripts/init_env.sh
+++ b/scripts/init_env.sh
@@ -7,7 +7,7 @@ export PROJ_ROOT="$(dirname "$SCRIPT_DIR")"
 export CLIENT_DIR="$PROJ_ROOT/cli"
 export LOG_DIR="$PROJ_ROOT/log"
 export CI_DIR="$PROJ_ROOT/ci"
-export RUST_LOG=info,ws=warn,substrate_api_client=warn
+export RUST_LOG=info,ws=warn,substrate_api_client=warn,ac_node_api=warn
 
 echo "Set environment variables:"
 echo "  BASH_SCRIPT_DIR: $SCRIPT_DIR"

--- a/scripts/init_env.sh
+++ b/scripts/init_env.sh
@@ -7,7 +7,7 @@ export PROJ_ROOT="$(dirname "$SCRIPT_DIR")"
 export CLIENT_DIR="$PROJ_ROOT/cli"
 export LOG_DIR="$PROJ_ROOT/log"
 export CI_DIR="$PROJ_ROOT/ci"
-
+export RUST_LOG=info,ws=warn,substrate_api_client=warn
 
 echo "Set environment variables:"
 echo "  BASH_SCRIPT_DIR: $SCRIPT_DIR"

--- a/sidechain/consensus/aura/src/lib.rs
+++ b/sidechain/consensus/aura/src/lib.rs
@@ -306,11 +306,12 @@ mod tests {
 	}
 
 	fn now_slot(slot: Slot) -> SlotInfo<ParentchainBlock> {
+		let now = duration_now();
 		SlotInfo {
 			slot,
-			timestamp: duration_now(),
+			timestamp: now,
 			duration: SLOT_DURATION,
-			ends_at: duration_now() + SLOT_DURATION,
+			ends_at: now + SLOT_DURATION,
 			last_imported_parentchain_head: default_header(),
 		}
 	}

--- a/sidechain/consensus/aura/src/slot_proposer.rs
+++ b/sidechain/consensus/aura/src/slot_proposer.rs
@@ -99,18 +99,7 @@ impl<ParentchainBlock, SignedSidechainBlock, TopPoolExecutor, BlockComposer, Stf
 			.get_trusted_calls(&self.shard)
 			.map_err(|e| ConsensusError::Other(e.to_string().into()))?;
 
-		// TODO: remove when we have proper on-boarding of new workers #273.
-		if trusted_calls.is_empty() {
-			info!("No trusted calls in top for shard: {:?}", self.shard);
-		// We return here when we actually import sidechain blocks because we currently have no
-		// means of worker on-boarding. Without on-boarding we have can't get a working multi
-		// worker-setup.
-		//
-		// But if we use this trick (only produce a sidechain block if there are trusted_calls), we
-		// we can simply wait with the submission of trusted calls until all workers are ready. Then
-		// we don't need to exchange any state and can have a functional multi-worker setup.
-		// return Ok(Default::default())
-		} else {
+		if !trusted_calls.is_empty() {
 			debug!("Got following trusted calls from pool: {:?}", trusted_calls);
 		}
 

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -34,6 +34,7 @@ its-consensus-common = { path = "../common", default-features = false }
 
 [dev-dependencies]
 itp-test = { path = "../../../core-primitives/test" }
+its-primitives = { path = "../../primitives" }
 its-test = { path = "../../test" }
 sp-keyring = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 tokio = "*"

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -34,7 +34,6 @@ its-consensus-common = { path = "../common", default-features = false }
 
 [dev-dependencies]
 itp-test = { path = "../../../core-primitives/test" }
-its-primitives = { path = "../../primitives" }
 its-test = { path = "../../test" }
 sp-keyring = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 tokio = "*"

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -33,6 +33,7 @@ itp-types = { path = "../../../core-primitives/types", default-features = false 
 its-consensus-common = { path = "../common", default-features = false }
 
 [dev-dependencies]
+itp-test = { path = "../../../core-primitives/test" }
 its-test = { path = "../../test" }
 sp-keyring = { version = "6.0.0", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.20" }
 tokio = "*"

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -316,10 +316,12 @@ impl<B: ParentchainBlock, T: SimpleSlotWorker<B>> PerShardSlotWorkerScheduler<B>
 				return slot_results
 			}
 
+			let shard_slot_ends_at = duration_now() + shard_remaining_duration;
 			let shard_slot = SlotInfo::new(
 				slot_info.slot,
 				duration_now(),
-				shard_remaining_duration,
+				slot_info.duration,
+				shard_slot_ends_at,
 				slot_info.last_imported_parentchain_head.clone(),
 			);
 

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -51,6 +51,12 @@ use std::{fmt::Debug, time::Duration, vec::Vec};
 mod slot_stream;
 mod slots;
 
+#[cfg(test)]
+mod mocks;
+
+#[cfg(test)]
+mod per_shard_slot_worker_tests;
+
 #[cfg(feature = "std")]
 pub use slot_stream::*;
 pub use slots::*;

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -326,7 +326,7 @@ impl<B: ParentchainBlock, T: SimpleSlotWorker<B>> PerShardSlotWorkerScheduler<B>
 			let shard_slot = SlotInfo::new(
 				slot_info.slot,
 				duration_now(),
-				slot_info.duration,
+				shard_remaining_duration,
 				shard_slot_ends_at,
 				slot_info.last_imported_parentchain_head.clone(),
 			);

--- a/sidechain/consensus/slots/src/mocks.rs
+++ b/sidechain/consensus/slots/src/mocks.rs
@@ -17,7 +17,9 @@
 
 use crate::{slots::Slot, ParentchainBlock, SimpleSlotWorker, SlotInfo, SlotResult};
 use its_consensus_common::{Proposal, Proposer, Result};
-use its_primitives::{traits::ShardIdentifierFor, types::SignedBlock as SignedSidechainBlock};
+use sidechain_primitives::{
+	traits::ShardIdentifierFor, types::SignedBlock as SignedSidechainBlock,
+};
 use std::{marker::PhantomData, thread, time::Duration};
 
 #[derive(Default)]

--- a/sidechain/consensus/slots/src/mocks.rs
+++ b/sidechain/consensus/slots/src/mocks.rs
@@ -1,0 +1,115 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{slots::Slot, ParentchainBlock, SimpleSlotWorker, SlotInfo, SlotResult};
+use its_consensus_common::{Proposal, Proposer, Result};
+use its_primitives::{traits::ShardIdentifierFor, types::SignedBlock as SignedSidechainBlock};
+use std::{marker::PhantomData, thread, time::Duration};
+
+#[derive(Default)]
+pub(crate) struct ProposerMock<ParentchainBlock> {
+	_phantom: PhantomData<ParentchainBlock>,
+}
+
+impl<B> Proposer<B, SignedSidechainBlock> for ProposerMock<B>
+where
+	B: ParentchainBlock,
+{
+	fn propose(&self, _max_duration: Duration) -> Result<Proposal<SignedSidechainBlock>> {
+		todo!()
+	}
+}
+
+#[derive(Default)]
+pub(crate) struct SimpleSlotWorkerMock<B>
+where
+	B: ParentchainBlock,
+{
+	pub slot_infos: Vec<SlotInfo<B>>,
+	pub slot_time_spent: Option<Duration>,
+}
+
+impl<B> SimpleSlotWorker<B> for SimpleSlotWorkerMock<B>
+where
+	B: ParentchainBlock,
+{
+	type Proposer = ProposerMock<B>;
+
+	type Claim = u64;
+
+	type EpochData = u64;
+
+	type Output = SignedSidechainBlock;
+
+	fn logging_target(&self) -> &'static str {
+		"test"
+	}
+
+	fn epoch_data(&self, _header: &B::Header, _slot: Slot) -> Result<Self::EpochData> {
+		todo!()
+	}
+
+	fn authorities_len(&self, _epoch_data: &Self::EpochData) -> Option<usize> {
+		todo!()
+	}
+
+	fn claim_slot(
+		&self,
+		_header: &B::Header,
+		_slot: Slot,
+		_epoch_data: &Self::EpochData,
+	) -> Option<Self::Claim> {
+		todo!()
+	}
+
+	fn proposer(
+		&mut self,
+		_header: B::Header,
+		_shard: ShardIdentifierFor<Self::Output>,
+	) -> Result<Self::Proposer> {
+		todo!()
+	}
+
+	fn proposing_remaining_duration(&self, _slot_info: &SlotInfo<B>) -> Duration {
+		todo!()
+	}
+
+	fn allow_delayed_proposal(&self) -> bool {
+		todo!()
+	}
+
+	fn import_latest_parentchain_block(
+		&self,
+		_current_latest_imported_header: &B::Header,
+	) -> Result<B::Header> {
+		todo!()
+	}
+
+	fn on_slot(
+		&mut self,
+		slot_info: SlotInfo<B>,
+		_shard: ShardIdentifierFor<Self::Output>,
+	) -> Option<SlotResult<Self::Output>> {
+		self.slot_infos.push(slot_info);
+
+		if let Some(sleep_duration) = self.slot_time_spent {
+			thread::sleep(sleep_duration);
+		}
+
+		None
+	}
+}

--- a/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
+++ b/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
@@ -40,6 +40,14 @@ fn slot_timings_are_correct_with_multiple_shards() {
 
 	assert_eq!(slot_worker.slot_infos.len(), shards.len());
 
+	// end-time of the first shard slot should not exceed timestamp + 1/(n_shards) of the total slot duration
+	assert!(
+		slot_worker.slot_infos.first().unwrap().ends_at.as_millis()
+			<= (slot_info.timestamp + SLOT_DURATION.checked_div(shards.len() as u32).unwrap())
+				.as_millis()
+	);
+
+	// none of the shard slot end times should exceed the global slot end time
 	for shard_slot_info in slot_worker.slot_infos {
 		assert!(
 			shard_slot_info.ends_at.as_millis() <= slot_info.ends_at.as_millis(),

--- a/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
+++ b/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
@@ -41,10 +41,15 @@ fn slot_timings_are_correct_with_multiple_shards() {
 	assert_eq!(slot_worker.slot_infos.len(), shards.len());
 
 	// end-time of the first shard slot should not exceed timestamp + 1/(n_shards) of the total slot duration
+	let first_shard_slot_end_time = slot_worker.slot_infos.first().unwrap().ends_at.as_millis();
+	let expected_upper_bound = (slot_info.timestamp.as_millis()
+		+ SLOT_DURATION.as_millis().checked_div(shards.len() as u128).unwrap())
+		+ 1u128;
 	assert!(
-		slot_worker.slot_infos.first().unwrap().ends_at.as_millis()
-			<= (slot_info.timestamp + SLOT_DURATION.checked_div(shards.len() as u32).unwrap())
-				.as_millis()
+		first_shard_slot_end_time <= expected_upper_bound,
+		"First shard end time, expected: {}, actual: {}",
+		expected_upper_bound,
+		first_shard_slot_end_time
 	);
 
 	// none of the shard slot end times should exceed the global slot end time

--- a/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
+++ b/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
@@ -1,0 +1,79 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	mocks::SimpleSlotWorkerMock, slot_from_timestamp_and_duration, PerShardSlotWorkerScheduler,
+	SlotInfo,
+};
+use itp_settings::sidechain::SLOT_DURATION;
+use itp_test::builders::parentchain_header_builder::ParentchainHeaderBuilder;
+use itp_time_utils::duration_now;
+use itp_types::{Block as ParentchainBlock, ShardIdentifier};
+
+type TestSlotWorker = SimpleSlotWorkerMock<ParentchainBlock>;
+
+#[test]
+fn slot_timings_are_correct_with_multiple_shards() {
+	let slot_info = slot_info_from_now();
+	let mut slot_worker =
+		TestSlotWorker { slot_infos: Vec::new(), slot_time_spent: Some(SLOT_DURATION / 10) };
+
+	let shards =
+		vec![ShardIdentifier::default(), ShardIdentifier::default(), ShardIdentifier::default()];
+
+	let _slot_results =
+		PerShardSlotWorkerScheduler::on_slot(&mut slot_worker, slot_info.clone(), shards.clone());
+
+	assert_eq!(slot_worker.slot_infos.len(), shards.len());
+
+	for shard_slot_info in slot_worker.slot_infos {
+		assert!(
+			shard_slot_info.ends_at.as_millis() <= slot_info.ends_at.as_millis(),
+			"shard slot info ends at: {} ms, total slot info ends at: {} ms",
+			shard_slot_info.ends_at.as_millis(),
+			slot_info.ends_at.as_millis()
+		);
+	}
+}
+
+#[test]
+fn if_shard_takes_up_all_slot_time_subsequent_shards_are_not_served() {
+	let slot_info = slot_info_from_now();
+	let mut slot_worker =
+		TestSlotWorker { slot_infos: Vec::new(), slot_time_spent: Some(SLOT_DURATION) };
+
+	let shards =
+		vec![ShardIdentifier::default(), ShardIdentifier::default(), ShardIdentifier::default()];
+
+	let _slot_results =
+		PerShardSlotWorkerScheduler::on_slot(&mut slot_worker, slot_info.clone(), shards.clone());
+
+	assert_eq!(1, slot_worker.slot_infos.len());
+}
+
+fn slot_info_from_now() -> SlotInfo<ParentchainBlock> {
+	let timestamp_now = duration_now();
+	let slot = slot_from_timestamp_and_duration(timestamp_now, SLOT_DURATION);
+	let slot_ends_at = timestamp_now + SLOT_DURATION;
+	SlotInfo::new(
+		slot,
+		timestamp_now,
+		SLOT_DURATION,
+		slot_ends_at,
+		ParentchainHeaderBuilder::default().build(),
+	)
+}

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -27,6 +27,7 @@ use its_consensus_common::Error as ConsensusError;
 use sidechain_primitives::traits::{
 	Block as SidechainBlockTrait, BlockData, SignedBlock as SignedSidechainBlockTrait,
 };
+use log::warn;
 use sp_runtime::traits::Block as ParentchainBlockTrait;
 use std::time::Duration;
 
@@ -94,8 +95,19 @@ pub(crate) fn timestamp_within_slot<
 ) -> bool {
 	let proposal_stamp = proposal.block().block_data().timestamp();
 
-	slot.timestamp.as_millis() as u64 <= proposal_stamp
-		&& slot.ends_at.as_millis() as u64 >= proposal_stamp
+	let is_within_slot = slot.timestamp.as_millis() as u64 <= proposal_stamp
+		&& slot.ends_at.as_millis() as u64 >= proposal_stamp;
+
+	if !is_within_slot {
+		warn!(
+			"Proposed block slot time: {} ms, slot start: {} ms , slot end: {} ms",
+			proposal_stamp,
+			slot.timestamp.as_millis(),
+			slot.ends_at.as_millis()
+		);
+	}
+
+	is_within_slot
 }
 
 pub fn slot_from_timestamp_and_duration(timestamp: Duration, duration: Duration) -> Slot {

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -24,10 +24,10 @@ pub use sp_consensus_slots::Slot;
 use itp_sgx_io::StaticSealedIO;
 use itp_time_utils::duration_now;
 use its_consensus_common::Error as ConsensusError;
+use log::warn;
 use sidechain_primitives::traits::{
 	Block as SidechainBlockTrait, BlockData, SignedBlock as SignedSidechainBlockTrait,
 };
-use log::warn;
 use sp_runtime::traits::Block as ParentchainBlockTrait;
 use std::time::Duration;
 

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -45,7 +45,7 @@ pub fn time_until_next_slot(slot_duration: Duration) -> Duration {
 }
 
 /// Information about a slot.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SlotInfo<ParentchainBlock: ParentchainBlockTrait> {
 	/// The slot number as found in the inherent data.
 	pub slot: Slot,

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -82,6 +82,9 @@ impl<ParentchainBlock: ParentchainBlockTrait> SlotInfo<ParentchainBlock> {
 }
 
 /// The time at which the slot ends.
+///
+/// !! Slot duration needs to be the 'global' slot duration that is used for the sidechain.
+/// Do not use this with 'custom' slot durations, as used e.g. for the shard slots.  
 pub fn slot_ends_at(slot: Slot, slot_duration: Duration) -> Duration {
 	Duration::from_millis(*slot.saturating_add(1u64) * (slot_duration.as_millis() as u64))
 }

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -33,6 +33,7 @@ use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use jsonrpc_core::{
 	futures::executor, serde_json::json, Error as RpcError, IoHandler, Params, Value,
 };
+use log::*;
 use std::{borrow::ToOwned, format, string::String, sync::Arc, vec, vec::Vec};
 
 type Hash = sp_core::H256;
@@ -134,6 +135,8 @@ fn author_submit_extrinsic_inner<R: AuthorApi<Hash, Hash> + Send + Sync + 'stati
 	author: Arc<R>,
 	params: Params,
 ) -> Result<Hash, String> {
+	debug!("Author submit and watch trusted operation..");
+
 	let hex_encoded_params = params.parse::<Vec<String>>().map_err(|e| format!("{:?}", e))?;
 
 	let request =
@@ -143,6 +146,11 @@ fn author_submit_extrinsic_inner<R: AuthorApi<Hash, Hash> + Send + Sync + 'stati
 	let encrypted_trusted_call: Vec<u8> = request.cyphertext;
 	let result = async { author.watch_top(encrypted_trusted_call, shard).await };
 	let response: Result<Hash, RpcError> = executor::block_on(result);
+
+	match &response {
+		Ok(h) => debug!("Trusted operation submitted successfully ({:?})", h),
+		Err(e) => warn!("Submitting trusted operation failed: {:?}", e),
+	}
 
 	response.map_err(|e| format!("{:?}", e))
 }


### PR DESCRIPTION
I noticed multiple failures in unit tests for the slot timing. As a new test (in this PR) demonstrates, the previous implementation was prone to delays in the system (it would fail the test). 

And while investigating that problem, I noticed that for the shard specific slot, we mixed the `slot_duration` with the `ends_at` calculation, giving wrong results.

So I had a closer look at how we compute `ends_at` of a slot, and I found that we can drastically and improve the calculation (at least that's what I'm trying to prove with this PR 😅 ).

In addition, this PR should fix some intermittent failures of the M6 (indirect) integration test.
* The same extrinsic can contain a shield funds AND a balance transfer call. Thus a recent change that introduced an `else-if` in that logic broke the functionality of scanning a block for all relevant calls.

Closes #801