### PR TITLE
800 long running benchmark tests

### DIFF
--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -77,7 +77,7 @@ pub mod worker {
 	// Factors to tune the initial amount of enclave funding:
 	// Should be set to a value that ensures that the enclave can register itself
 	// and the worker can run for a certain time. Only for development.
-	pub const EXISTENTIAL_DEPOSIT_FACTOR_FOR_INIT_FUNDS: u128 = 1_000_000;
+	pub const EXISTENTIAL_DEPOSIT_FACTOR_FOR_INIT_FUNDS: u128 = 200_000;
 	// Should be set to a value that ensures that the enclave can register itself
 	// and that the worker can start.
 	pub const REGISTERING_FEE_FACTOR_FOR_INIT_FUNDS: u128 = 10;

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -77,7 +77,7 @@ pub mod worker {
 	// Factors to tune the initial amount of enclave funding:
 	// Should be set to a value that ensures that the enclave can register itself
 	// and the worker can run for a certain time. Only for development.
-	pub const EXISTENTIAL_DEPOSIT_FACTOR_FOR_INIT_FUNDS: u128 = 10_000;
+	pub const EXISTENTIAL_DEPOSIT_FACTOR_FOR_INIT_FUNDS: u128 = 1_000_000;
 	// Should be set to a value that ensures that the enclave can register itself
 	// and that the worker can start.
 	pub const REGISTERING_FEE_FACTOR_FOR_INIT_FUNDS: u128 = 10;

--- a/core-primitives/stf-state-handler/src/file_io.rs
+++ b/core-primitives/stf-state-handler/src/file_io.rs
@@ -228,7 +228,12 @@ pub mod sgx {
 
 			let state_hash = rsgx_sha256_slice(&cyphertext)?;
 
-			debug!("new encrypted state with hash={:?} written to {:?}", state_hash, state_path);
+			debug!(
+				"new encrypted state with hash={:?} and length={} written to {:?}",
+				state_hash,
+				cyphertext.len(),
+				state_path
+			);
 
 			io_write(&cyphertext, &state_path)?;
 			Ok(state_hash.into())

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -91,7 +91,7 @@ pub fn setup_account_funding(
 fn ensure_account_has_funds(api: &ParentchainApi, accountid: &AccountId32) -> Result<(), Error> {
 	// check account balance
 	let free_balance = api.get_free_balance(accountid)?;
-	info!("TEE's free balance = {:?}", free_balance);
+	info!("TEE's free balance = {:?} (Account: {})", free_balance, accountid);
 
 	let existential_deposit = api.get_existential_deposit()?;
 	info!("Existential deposit is = {:?}", existential_deposit);
@@ -101,6 +101,7 @@ fn ensure_account_has_funds(api: &ParentchainApi, accountid: &AccountId32) -> Re
 	let missing_funds = min_required_funds.saturating_sub(free_balance);
 
 	if missing_funds > 0 {
+		info!("Transfer {:?} from Alice to {}", missing_funds, accountid);
 		bootstrap_funds_from_alice(api, accountid, missing_funds)?;
 	}
 	Ok(())


### PR DESCRIPTION
- Main change is to increase the initial funding for the enclave.
  - Before the enclave would run out of funds after 4 hours, now it is enough for around 80 hours
  - Only affects '--dev' mode
- Some minor additions in the logs