### PR TITLE
Reduce test flakiness for the shard slot timings test

### DIFF
--- a/core-primitives/time-utils/src/lib.rs
+++ b/core-primitives/time-utils/src/lib.rs
@@ -36,9 +36,15 @@ pub fn now_as_nanos() -> u128 {
 	duration_now().as_nanos()
 }
 
-/// Calculates the remaining time `until`.
+/// Calculates the remaining time from now to `until`.
 pub fn remaining_time(until: Duration) -> Option<Duration> {
-	until.checked_sub(duration_now())
+	duration_difference(duration_now(), until)
+}
+
+/// Calculate the difference in duration between `from` and `to`.
+/// Returns `None` if `to` < `from`.
+pub fn duration_difference(from: Duration, to: Duration) -> Option<Duration> {
+	to.checked_sub(from)
 }
 
 /// Returns current duration since unix epoch.

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -33,7 +33,7 @@ extern crate sgx_tstd as std;
 
 use codec::Encode;
 use derive_more::From;
-use itp_time_utils::{duration_now, remaining_time};
+use itp_time_utils::{duration_difference, duration_now};
 use itp_types::OpaqueCall;
 use its_consensus_common::{Error as ConsensusError, Proposer};
 use log::*;
@@ -322,7 +322,8 @@ impl<ParentchainBlock: ParentchainBlockTrait, T: SimpleSlotWorker<ParentchainBlo
 		let mut slot_results = Vec::with_capacity(remaining_shards);
 
 		for shard in shards.into_iter() {
-			let shard_remaining_duration = remaining_time(slot_info.ends_at)
+			let now = duration_now(); // It's important we have a common `now` for all following computations.
+			let shard_remaining_duration = duration_difference(now, slot_info.ends_at)
 				.and_then(|time| time.checked_div(remaining_shards as u32))
 				.unwrap_or_default();
 
@@ -337,7 +338,6 @@ impl<ParentchainBlock: ParentchainBlockTrait, T: SimpleSlotWorker<ParentchainBlo
 				return slot_results
 			}
 
-			let now = duration_now();
 			let shard_slot_ends_at = now + shard_remaining_duration;
 			let shard_slot = SlotInfo::new(
 				slot_info.slot,


### PR DESCRIPTION
We still had some intermittent test failures of `slot_timings_are_correct_with_multiple_shards`.

My changes here hopefully mitigate those failures by introducing a common `now` in the computation of the shard slot timings.