### PR TITLE
Minor cleanup in light-client: Remove obsolete type parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,7 +2327,6 @@ dependencies = [
  "itc-parentchain-indirect-calls-executor",
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
- "itp-ocall-api",
  "itp-settings",
  "itp-stf-executor",
  "itp-types",

--- a/core/parentchain/block-importer/Cargo.toml
+++ b/core/parentchain/block-importer/Cargo.toml
@@ -15,7 +15,6 @@ ita-stf = { path = "../../../app-libs/stf", default-features = false }
 itc-parentchain-indirect-calls-executor = { path = "../indirect-calls-executor", default-features = false }
 itc-parentchain-light-client = { path = "../light-client", default-features = false }
 itp-extrinsics-factory = { path = "../../../core-primitives/extrinsics-factory", default-features = false }
-itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features = false }
 itp-settings = { path = "../../../core-primitives/settings" }
 itp-stf-executor = { path = "../../../core-primitives/stf-executor", default-features = false }
 
@@ -44,7 +43,6 @@ std = [
     "itc-parentchain-indirect-calls-executor/std",
     "itc-parentchain-light-client/std",
     "itp-extrinsics-factory/std",
-    "itp-ocall-api/std",
     "itp-stf-executor/std",
     "itp-types/std",
     # no-std compatible libraries

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -29,7 +29,6 @@ use itc_parentchain_light_client::{
 	Validator,
 };
 use itp_extrinsics_factory::CreateExtrinsics;
-use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
 use itp_settings::node::{PROCESSED_PARENTCHAIN_BLOCK, TEEREX_MODULE};
 use itp_stf_executor::traits::StfUpdateState;
 use itp_types::{OpaqueCall, H256};
@@ -44,15 +43,13 @@ use std::{marker::PhantomData, sync::Arc, vec::Vec};
 pub struct ParentchainBlockImporter<
 	ParentchainBlock,
 	ValidatorAccessor,
-	OCallApi,
 	StfExecutor,
 	ExtrinsicsFactory,
 	IndirectCallsExecutor,
 > where
 	ParentchainBlock: ParentchainBlockTrait<Hash = H256>,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
-	ValidatorAccessor: ValidatorAccess<ParentchainBlock, OCallApi>,
-	OCallApi: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
+	ValidatorAccessor: ValidatorAccess<ParentchainBlock>,
 	StfExecutor: StfUpdateState,
 	ExtrinsicsFactory: CreateExtrinsics,
 	IndirectCallsExecutor: ExecuteIndirectCalls,
@@ -61,13 +58,12 @@ pub struct ParentchainBlockImporter<
 	stf_executor: Arc<StfExecutor>,
 	extrinsics_factory: Arc<ExtrinsicsFactory>,
 	indirect_calls_executor: Arc<IndirectCallsExecutor>,
-	_phantom: PhantomData<(ParentchainBlock, OCallApi)>,
+	_phantom: PhantomData<ParentchainBlock>,
 }
 
 impl<
 		ParentchainBlock,
 		ValidatorAccessor,
-		OCallApi,
 		StfExecutor,
 		ExtrinsicsFactory,
 		IndirectCallsExecutor,
@@ -75,15 +71,13 @@ impl<
 	ParentchainBlockImporter<
 		ParentchainBlock,
 		ValidatorAccessor,
-		OCallApi,
 		StfExecutor,
 		ExtrinsicsFactory,
 		IndirectCallsExecutor,
 	> where
 	ParentchainBlock: ParentchainBlockTrait<Hash = H256, Header = ParentchainHeader>,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
-	ValidatorAccessor: ValidatorAccess<ParentchainBlock, OCallApi>,
-	OCallApi: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
+	ValidatorAccessor: ValidatorAccess<ParentchainBlock>,
 	StfExecutor: StfUpdateState,
 	ExtrinsicsFactory: CreateExtrinsics,
 	IndirectCallsExecutor: ExecuteIndirectCalls,
@@ -107,7 +101,6 @@ impl<
 impl<
 		ParentchainBlock,
 		ValidatorAccessor,
-		OCallApi,
 		StfExecutor,
 		ExtrinsicsFactory,
 		IndirectCallsExecutor,
