### PR TITLE
Peer fetch only missing blocks, not every block available

### DIFF
--- a/core-primitives/ocall-api/src/lib.rs
+++ b/core-primitives/ocall-api/src/lib.rs
@@ -115,7 +115,8 @@ pub trait EnclaveSidechainOCallApi: Clone + Send + Sync {
 
 	fn fetch_sidechain_blocks_from_peer<SignedSidechainBlock: Decode>(
 		&self,
-		last_known_block_hash: BlockHash,
+		last_imported_block_hash: BlockHash,
+		maybe_until_block_hash: Option<BlockHash>,
 		shard_identifier: ShardIdentifier,
 	) -> SgxResult<Vec<SignedSidechainBlock>>;
 }

--- a/core-primitives/test/src/mock/onchain_mock.rs
+++ b/core-primitives/test/src/mock/onchain_mock.rs
@@ -138,7 +138,8 @@ impl EnclaveSidechainOCallApi for OnchainMock {
 
 	fn fetch_sidechain_blocks_from_peer<SignedSidechainBlock: Decode>(
 		&self,
-		_last_known_block_hash: BlockHash,
+		_last_imported_block_hash: BlockHash,
+		_maybe_until_block_hash: Option<BlockHash>,
 		_shard_identifier: ShardIdentifier,
 	) -> SgxResult<Vec<SignedSidechainBlock>> {
 		Ok(Vec::new())

--- a/core-primitives/test/src/mock/sidechain_ocall_api_mock.rs
+++ b/core-primitives/test/src/mock/sidechain_ocall_api_mock.rs
@@ -92,7 +92,8 @@ where
 
 	fn fetch_sidechain_blocks_from_peer<SignedSidechainBlock: Decode>(
 		&self,
-		_last_known_block_hash: BlockHash,
+		_last_imported_block_hash: BlockHash,
+		_maybe_until_block_hash: Option<BlockHash>,
 		_shard_identifier: ShardIdentifier,
 	) -> SgxResult<Vec<SignedSidechainBlock>> {
 		let mut number_of_fetch_calls_lock = self.number_of_fetch_calls.write().unwrap();

--- a/core/rpc-server/src/mock.rs
+++ b/core/rpc-server/src/mock.rs
@@ -43,4 +43,13 @@ impl FetchBlocks<SignedSidechainBlock> for MockSidechainBlockFetcher {
 	) -> its_storage::Result<Vec<SignedBlock>> {
 		Ok(Vec::new())
 	}
+
+	fn fetch_blocks_in_range(
+		&self,
+		_block_hash_from: &BlockHash,
+		_block_hash_until: &BlockHash,
+		_shard_identifier: &ShardIdentifierFor<SignedBlock>,
+	) -> its_storage::Result<Vec<SignedBlock>> {
+		Ok(Vec::new())
+	}
 }

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -163,7 +163,8 @@ enclave {
 	    );
 
 	    sgx_status_t ocall_fetch_sidechain_blocks_from_peer(
-	        [in, size = last_known_block_hash_size] uint8_t * last_known_block_hash, uint32_t last_known_block_hash_size,
+	        [in, size = last_imported_block_hash_size] uint8_t * last_imported_block_hash, uint32_t last_imported_block_hash_size,
+	        [in, size = maybe_until_block_hash_size] uint8_t * maybe_until_block_hash, uint32_t maybe_until_block_hash_size,
 	        [in, size = shard_identifier_size] uint8_t * shard_identifier, uint32_t shard_identifier_size,
 	        [out, size = sidechain_blocks_size] uint8_t * sidechain_blocks, uint32_t sidechain_blocks_size
 	    );

--- a/enclave-runtime/src/ocall/ffi.rs
+++ b/enclave-runtime/src/ocall/ffi.rs
@@ -78,8 +78,10 @@ extern "C" {
 
 	pub fn ocall_fetch_sidechain_blocks_from_peer(
 		ret_val: *mut sgx_status_t,
-		last_known_block_hash: *const u8,
-		last_known_block_hash_size: u32,
+		last_imported_block_hash: *const u8,
+		last_imported_block_hash_size: u32,
+		maybe_until_block_hash: *const u8,
+		maybe_until_block_hash_encoded_size: u32,
 		shard_identifier: *const u8,
 		shard_identifier_size: u32,
 		sidechain_blocks: *mut u8,

--- a/enclave-runtime/src/ocall/sidechain_ocall.rs
+++ b/enclave-runtime/src/ocall/sidechain_ocall.rs
@@ -70,11 +70,13 @@ impl EnclaveSidechainOCallApi for OcallApi {
 
 	fn fetch_sidechain_blocks_from_peer<SignedSidechainBlock: Decode>(
 		&self,
-		last_known_block_hash: BlockHash,
+		last_imported_block_hash: BlockHash,
+		maybe_until_block_hash: Option<BlockHash>,
 		shard_identifier: ShardIdentifier,
 	) -> SgxResult<Vec<SignedSidechainBlock>> {
 		let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
-		let last_known_block_hash_encoded = last_known_block_hash.encode();
+		let last_imported_block_hash_encoded = last_imported_block_hash.encode();
+		let maybe_until_block_hash_encoded = maybe_until_block_hash.encode();
 		let shard_identifier_encoded = shard_identifier.encode();
 
 		// We have to pre-allocate the vector and hope it's large enough
@@ -83,8 +85,10 @@ impl EnclaveSidechainOCallApi for OcallApi {
 		let res = unsafe {
 			ffi::ocall_fetch_sidechain_blocks_from_peer(
 				&mut rt as *mut sgx_status_t,
-				last_known_block_hash_encoded.as_ptr(),
-				last_known_block_hash_encoded.len() as u32,
+				last_imported_block_hash_encoded.as_ptr(),
+				last_imported_block_hash_encoded.len() as u32,
+				maybe_until_block_hash_encoded.as_ptr(),
+				maybe_until_block_hash_encoded.len() as u32,
 				shard_identifier_encoded.as_ptr(),
 				shard_identifier_encoded.len() as u32,
 				signed_blocks_encoded.as_mut_ptr(),

--- a/enclave-runtime/src/test/mocks/propose_to_import_call_mock.rs
+++ b/enclave-runtime/src/test/mocks/propose_to_import_call_mock.rs
@@ -103,7 +103,8 @@ impl EnclaveSidechainOCallApi for ProposeToImportOCallApi {
 
 	fn fetch_sidechain_blocks_from_peer<SignedSidechainBlock: Decode>(
 		&self,
-		_last_known_block_hash: BlockHash,
+		_last_imported_block_hash: BlockHash,
+		_maybe_until_block_hash: Option<BlockHash>,
 		_shard_identifier: ShardIdentifier,
 	) -> SgxResult<Vec<SignedSidechainBlock>> {
 		Ok(Vec::new())

--- a/service/src/ocall_bridge/bridge_api.rs
+++ b/service/src/ocall_bridge/bridge_api.rs
@@ -206,7 +206,8 @@ pub trait SidechainBridge {
 
 	fn fetch_sidechain_blocks_from_peer(
 		&self,
-		last_known_block_hash_encoded: Vec<u8>,
+		last_imported_block_hash_encoded: Vec<u8>,
+		maybe_until_block_hash_encoded: Vec<u8>,
 		shard_identifier_encoded: Vec<u8>,
 	) -> OCallBridgeResult<Vec<u8>>;
 }

--- a/service/src/ocall_bridge/ffi/fetch_sidechain_blocks_from_peer.rs
+++ b/service/src/ocall_bridge/ffi/fetch_sidechain_blocks_from_peer.rs
@@ -49,6 +49,7 @@ pub unsafe extern "C" fn ocall_fetch_sidechain_blocks_from_peer(
 	)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn fetch_sidechain_blocks_from_peer(
 	last_imported_block_hash_ptr: *const u8,
 	last_imported_block_hash_size: u32,

--- a/service/src/ocall_bridge/ffi/fetch_sidechain_blocks_from_peer.rs
+++ b/service/src/ocall_bridge/ffi/fetch_sidechain_blocks_from_peer.rs
@@ -27,16 +27,20 @@ use std::{slice, sync::Arc};
 /// FFI are always unsafe
 #[no_mangle]
 pub unsafe extern "C" fn ocall_fetch_sidechain_blocks_from_peer(
-	last_known_block_hash_ptr: *const u8,
-	last_known_block_hash_size: u32,
+	last_imported_block_hash_ptr: *const u8,
+	last_imported_block_hash_size: u32,
+	maybe_until_block_hash_ptr: *const u8,
+	maybe_until_block_hash_size: u32,
 	shard_identifier_ptr: *const u8,
 	shard_identifier_size: u32,
 	sidechain_blocks_ptr: *mut u8,
 	sidechain_blocks_size: u32,
 ) -> sgx_status_t {
 	fetch_sidechain_blocks_from_peer(
-		last_known_block_hash_ptr,
-		last_known_block_hash_size,
+		last_imported_block_hash_ptr,
+		last_imported_block_hash_size,
+		maybe_until_block_hash_ptr,
+		maybe_until_block_hash_size,
 		shard_identifier_ptr,
 		shard_identifier_size,
 		sidechain_blocks_ptr,
@@ -46,27 +50,37 @@ pub unsafe extern "C" fn ocall_fetch_sidechain_blocks_from_peer(
 }
 
 fn fetch_sidechain_blocks_from_peer(
-	last_known_block_hash_ptr: *const u8,
-	last_known_block_hash_size: u32,
+	last_imported_block_hash_ptr: *const u8,
+	last_imported_block_hash_size: u32,
+	maybe_until_block_hash_ptr: *const u8,
+	maybe_until_block_hash_size: u32,
 	shard_identifier_ptr: *const u8,
 	shard_identifier_size: u32,
 	sidechain_blocks_ptr: *mut u8,
 	sidechain_blocks_size: u32,
 	sidechain_api: Arc<dyn SidechainBridge>,
 ) -> sgx_status_t {
-	let last_known_block_hash_encoded = unsafe {
+	let last_imported_block_hash_encoded = unsafe {
 		Vec::from(slice::from_raw_parts(
-			last_known_block_hash_ptr,
-			last_known_block_hash_size as usize,
+			last_imported_block_hash_ptr,
+			last_imported_block_hash_size as usize,
+		))
+	};
+	let maybe_until_block_hash = unsafe {
+		Vec::from(slice::from_raw_parts(
+			maybe_until_block_hash_ptr,
+			maybe_until_block_hash_size as usize,
 		))
 	};
 	let shard_identifier_encoded = unsafe {
 		Vec::from(slice::from_raw_parts(shard_identifier_ptr, shard_identifier_size as usize))
 	};
 
-	let sidechain_blocks_encoded = match sidechain_api
-		.fetch_sidechain_blocks_from_peer(last_known_block_hash_encoded, shard_identifier_encoded)
-	{
+	let sidechain_blocks_encoded = match sidechain_api.fetch_sidechain_blocks_from_peer(
+		last_imported_block_hash_encoded,
+		maybe_until_block_hash,
+		shard_identifier_encoded,
+	) {
 		Ok(r) => r,
 		Err(e) => {
 			error!("fetch sidechain blocks from peer failed: {:?}", e);
@@ -112,6 +126,7 @@ mod tests {
 
 		let result = call_fetch_sidechain_blocks_from_peer(
 			last_known_block_hash,
+			None,
 			shard_identifier,
 			&mut block_buffer,
 			sidechain_bridge_mock,
@@ -142,6 +157,7 @@ mod tests {
 
 		let result = call_fetch_sidechain_blocks_from_peer(
 			last_known_block_hash,
+			None,
 			shard_identifier,
 			&mut block_buffer,
 			sidechain_bridge_mock,
@@ -151,17 +167,21 @@ mod tests {
 	}
 
 	fn call_fetch_sidechain_blocks_from_peer(
-		last_known_block_hash: H256,
+		last_imported_block_hash: H256,
+		maybe_until_block_hash: Option<H256>,
 		shard_identifier: H256,
 		buffer: &mut Vec<u8>,
 		sidechain_bridge: Arc<dyn SidechainBridge>,
 	) -> sgx_status_t {
-		let last_known_block_hash_encoded = last_known_block_hash.encode();
+		let last_imported_block_hash_encoded = last_imported_block_hash.encode();
+		let maybe_until_block_hash_encoded = maybe_until_block_hash.encode();
 		let shard_identifier_encoded = shard_identifier.encode();
 
 		fetch_sidechain_blocks_from_peer(
-			last_known_block_hash_encoded.as_ptr(),
-			last_known_block_hash_encoded.len() as u32,
+			last_imported_block_hash_encoded.as_ptr(),
+			last_imported_block_hash_encoded.len() as u32,
+			maybe_until_block_hash_encoded.as_ptr(),
+			maybe_until_block_hash_encoded.len() as u32,
 			shard_identifier_encoded.as_ptr(),
 			shard_identifier_encoded.len() as u32,
 			buffer.as_mut_ptr(),

--- a/service/src/ocall_bridge/test/mocks/sidechain_bridge_mock.rs
+++ b/service/src/ocall_bridge/test/mocks/sidechain_bridge_mock.rs
@@ -41,7 +41,8 @@ impl SidechainBridge for SidechainBridgeMock {
 
 	fn fetch_sidechain_blocks_from_peer(
 		&self,
-		_last_known_block_hash_encoded: Vec<u8>,
+		_last_imported_block_hash_encoded: Vec<u8>,
+		_maybe_until_block_hash_encoded: Vec<u8>,
 		_shard_identifier_encoded: Vec<u8>,
 	) -> OCallBridgeResult<Vec<u8>> {
 		Ok(self.peer_blocks_encoded.clone())

--- a/sidechain/consensus/common/src/block_import.rs
+++ b/sidechain/consensus/common/src/block_import.rs
@@ -113,8 +113,9 @@ where
 		let shard = sidechain_block.header().shard_id();
 
 		debug!(
-			"Attempting to import sidechain block (number: {}, parentchain hash: {:?})",
+			"Attempting to import sidechain block (number: {}, hash: {:?}, parentchain hash: {:?})",
 			signed_sidechain_block.block().header().block_number(),
+			signed_sidechain_block.block().hash(),
 			signed_sidechain_block.block().block_data().layer_one_head()
 		);
 

--- a/sidechain/consensus/common/src/peer_block_sync.rs
+++ b/sidechain/consensus/common/src/peer_block_sync.rs
@@ -258,7 +258,7 @@ mod tests {
 
 		peer_syncer.sync_block(signed_sidechain_block, &parentchain_header).unwrap();
 
-		assert_eq!(3, block_importer_mock.get_imported_blocks().len());
+		assert_eq!(4, block_importer_mock.get_imported_blocks().len());
 		assert_eq!(1, sidechain_ocall_api.number_of_fetch_calls());
 	}
 }

--- a/sidechain/consensus/common/src/peer_block_sync.rs
+++ b/sidechain/consensus/common/src/peer_block_sync.rs
@@ -148,7 +148,7 @@ where
 						shard_identifier,
 					)?;
 
-					self.importer.import_block(sidechain_block.clone(), &updated_parentchain_header)
+					self.importer.import_block(sidechain_block, &updated_parentchain_header)
 				},
 				Error::InvalidFirstBlock(block_number, _) => {
 					warn!("Got invalid first block error upon block import (expected first block, but got block with number {}). \
@@ -160,7 +160,7 @@ where
 						shard_identifier,
 					)?;
 
-					self.importer.import_block(sidechain_block.clone(), &updated_parentchain_header)
+					self.importer.import_block(sidechain_block, &updated_parentchain_header)
 				},
 				Error::BlockAlreadyImported(to_import_block_number, last_known_block_number) => {
 					warn!("Sidechain block from queue (number: {}) was already imported (current block number: {}). Block will be ignored.", 

--- a/sidechain/peer-fetch/src/block_fetch_client.rs
+++ b/sidechain/peer-fetch/src/block_fetch_client.rs
@@ -58,13 +58,18 @@ where
 
 	async fn fetch_blocks_from_peer(
 		&self,
-		last_known_block_hash: BlockHash,
+		last_imported_block_hash: BlockHash,
+		maybe_until_block_hash: Option<BlockHash>,
 		shard_identifier: ShardIdentifier,
 	) -> Result<Vec<Self::SignedBlockType>> {
 		let sync_source_rpc_url =
 			self.peer_fetcher.get_untrusted_peer_url_of_shard(&shard_identifier)?;
 
-		let rpc_parameters = vec![to_json_value((last_known_block_hash, shard_identifier))?];
+		let rpc_parameters = vec![to_json_value((
+			last_imported_block_hash,
+			maybe_until_block_hash,
+			shard_identifier,
+		))?];
 
 		info!("Got untrusted url for peer block fetching: {}", sync_source_rpc_url);
 
@@ -96,10 +101,11 @@ mod tests {
 	use sidechain_primitives::types::block::SignedBlock;
 	use std::{net::SocketAddr, sync::Arc};
 
-	const W1_URL: &str = "127.0.0.1:2233";
-
-	async fn run_server(blocks: Vec<SignedBlock>) -> anyhow::Result<SocketAddr> {
-		let mut server = WsServerBuilder::default().build(W1_URL).await?;
+	async fn run_server(
+		blocks: Vec<SignedBlock>,
+		web_socket_url: &str,
+	) -> anyhow::Result<SocketAddr> {
+		let mut server = WsServerBuilder::default().build(web_socket_url).await?;
 
 		let storage_block_fetcher = Arc::new(FetchBlocksMock::default().with_blocks(blocks));
 		let module = BlockFetchServerModuleBuilder::new(storage_block_fetcher).build().unwrap();
@@ -112,19 +118,21 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn fetch_blocks_from_peer() {
+	async fn fetch_blocks_without_bounds_from_peer_works() {
+		const W1_URL: &str = "127.0.0.1:2233";
+
 		let blocks_to_fetch = vec![
 			SidechainBlockBuilder::random().build_signed(),
 			SidechainBlockBuilder::random().build_signed(),
 		];
-		run_server(blocks_to_fetch.clone()).await.unwrap();
+		run_server(blocks_to_fetch.clone(), W1_URL).await.unwrap();
 
 		let peer_fetch_mock = UntrustedPeerFetcherMock::new(format!("ws://{}", W1_URL));
 
 		let peer_fetcher_client = BlockFetcher::<SignedBlock, _>::new(peer_fetch_mock);
 
 		let blocks_fetched = peer_fetcher_client
-			.fetch_blocks_from_peer(BlockHash::default(), ShardIdentifier::default())
+			.fetch_blocks_from_peer(BlockHash::default(), None, ShardIdentifier::default())
 			.await
 			.unwrap();
 

--- a/sidechain/peer-fetch/src/block_fetch_server.rs
+++ b/sidechain/peer-fetch/src/block_fetch_server.rs
@@ -45,15 +45,30 @@ where
 			|params, sidechain_block_fetcher| {
 				debug!("{}: {:?}", RPC_METHOD_NAME_FETCH_BLOCKS_FROM_PEER, params);
 
-				let (block_hash, shard_identifier) =
-					params.one::<(BlockHash, ShardIdentifier)>()?;
-				info!("Got request to fetch sidechain blocks from peer. Fetching sidechain blocks from storage (block hash: {}, shard: {}", block_hash, shard_identifier);
-				sidechain_block_fetcher
-					.fetch_all_blocks_after(&block_hash, &shard_identifier)
-					.map_err(|e| {
-						error!("Failed to fetch sidechain blocks from storage: {:?}", e);
-						CallError::Failed(e.into())
-					})
+				let (from_block_hash, maybe_until_block_hash, shard_identifier) =
+					params.one::<(BlockHash, Option<BlockHash>, ShardIdentifier)>()?;
+				info!("Got request to fetch sidechain blocks from peer. Fetching sidechain blocks from storage \
+					(last imported block hash: {:?}, until block hash: {:?}, shard: {}", 
+					from_block_hash, maybe_until_block_hash, shard_identifier);
+
+				match maybe_until_block_hash {
+					Some(until_block_hash) => sidechain_block_fetcher
+						.fetch_blocks_in_range(
+							&from_block_hash,
+							&until_block_hash,
+							&shard_identifier,
+						)
+						.map_err(|e| {
+							error!("Failed to fetch sidechain blocks from storage: {:?}", e);
+							CallError::Failed(e.into())
+						}),
+					None => sidechain_block_fetcher
+						.fetch_all_blocks_after(&from_block_hash, &shard_identifier)
+						.map_err(|e| {
+							error!("Failed to fetch sidechain blocks from storage: {:?}", e);
+							CallError::Failed(e.into())
+						}),
+				}
 			},
 		)?;
 		Ok(fetch_sidechain_blocks_module)

--- a/sidechain/peer-fetch/src/lib.rs
+++ b/sidechain/peer-fetch/src/lib.rs
@@ -42,7 +42,8 @@ pub trait FetchBlocksFromPeer {
 
 	async fn fetch_blocks_from_peer(
 		&self,
-		last_known_block_hash: BlockHash,
+		last_imported_block_hash: BlockHash,
+		maybe_until_block_hash: Option<BlockHash>,
 		shard_identifier: ShardIdentifier,
 	) -> Result<Vec<Self::SignedBlockType>>;
 }

--- a/sidechain/peer-fetch/src/mocks/fetch_blocks_from_peer_mock.rs
+++ b/sidechain/peer-fetch/src/mocks/fetch_blocks_from_peer_mock.rs
@@ -52,7 +52,8 @@ where
 
 	async fn fetch_blocks_from_peer(
 		&self,
-		_last_known_block_hash: BlockHash,
+		_last_imported_block_hash: BlockHash,
+		_maybe_until_block_hash: Option<BlockHash>,
 		shard_identifier: ShardIdentifier,
 	) -> Result<Vec<Self::SignedBlockType>> {
 		Ok(self.signed_blocks_map.get(&shard_identifier).cloned().unwrap_or_default())

--- a/sidechain/storage/src/fetch_blocks_mock.rs
+++ b/sidechain/storage/src/fetch_blocks_mock.rs
@@ -41,4 +41,13 @@ impl FetchBlocks<SignedBlock> for FetchBlocksMock {
 	) -> Result<Vec<SignedBlock>> {
 		Ok(self.blocks_to_be_fetched.clone())
 	}
+
+	fn fetch_blocks_in_range(
+		&self,
+		_block_hash_from: &BlockHash,
+		_block_hash_until: &BlockHash,
+		_shard_identifier: &ShardIdentifierFor<SignedBlock>,
+	) -> Result<Vec<SignedBlock>> {
+		Ok(self.blocks_to_be_fetched.clone())
+	}
 }

--- a/sidechain/storage/src/interface.rs
+++ b/sidechain/storage/src/interface.rs
@@ -65,6 +65,18 @@ pub trait FetchBlocks<SignedBlock: SignedBlockT> {
 		block_hash: &BlockHash,
 		shard_identifier: &ShardIdentifierFor<SignedBlock>,
 	) -> Result<Vec<SignedBlock>>;
+
+	/// Fetch all blocks within a range, defined by a starting block (lower bound) and end block (upper bound) hash.
+	///
+	/// Does NOT include the bound defining blocks in the result. ]from..until[.
+	/// Returns an empty vector if 'from' cannot be found in storage.
+	/// Returns the same as 'fetch_all_blocks_after' if 'until' cannot be found in storage.
+	fn fetch_blocks_in_range(
+		&self,
+		block_hash_from: &BlockHash,
+		block_hash_until: &BlockHash,
+		shard_identifier: &ShardIdentifierFor<SignedBlock>,
+	) -> Result<Vec<SignedBlock>>;
 }
 
 impl<SignedBlock: SignedBlockT> BlockStorage<SignedBlock> for SidechainStorageLock<SignedBlock> {
@@ -86,5 +98,16 @@ impl<SignedBlock: SignedBlockT> FetchBlocks<SignedBlock> for SidechainStorageLoc
 		shard_identifier: &ShardIdentifierFor<SignedBlock>,
 	) -> Result<Vec<SignedBlock>> {
 		self.storage.read().get_blocks_after(block_hash, shard_identifier)
+	}
+
+	fn fetch_blocks_in_range(
+		&self,
+		block_hash_from: &BlockHash,
+		block_hash_until: &BlockHash,
+		shard_identifier: &ShardIdentifierFor<SignedBlock>,
+	) -> Result<Vec<SignedBlock>> {
+		self.storage
+			.read()
+			.get_blocks_in_range(block_hash_from, block_hash_until, shard_identifier)
 	}
 }

--- a/sidechain/storage/src/lib.rs
+++ b/sidechain/storage/src/lib.rs
@@ -33,6 +33,9 @@ mod storage;
 mod storage_tests_get_blocks_after;
 
 #[cfg(test)]
+mod storage_tests_get_blocks_in_range;
+
+#[cfg(test)]
 mod test_utils;
 
 #[cfg(feature = "mocks")]

--- a/sidechain/storage/src/storage.rs
+++ b/sidechain/storage/src/storage.rs
@@ -145,6 +145,22 @@ impl<SignedBlock: SignedBlockT> SidechainStorage<SignedBlock> {
 		Ok(blocks_to_return)
 	}
 
+	/// Get blocks in a range, defined by 'from' and 'until' (result does NOT include the bound defining blocks).
+	pub fn get_blocks_in_range(
+		&self,
+		block_hash_from: &BlockHash,
+		block_hash_until: &BlockHash,
+		shard_identifier: &ShardIdentifierFor<SignedBlock>,
+	) -> Result<Vec<SignedBlock>> {
+		let all_blocks_from_lower_bound =
+			self.get_blocks_after(block_hash_from, shard_identifier)?;
+
+		Ok(all_blocks_from_lower_bound
+			.into_iter()
+			.take_while(|b| b.hash() != *block_hash_until)
+			.collect())
+	}
+
 	/// Update sidechain storage with blocks.
 	///
 	/// Blocks are iterated through one by one. In case more than one block per shard is included,

--- a/sidechain/storage/src/storage_tests_get_blocks_in_range.rs
+++ b/sidechain/storage/src/storage_tests_get_blocks_in_range.rs
@@ -1,0 +1,104 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::test_utils::{
+	create_signed_block_with_parenthash as create_signed_block, default_shard,
+	fill_storage_with_blocks, get_storage,
+};
+use itp_types::BlockHash;
+use sidechain_primitives::traits::SignedBlock;
+
+#[test]
+fn get_blocks_in_range_works_for_regular_case() {
+	let block_1 = create_signed_block(1, BlockHash::default());
+	let block_2 = create_signed_block(2, block_1.hash());
+	let block_3 = create_signed_block(3, block_2.hash());
+	let block_4 = create_signed_block(4, block_3.hash());
+	let block_5 = create_signed_block(5, block_4.hash());
+
+	let temp_dir = fill_storage_with_blocks(vec![
+		block_1.clone(),
+		block_2.clone(),
+		block_3,
+		block_4.clone(),
+		block_5.clone(),
+	]);
+
+	{
+		let updated_sidechain_db = get_storage(temp_dir.path().to_path_buf());
+		let blocks_2_to_4 = updated_sidechain_db
+			.get_blocks_in_range(&block_1.hash(), &block_5.hash(), &default_shard())
+			.unwrap();
+
+		assert_eq!(3, blocks_2_to_4.len());
+		assert_eq!(block_2.hash(), blocks_2_to_4.first().unwrap().hash());
+		assert_eq!(block_4.hash(), blocks_2_to_4.last().unwrap().hash());
+	}
+}
+
+#[test]
+fn get_blocks_in_range_returns_empty_vec_if_from_is_invalid() {
+	let block_1 = create_signed_block(1, BlockHash::default());
+	let block_2 = create_signed_block(2, block_1.hash());
+	let block_3 = create_signed_block(3, block_2.hash());
+	let block_4 = create_signed_block(4, block_3.hash());
+
+	let temp_dir = fill_storage_with_blocks(vec![
+		block_1.clone(),
+		block_2.clone(),
+		block_3.clone(),
+		block_4.clone(),
+	]);
+
+	{
+		let updated_sidechain_db = get_storage(temp_dir.path().to_path_buf());
+		let invalid_block_hash = BlockHash::from_low_u64_be(1);
+
+		assert!(updated_sidechain_db
+			.get_blocks_in_range(&invalid_block_hash, &block_3.hash(), &default_shard())
+			.unwrap()
+			.is_empty());
+	}
+}
+
+#[test]
+fn get_blocks_in_range_returns_all_blocks_if_upper_bound_is_invalid() {
+	let block_1 = create_signed_block(1, BlockHash::default());
+	let block_2 = create_signed_block(2, block_1.hash());
+	let block_3 = create_signed_block(3, block_2.hash());
+	let block_4 = create_signed_block(4, block_3.hash());
+	let block_5 = create_signed_block(5, block_4.hash());
+
+	let temp_dir = fill_storage_with_blocks(vec![
+		block_1.clone(),
+		block_2.clone(),
+		block_3.clone(),
+		block_4.clone(),
+		block_5.clone(),
+	]);
+
+	{
+		let updated_sidechain_db = get_storage(temp_dir.path().to_path_buf());
+		let blocks_in_range = updated_sidechain_db
+			.get_blocks_in_range(&block_2.hash(), &BlockHash::from_low_u64_be(1), &default_shard())
+			.unwrap();
+
+		assert_eq!(3, blocks_in_range.len());
+		assert_eq!(block_3.hash(), blocks_in_range.first().unwrap().hash());
+		assert_eq!(block_5.hash(), blocks_in_range.last().unwrap().hash());
+	}
+}


### PR DESCRIPTION
Before, we peer fetched all blocks that were available on the peer, leading to overlap with the block import queue of a worker. This had to be detected with an 'AlreadyImported' warning.

Because this is inefficient and causes a lot of potentially misleading warnings, this PR changes the mechanism of peer fetching to fetch only the missing blocks.

Closes #821 