### PR TITLE
Fix issue#794: Make the kind of tip we use configurable per set of extrinsics

### DIFF
--- a/core-primitives/extrinsics-factory/src/mock.rs
+++ b/core-primitives/extrinsics-factory/src/mock.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{error::Result, CreateExtrinsics};
-use itp_types::OpaqueCall;
+use itp_types::{OpaqueCall, ParentchainExtrinsicParamsBuilder};
 use sp_runtime::OpaqueExtrinsic;
 use std::vec::Vec;
 
@@ -27,7 +27,11 @@ use std::vec::Vec;
 pub struct ExtrinsicsFactoryMock;
 
 impl CreateExtrinsics for ExtrinsicsFactoryMock {
-	fn create_extrinsics(&self, _calls: &[OpaqueCall]) -> Result<Vec<OpaqueExtrinsic>> {
+	fn create_extrinsics(
+		&self,
+		_calls: &[OpaqueCall],
+		_extrinsics_params_builder: Option<ParentchainExtrinsicParamsBuilder>,
+	) -> Result<Vec<OpaqueExtrinsic>> {
 		// Intention was to map an OpaqueCall to some dummy OpaqueExtrinsic,
 		// so the output vector has the same size as the input one (and thus can be tested from the outside).
 		// However, it doesn't seem to be possible to construct an empty of dummy OpaqueExtrinsic,

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -177,7 +177,8 @@ impl<
 		}
 
 		// Create extrinsics for all `unshielding` and `block processed` calls we've gathered.
-		let parentchain_extrinsics = self.extrinsics_factory.create_extrinsics(calls.as_slice())?;
+		let parentchain_extrinsics =
+			self.extrinsics_factory.create_extrinsics(calls.as_slice(), None)?;
 
 		// Sending the extrinsic requires mut access because the validator caches the sent extrinsics internally.
 		self.validator_accessor

--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -297,7 +297,7 @@ where
 	debug!("Proposing {} sidechain block(s) (broadcasting to peers)", blocks.len());
 	ocall_api.propose_sidechain_blocks(blocks)?;
 
-	let xts = extrinsics_factory.create_extrinsics(opaque_calls.as_slice())?;
+	let xts = extrinsics_factory.create_extrinsics(opaque_calls.as_slice(), None)?;
 
 	debug!("Sending sidechain block(s) confirmation extrinsic.. ");
 	validator_access.execute_mut_on_validator(|v| v.send_extrinsics(xts))?;


### PR DESCRIPTION
Add Option<ParentchainExtrinsicParamsBuilder> parm to create_extrinsics
Default native token.