@@ -115,15 +108,13 @@ impl<
 	for ParentchainBlockImporter<
 		ParentchainBlock,
 		ValidatorAccessor,
-		OCallApi,
 		StfExecutor,
 		ExtrinsicsFactory,
 		IndirectCallsExecutor,
 	> where
 	ParentchainBlock: ParentchainBlockTrait<Hash = H256, Header = ParentchainHeader>,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
-	ValidatorAccessor: ValidatorAccess<ParentchainBlock, OCallApi>,
-	OCallApi: EnclaveOnChainOCallApi + EnclaveAttestationOCallApi,
+	ValidatorAccessor: ValidatorAccess<ParentchainBlock>,
 	StfExecutor: StfUpdateState,
 	ExtrinsicsFactory: CreateExtrinsics,
 	IndirectCallsExecutor: ExecuteIndirectCalls,

--- a/core/parentchain/light-client/src/concurrent_access.rs
+++ b/core/parentchain/light-client/src/concurrent_access.rs
@@ -30,7 +30,6 @@ use crate::{
 	Validator as ValidatorTrait,
 };
 use finality_grandpa::BlockNumberOps;
-use itp_ocall_api::EnclaveOnChainOCallApi;
 use itp_sgx_io::StaticSealedIO;
 use sp_runtime::traits::{Block as ParentchainBlockTrait, NumberFor};
 use std::marker::PhantomData;
@@ -41,11 +40,10 @@ use std::marker::PhantomData;
 /// either a mutating, or a non-mutating function on the validator.
 /// The reason we have this additional wrapper around `SealedIO`, is that we need
 /// to guard against concurrent access by using RWLocks (which `SealedIO` does not do).
-pub trait ValidatorAccess<ParentchainBlock, OCallApi>
+pub trait ValidatorAccess<ParentchainBlock>
 where
 	ParentchainBlock: ParentchainBlockTrait,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
-	OCallApi: EnclaveOnChainOCallApi,
 {
 	type ValidatorType: ValidatorTrait<ParentchainBlock>
 		+ LightClientState<ParentchainBlock>
@@ -64,7 +62,7 @@ where
 
 /// Implementation of a validator access based on a global lock and corresponding file.
 #[derive(Debug)]
-pub struct ValidatorAccessor<Validator, ParentchainBlock, Seal, OCallApi>
+pub struct ValidatorAccessor<Validator, ParentchainBlock, Seal>
 where
 	Validator: ValidatorTrait<ParentchainBlock>
 		+ LightClientState<ParentchainBlock>
@@ -72,14 +70,12 @@ where
 	Seal: StaticSealedIO<Error = Error, Unsealed = LightValidationState<ParentchainBlock>>,
 	ParentchainBlock: ParentchainBlockTrait,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
-	OCallApi: EnclaveOnChainOCallApi,
 {
 	light_validation: RwLock<Validator>,
-	_phantom: PhantomData<(Seal, Validator, ParentchainBlock, OCallApi)>,
+	_phantom: PhantomData<(Seal, Validator, ParentchainBlock)>,
 }
 
-impl<Validator, ParentchainBlock, Seal, OCallApi>
-	ValidatorAccessor<Validator, ParentchainBlock, Seal, OCallApi>
+impl<Validator, ParentchainBlock, Seal> ValidatorAccessor<Validator, ParentchainBlock, Seal>
 where
 	Validator: ValidatorTrait<ParentchainBlock>
 		+ LightClientState<ParentchainBlock>
@@ -87,15 +83,14 @@ where
 	Seal: StaticSealedIO<Error = Error, Unsealed = LightValidationState<ParentchainBlock>>,
 	ParentchainBlock: ParentchainBlockTrait,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
-	OCallApi: EnclaveOnChainOCallApi,
 {
 	pub fn new(validator: Validator) -> Self {
 		ValidatorAccessor { light_validation: RwLock::new(validator), _phantom: Default::default() }
 	}
 }
 
-impl<Validator, ParentchainBlock, Seal, OCallApi> ValidatorAccess<ParentchainBlock, OCallApi>
-	for ValidatorAccessor<Validator, ParentchainBlock, Seal, OCallApi>
+impl<Validator, ParentchainBlock, Seal> ValidatorAccess<ParentchainBlock>
+	for ValidatorAccessor<Validator, ParentchainBlock, Seal>
 where
 	Validator: ValidatorTrait<ParentchainBlock>
 		+ LightClientState<ParentchainBlock>
@@ -103,7 +98,6 @@ where
 	Seal: StaticSealedIO<Error = Error, Unsealed = LightValidationState<ParentchainBlock>>,
 	ParentchainBlock: ParentchainBlockTrait,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
-	OCallApi: EnclaveOnChainOCallApi,
 {
 	type ValidatorType = Validator;
 
@@ -138,11 +132,9 @@ mod tests {
 	use crate::mocks::{
 		validator_mock::ValidatorMock, validator_mock_seal::LightValidationStateSealMock,
 	};
-	use itp_test::mock::onchain_mock::OnchainMock;
 	use itp_types::Block;
 
-	type TestAccessor =
-		ValidatorAccessor<ValidatorMock, Block, LightValidationStateSealMock, OnchainMock>;
+	type TestAccessor = ValidatorAccessor<ValidatorMock, Block, LightValidationStateSealMock>;
 
 	#[test]
 	fn execute_with_and_without_mut_in_single_thread_works() {

--- a/core/parentchain/light-client/src/mocks/validator_access_mock.rs
+++ b/core/parentchain/light-client/src/mocks/validator_access_mock.rs
@@ -26,7 +26,6 @@ use crate::{
 	error::{Error, Result},
 	mocks::validator_mock::ValidatorMock,
 };
-use itp_ocall_api::EnclaveOnChainOCallApi;
 use itp_types::Block;
 
 /// Mock for the validator access.
@@ -37,7 +36,7 @@ pub struct ValidatorAccessMock {
 	validator: RwLock<ValidatorMock>,
 }
 
-impl<OCallApi: EnclaveOnChainOCallApi> ValidatorAccess<Block, OCallApi> for ValidatorAccessMock {
+impl ValidatorAccess<Block> for ValidatorAccessMock {
 	type ValidatorType = ValidatorMock;
 
 	fn execute_on_validator<F, R>(&self, getter_function: F) -> Result<R>

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1270,7 +1270,6 @@ dependencies = [
  "itc-parentchain-indirect-calls-executor",
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
- "itp-ocall-api",
  "itp-settings",
  "itp-stf-executor",
  "itp-types",

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -89,12 +89,10 @@ pub type EnclaveValidatorAccessor = ValidatorAccessor<
 	LightValidation<ParentchainBlock, EnclaveOCallApi>,
 	ParentchainBlock,
 	LightClientStateSeal<ParentchainBlock, LightValidationState<ParentchainBlock>>,
-	EnclaveOCallApi,
 >;
 pub type EnclaveParentChainBlockImporter = ParentchainBlockImporter<
 	ParentchainBlock,
 	EnclaveValidatorAccessor,
-	EnclaveOCallApi,
 	EnclaveStfExecutor,
 	EnclaveExtrinsicsFactory,
 	EnclaveIndirectCallsExecutor,

--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -288,8 +288,8 @@ pub(crate) fn send_blocks_and_extrinsics<
 where
 	ParentchainBlock: BlockTrait,
 	SignedSidechainBlock: SignedBlock + 'static,
-	OCallApi: EnclaveSidechainOCallApi + EnclaveOnChainOCallApi,
-	ValidatorAccessor: ValidatorAccess<ParentchainBlock, OCallApi> + Send + Sync + 'static,
+	OCallApi: EnclaveSidechainOCallApi,
+	ValidatorAccessor: ValidatorAccess<ParentchainBlock> + Send + Sync + 'static,
 	NumberFor<ParentchainBlock>: BlockNumberOps,
 	ExtrinsicsFactory: CreateExtrinsics,
 {


### PR DESCRIPTION
We've done some refactorings in the past, that rendered the `OCallApi` type parameter on the `ValidatorAccess` trait obsolete. This PR removes it now.

(this is a small cleanup discovered while doing a proof-of-concept for #836 )