### PR TITLE
Fix message logging within the enclave

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,8 +2282,8 @@ dependencies = [
  "itp-rpc",
  "itp-types",
  "itp-utils",
- "jsonrpc-core 16.1.0",
- "jsonrpc-core 18.0.0",
+ "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "log 0.4.17",
  "parity-scale-codec",
  "serde_json 1.0.81",
@@ -2780,8 +2780,8 @@ dependencies = [
  "itp-teerex-storage",
  "itp-time-utils",
  "itp-types",
- "jsonrpc-core 16.1.0",
- "jsonrpc-core 18.0.0",
+ "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "parity-scale-codec",
  "sgx-externalities",
  "sgx_crypto_helper",
@@ -2808,8 +2808,8 @@ dependencies = [
  "ita-stf",
  "itc-direct-rpc-server",
  "itp-types",
- "jsonrpc-core 16.1.0",
- "jsonrpc-core 18.0.0",
+ "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "linked-hash-map 0.5.2",
  "linked-hash-map 0.5.4",
  "log 0.4.17",
@@ -2843,8 +2843,8 @@ dependencies = [
  "itp-top-pool",
  "itp-types",
  "itp-utils",
- "jsonrpc-core 16.1.0",
- "jsonrpc-core 18.0.0",
+ "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "log 0.4.17",
  "parity-scale-codec",
  "sgx_crypto_helper",
@@ -3029,8 +3029,8 @@ dependencies = [
  "itp-top-pool-author",
  "itp-types",
  "itp-utils",
- "jsonrpc-core 16.1.0",
- "jsonrpc-core 18.0.0",
+ "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "log 0.4.17",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3173,19 +3173,6 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "jsonrpc-core"
-version = "16.1.0"
-source = "git+https://github.com/scs/jsonrpc?branch=no_std#694656d8153005de90c849fce2633586849846e4"
-dependencies = [
- "futures 0.3.8",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
- "serde_derive 1.0.118",
- "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=master)",
-]
-
-[[package]]
-name = "jsonrpc-core"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
@@ -3197,6 +3184,19 @@ dependencies = [
  "serde 1.0.137",
  "serde_derive 1.0.137",
  "serde_json 1.0.81",
+]
+
+[[package]]
+name = "jsonrpc-core"
+version = "18.0.0"
+source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#eb7cdf49c0e5d35174f972743a7e3ff460aadedc"
+dependencies = [
+ "futures 0.3.8",
+ "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde_derive 1.0.118",
+ "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=master)",
 ]
 
 [[package]]
@@ -6597,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#622f532e605270c9d4f932aea666073e409e02f9"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6c5ac3168d7ce4810648d667969c82b1db9950ac"
 
 [[package]]
 name = "sp-std"
@@ -7417,7 +7417,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7417,7 +7417,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.3",
  "rand 0.8.5",
  "static_assertions",

--- a/core-primitives/extrinsics-factory/Cargo.toml
+++ b/core-primitives/extrinsics-factory/Cargo.toml
@@ -5,24 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = [
-    "itp-nonce-cache/std",
-    "itp-types/std",
-    "log/std",
-    "substrate-api-client/std",
-    "thiserror",
-]
-sgx = [
-    "itp-nonce-cache/sgx",
-    "sgx_tstd",
-    "thiserror_sgx",
-]
-mocks = []
-
 [dependencies]
 # sgx dependencies
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
@@ -47,3 +29,19 @@ log = { version = "0.4", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+
+[features]
+default = ["std"]
+std = [
+    "itp-nonce-cache/std",
+    "itp-types/std",
+    "log/std",
+    "substrate-api-client/std",
+    "thiserror",
+]
+sgx = [
+    "itp-nonce-cache/sgx",
+    "sgx_tstd",
+    "thiserror_sgx",
+]
+mocks = []

--- a/core-primitives/nonce-cache/Cargo.toml
+++ b/core-primitives/nonce-cache/Cargo.toml
@@ -5,19 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = [
-    "log/std",
-    "thiserror",
-]
-sgx = [
-    "sgx_tstd",
-    "thiserror_sgx",
-]
-
 [dependencies]
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
@@ -33,3 +20,14 @@ thiserror = { version = "1.0", optional = true }
 # no-std dependencies
 log = { version = "0.4", default-features = false }
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
+
+[features]
+default = ["std"]
+std = [
+    "log/std",
+    "thiserror",
+]
+sgx = [
+    "sgx_tstd",
+    "thiserror_sgx",
+]

--- a/core-primitives/primitives-cache/Cargo.toml
+++ b/core-primitives/primitives-cache/Cargo.toml
@@ -5,18 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-
-[features]
-default = ["std"]
-std = [
-    "log/std",
-    "thiserror",
-]
-sgx = [
-    "sgx_tstd",
-    "thiserror_sgx",
-]
-
 [dependencies]
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
@@ -32,3 +20,15 @@ thiserror = { version = "1.0", optional = true }
 # no-std dependencies
 log = { version = "0.4", default-features = false }
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
+
+
+[features]
+default = ["std"]
+std = [
+    "log/std",
+    "thiserror",
+]
+sgx = [
+    "sgx_tstd",
+    "thiserror_sgx",
+]

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -10,7 +10,7 @@ aes = { version = "0.6.0" }
 ofb = { version = "0.4.0" }
 codec  = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 derive_more = { version = "0.99.5" }
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -5,35 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = [
-    "rust-base58",
-    "ita-stf/std",
-    "itp-sgx-crypto/std",
-    "itp-sgx-io/std",
-    "itp-time-utils/std",
-    "itp-types/std",
-    "sgx-externalities/std",
-    "thiserror",
-]
-sgx = [
-    "sgx_tstd",
-    "sgx_tcrypto",
-    "rust-base58_sgx",
-    "ita-stf/sgx",
-    "itp-sgx-crypto/sgx",
-    "itp-sgx-io/sgx",
-    "itp-time-utils/sgx",
-    "sgx-externalities/sgx",
-    "thiserror_sgx",
-]
-test = [
-    "itp-sgx-crypto/mocks"
-]
-
 [dependencies]
 # sgx dependencies
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
@@ -67,3 +38,32 @@ sp-core = { default-features = false, features = ["full_crypto"], git = "https:/
 
 [dev-dependencies]
 itp-sgx-crypto = { path = "../../core-primitives/sgx/crypto", features = ["mocks"] }
+
+
+[features]
+default = ["std"]
+std = [
+    "rust-base58",
+    "ita-stf/std",
+    "itp-sgx-crypto/std",
+    "itp-sgx-io/std",
+    "itp-time-utils/std",
+    "itp-types/std",
+    "sgx-externalities/std",
+    "thiserror",
+    "log/std",
+]
+sgx = [
+    "sgx_tstd",
+    "sgx_tcrypto",
+    "rust-base58_sgx",
+    "ita-stf/sgx",
+    "itp-sgx-crypto/sgx",
+    "itp-sgx-io/sgx",
+    "itp-time-utils/sgx",
+    "sgx-externalities/sgx",
+    "thiserror_sgx",
+]
+test = [
+    "itp-sgx-crypto/mocks"
+]

--- a/core-primitives/test/Cargo.toml
+++ b/core-primitives/test/Cargo.toml
@@ -12,7 +12,7 @@ sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teacla
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
-jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
+jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 
 # std-only deps
 jsonrpc-core = { version = "18", optional = true }

--- a/core-primitives/top-pool-author/Cargo.toml
+++ b/core-primitives/top-pool-author/Cargo.toml
@@ -26,7 +26,7 @@ itp-types = { default-features = false, git = "https://github.com/integritee-net
 itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
 
 # sgx enabled external libraries
-jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
+jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)

--- a/core-primitives/top-pool/Cargo.toml
+++ b/core-primitives/top-pool/Cargo.toml
@@ -48,7 +48,7 @@ itc-direct-rpc-server = { path = "../../core/direct-rpc-server", default-feature
 itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
 
 # sgx enabled external libraries
-jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
+jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 linked-hash-map_sgx = { package = "linked-hash-map", git = "https://github.com/mesalock-linux/linked-hash-map-sgx", optional = true }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 

--- a/core-primitives/top-pool/Cargo.toml
+++ b/core-primitives/top-pool/Cargo.toml
@@ -5,36 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-sgx = [
-    "sgx_tstd",
-    "sgx_types",
-    "ita-stf/sgx",
-    "itc-direct-rpc-server/sgx",
-    "itp-types/sgx",
-    "jsonrpc-core_sgx",
-    "linked-hash-map_sgx",
-    "thiserror_sgx",
-]
-std = [
-    "ita-stf/std",
-    "itc-direct-rpc-server/std",
-    "itp-types/std",
-    "sidechain-primitives/std",
-    "jsonrpc-core",
-    "linked-hash-map",
-    "log/std",
-    "serde/std",
-    "sp-core/std",
-    "sp-runtime/std",
-    "sp-application-crypto/std",
-    "thiserror",
-]
-mocks = []
-
 [dependencies]
 # sgx dependencies
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
@@ -71,3 +41,31 @@ sidechain-primitives = { default-features = false, git = "https://github.com/int
 # dev dependencies (for tests)
 [dev-dependencies]
 parity-util-mem = { version = "0.11.0", default-features = false, features = ["primitive-types"] }
+
+[features]
+default = ["std"]
+sgx = [
+    "sgx_tstd",
+    "sgx_types",
+    "ita-stf/sgx",
+    "itc-direct-rpc-server/sgx",
+    "itp-types/sgx",
+    "jsonrpc-core_sgx",
+    "linked-hash-map_sgx",
+    "thiserror_sgx",
+]
+std = [
+    "ita-stf/std",
+    "itc-direct-rpc-server/std",
+    "itp-types/std",
+    "sidechain-primitives/std",
+    "jsonrpc-core",
+    "linked-hash-map",
+    "log/std",
+    "serde/std",
+    "sp-core/std",
+    "sp-runtime/std",
+    "sp-application-crypto/std",
+    "thiserror",
+]
+mocks = []

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -25,7 +25,7 @@ itc-tls-websocket-server = { path = "../tls-websocket-server", default-features 
 itp-rpc = { path = "../../core-primitives/rpc", default-features = false }
 
 # sgx enabled external libraries
-jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
+jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -35,6 +35,10 @@ thiserror = { version = "1.0", optional = true }
 [features]
 default = ["std"]
 std = [
+    "codec/std",
+    "log/std",
+    "serde_json/std",
+    "sp-runtime/std",
     "itc-tls-websocket-server/std",
     "itp-rpc/std",
     "itp-types/std",

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -35,14 +35,18 @@ thiserror = { version = "1.0", optional = true }
 [features]
 default = ["std"]
 std = [
+    # no-std dependencies
     "codec/std",
     "log/std",
     "serde_json/std",
     "sp-runtime/std",
-    "itc-tls-websocket-server/std",
-    "itp-rpc/std",
+    # integritee dependencies
     "itp-types/std",
     "itp-utils/std",
+    # local
+    "itc-tls-websocket-server/std",
+    "itp-rpc/std",
+    # optional ones
     "jsonrpc-core",
     "thiserror",
 ]

--- a/core/direct-rpc-server/src/lib.rs
+++ b/core/direct-rpc-server/src/lib.rs
@@ -20,6 +20,9 @@
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
 
+#[cfg(all(not(feature = "std"), not(feature = "sgx")))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be disabled at the same time");
+
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 

--- a/core/direct-rpc-server/src/lib.rs
+++ b/core/direct-rpc-server/src/lib.rs
@@ -20,9 +20,6 @@
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
 
-#[cfg(all(not(feature = "std"), not(feature = "sgx")))]
-compile_error!("feature \"std\" and feature \"sgx\" cannot be disabled at the same time");
-
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 

--- a/core/parentchain/light-client/Cargo.toml
+++ b/core/parentchain/light-client/Cargo.toml
@@ -4,6 +4,41 @@ version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
+derive_more = { version = "0.99.5" }
+finality-grandpa = { version = "0.15.0", default-features = false, features = ["derive-codec"] }
+hash-db = { version = "0.15.2", default-features = false }
+lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
+log = { version = "0.4", default-features = false }
+num = { package = "num-traits", version = "0.2", default-features = false }
+thiserror = { version = "1.0.26", optional = true }
+
+# sgx-deps
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs"], optional = true}
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
+
+# local deps
+itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features = false }
+itp-sgx-io = { path = "../../../core-primitives/sgx/io", default-features = false }
+itp-settings = { path = "../../../core-primitives/settings" }
+itp-storage = { path = "../../../core-primitives/storage", default-features = false }
+
+# integritee
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
+
+# substrate deps
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+sp-application-crypto = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+sp-finality-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+sp-trie = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+
+[dev-dependencies]
+itp-test = { path = "../../../core-primitives/test" }
+
 [features]
 default = ["std"]
 std = [
@@ -36,38 +71,3 @@ sgx = [
     "itp-types/sgx",
 ]
 mocks = []
-
-[dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
-derive_more = { version = "0.99.5" }
-finality-grandpa = { version = "0.15.0", default-features = false, features = ["derive-codec"] }
-hash-db = { version = "0.15.2", default-features = false }
-lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
-log = { version = "0.4.17", default-features = false }
-num = { package = "num-traits", version = "0.2", default-features = false }
-thiserror = { version = "1.0.26", optional = true }
-
-# sgx-deps
-sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_fs"], optional = true}
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-thiserror-sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
-
-# local deps
-itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features = false }
-itp-sgx-io = { path = "../../../core-primitives/sgx/io", default-features = false }
-itp-settings = { path = "../../../core-primitives/settings" }
-itp-storage = { path = "../../../core-primitives/storage", default-features = false }
-
-# integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
-
-# substrate deps
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
-sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
-sp-application-crypto = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
-sp-finality-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
-sp-trie = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
-
-[dev-dependencies]
-itp-test = { path = "../../../core-primitives/test" }

--- a/core/rest-client/Cargo.toml
+++ b/core/rest-client/Cargo.toml
@@ -4,27 +4,7 @@ version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = [
-    "http",
-    "http_req",
-    "thiserror",
-    "url",
-]
-sgx = [
-    "http-sgx",
-    "http_req-sgx",
-    "sgx_types",
-    "sgx_tstd",
-    "thiserror_sgx",
-    "url_sgx",
-]
-
 [dependencies]
-
 # std dependencies
 http_req = { version = "0.7", optional = true, default-features = false, features = ["rust-tls"] }
 http = { version = "0.2", optional = true }
@@ -44,3 +24,26 @@ base64 = { version = "0.13", default-features = false, features = ["alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 log = { version = "0.4", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    # std only
+    "http",
+    "http_req",
+    "thiserror",
+    "url",
+    # no_std
+    "base64/std",
+    "serde/std",
+    "serde_json/std",
+    "log/std",
+]
+sgx = [
+    "http-sgx",
+    "http_req-sgx",
+    "sgx_types",
+    "sgx_tstd",
+    "thiserror_sgx",
+    "url_sgx",
+]

--- a/core/rpc-server/Cargo.toml
+++ b/core/rpc-server/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [dependencies]
 anyhow = "1.0.40"
-log = "0.4.17"
+log = "0.4"
 jsonrpsee = { version = "0.2.0-alpha.7", features = ["full"] }
 serde_json = "1.0.64"
 tokio = { version = "1.6.1", features = ["full"] }

--- a/core/tls-websocket-server/Cargo.toml
+++ b/core/tls-websocket-server/Cargo.toml
@@ -5,38 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 resolver = "2"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-sgx = [
-    "itp-sgx-crypto/sgx",
-    "itp-sgx-io/sgx",
-    "mio-extras/sgx",
-    "mio_sgx",
-    "rcgen/sgx",
-    "rustls_sgx",
-    "sgx_tstd",
-    "sgx_types",
-    "thiserror_sgx",
-    "tungstenite_sgx",
-    "webpki_sgx",
-    "yasna_sgx",
-]
-std = [
-    "itp-sgx-crypto/std",
-    "itp-sgx-io/std",
-    "mio",
-    "mio-extras/std",
-    "rcgen/std",
-    "rustls",
-    "thiserror",
-    "tungstenite",
-    "webpki",
-    "yasna",
-]
-mocks = []
-
 [dependencies]
 bit-vec = { version = "0.6", default-features = false }
 rcgen = { package = "rcgen", git = 'https://github.com/integritee-network/rcgen', default-features = false, features = ["pem"] }
@@ -78,3 +46,35 @@ log = { version = "0.4", default-features = false }
 env_logger = "0.9.0"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }
 url = { version = "2.0.0" }
+
+
+[features]
+default = ["std"]
+sgx = [
+    "itp-sgx-crypto/sgx",
+    "itp-sgx-io/sgx",
+    "mio-extras/sgx",
+    "mio_sgx",
+    "rcgen/sgx",
+    "rustls_sgx",
+    "sgx_tstd",
+    "sgx_types",
+    "thiserror_sgx",
+    "tungstenite_sgx",
+    "webpki_sgx",
+    "yasna_sgx",
+]
+std = [
+    "itp-sgx-crypto/std",
+    "itp-sgx-io/std",
+    "mio",
+    "mio-extras/std",
+    "rcgen/std",
+    "rustls",
+    "thiserror",
+    "tungstenite",
+    "webpki",
+    "yasna",
+    "log/std",
+]
+mocks = []

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.1.0"
 source = "git+https://github.com/scs/substrate-api-client?branch=polkadot-v0.9.24#081d98ec22bad60abf9373fabf5d2ee8270c1d5d"
 dependencies = [
  "ac-primitives",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.24)",
@@ -629,7 +629,7 @@ dependencies = [
  "jsonrpc-core",
  "lazy_static",
  "linked-hash-map",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log",
  "multibase",
  "num-bigint",
  "parity-scale-codec",
@@ -669,10 +669,11 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
-source = "git+https://github.com/mesalock-linux/env_logger-sgx#839ef5144497dd61e7a5dc99ace41c561b576f20"
+version = "0.9.0"
+source = "git+https://github.com/integritee-network/env_logger-sgx#521e7496876971f0851629d89a92fbec8d3468e5"
 dependencies = [
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "humantime",
+ "log",
  "sgx_tstd",
 ]
 
@@ -765,7 +766,7 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "paste",
  "scale-info",
@@ -822,7 +823,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
  "frame-support",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -1128,6 +1129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "1.3.0"
+source = "git+https://github.com/mesalock-linux/humantime-sgx#c5243dfa36002c01adbc9aade288ead1b2c411cc"
+dependencies = [
+ "quick-error",
+ "sgx_tstd",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.0"
 source = "git+https://github.com/mesalock-linux/rust-url-sgx?tag=sgx_1.1.3#23832f3191456c2d4a0faab10952e1747be58ca8"
@@ -1208,7 +1218,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "its-state",
- "log 0.4.17",
+ "log",
  "pallet-balances",
  "parity-scale-codec",
  "sgx-externalities",
@@ -1230,7 +1240,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "jsonrpc-core",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "serde_json 1.0.81",
  "sgx_tstd",
@@ -1255,7 +1265,7 @@ version = "0.8.0"
 dependencies = [
  "itc-parentchain-block-importer",
  "itp-block-import-queue",
- "log 0.4.17",
+ "log",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -1273,7 +1283,7 @@ dependencies = [
  "itp-settings",
  "itp-stf-executor",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -1296,7 +1306,7 @@ dependencies = [
  "itp-stf-executor",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -1320,7 +1330,7 @@ dependencies = [
  "itp-storage",
  "itp-types",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "num-traits 0.2.15",
  "parity-scale-codec",
  "sgx_tstd",
@@ -1341,7 +1351,7 @@ dependencies = [
  "chrono 0.4.19",
  "itp-sgx-crypto",
  "itp-sgx-io",
- "log 0.4.17",
+ "log",
  "mio",
  "mio-extras",
  "rcgen",
@@ -1382,7 +1392,7 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 name = "itp-block-import-queue"
 version = "0.8.0"
 dependencies = [
- "log 0.4.17",
+ "log",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -1413,7 +1423,7 @@ dependencies = [
  "itp-nonce-cache",
  "itp-settings",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -1428,7 +1438,7 @@ name = "itp-nonce-cache"
 version = "0.8.0"
 dependencies = [
  "lazy_static",
- "log 0.4.17",
+ "log",
  "sgx_tstd",
  "thiserror 1.0.9",
 ]
@@ -1452,7 +1462,7 @@ name = "itp-primitives-cache"
 version = "0.8.0"
 dependencies = [
  "lazy_static",
- "log 0.4.17",
+ "log",
  "sgx_tstd",
  "thiserror 1.0.9",
 ]
@@ -1480,7 +1490,7 @@ dependencies = [
  "derive_more",
  "itp-settings",
  "itp-sgx-io",
- "log 0.4.17",
+ "log",
  "ofb",
  "parity-scale-codec",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
@@ -1511,7 +1521,7 @@ dependencies = [
  "itp-test",
  "itp-time-utils",
  "itp-types",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx-externalities",
  "sgx_crypto_helper",
@@ -1533,7 +1543,7 @@ dependencies = [
  "itp-time-utils",
  "itp-types",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rust-base58",
  "sgx-externalities",
@@ -1612,7 +1622,7 @@ dependencies = [
  "itp-types",
  "jsonrpc-core",
  "linked-hash-map",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "serde 1.0.137",
  "sgx_tstd",
@@ -1641,7 +1651,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "jsonrpc-core",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -1693,7 +1703,7 @@ dependencies = [
  "itp-top-pool-author",
  "itp-types",
  "its-state",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx-externalities",
  "sgx_tstd",
@@ -1727,7 +1737,7 @@ dependencies = [
  "its-state",
  "its-top-pool-executor",
  "its-validateer-fetch",
- "log 0.4.17",
+ "log",
  "sgx-externalities",
  "sgx_tstd",
  "sidechain-primitives",
@@ -1744,7 +1754,7 @@ dependencies = [
  "itp-sgx-crypto",
  "itp-types",
  "its-state",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -1764,7 +1774,7 @@ dependencies = [
  "itp-types",
  "its-consensus-common",
  "lazy_static",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sidechain-primitives",
@@ -1781,7 +1791,7 @@ dependencies = [
  "itp-types",
  "itp-utils",
  "jsonrpc-core",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "rust-base58",
  "sgx_tstd",
@@ -1811,7 +1821,7 @@ version = "0.8.0"
 dependencies = [
  "frame-support",
  "itp-storage",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "serde 1.0.137",
  "sgx-externalities",
@@ -1833,7 +1843,7 @@ dependencies = [
  "itp-top-pool-author",
  "itp-types",
  "its-state",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx-externalities",
  "sgx_tstd",
@@ -1867,7 +1877,7 @@ version = "18.0.0"
 source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#eb7cdf49c0e5d35174f972743a7e3ff460aadedc"
 dependencies = [
  "futures 0.3.8",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
  "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
@@ -1968,29 +1978,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
-source = "git+https://github.com/mesalock-linux/log-sgx?tag=sgx_1.1.3#2ca9039a9ebba0ed90ed2ad57425917d4b3a2a24"
-dependencies = [
- "cfg-if 1.0.0",
- "sgx_tstd",
-]
-
-[[package]]
-name = "log"
-version = "0.4.14"
-source = "git+https://github.com/mesalock-linux/log-sgx#2ca9039a9ebba0ed90ed2ad57425917d4b3a2a24"
-dependencies = [
- "cfg-if 1.0.0",
- "sgx_tstd",
-]
-
-[[package]]
-name = "log"
 version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+source = "git+https://github.com/integritee-network/log-sgx#483383a9be3e2e900042eef9b6b2d0837411783f"
 dependencies = [
  "cfg-if 1.0.0",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -2043,7 +2035,7 @@ version = "0.6.21"
 source = "git+https://github.com/mesalock-linux/mio-sgx?tag=sgx_1.1.3#5b0e56a3066231c7a8d1876c7be3a19b08ffdfd5"
 dependencies = [
  "iovec",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log",
  "net2",
  "sgx_libc",
  "sgx_trts",
@@ -2057,7 +2049,7 @@ version = "2.0.6"
 source = "git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b#963234bf55e44f9efff921938255126c48deef3a"
 dependencies = [
  "lazycell",
- "log 0.4.17",
+ "log",
  "mio",
  "sgx_tstd",
  "sgx_types",
@@ -2271,7 +2263,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -2285,7 +2277,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -2307,7 +2299,7 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=master#aa
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -2338,7 +2330,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -2371,7 +2363,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -2570,6 +2562,11 @@ checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "git+https://github.com/mesalock-linux/quick-error-sgx#468bf2cce746f34dd3df8c1c5b4a5a6494914d36"
 
 [[package]]
 name = "quick-protobuf"
@@ -2810,7 +2807,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?tag=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log",
  "ring",
  "sct",
  "sgx_tstd",
@@ -2823,7 +2820,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log",
  "ring",
  "sct",
  "sgx_tstd",
@@ -2836,7 +2833,7 @@ version = "0.19.0"
 source = "git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3#95b5e79dc24b02f3ce424437eb9698509d0baf58"
 dependencies = [
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx)",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
+ "log",
  "ring",
  "sct",
  "sgx_tstd",
@@ -3064,7 +3061,7 @@ source = "git+https://github.com/integritee-network/sgx-runtime?branch=master#89
 dependencies = [
  "derive_more",
  "environmental",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "postcard",
  "serde 1.0.137",
@@ -3414,7 +3411,7 @@ name = "sp-api"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.24#814752f60ab8cce7e2ece3ce0c1b10799b4eab28"
 dependencies = [
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sp-api-proc-macro",
  "sp-core",
@@ -3526,7 +3523,7 @@ dependencies = [
  "hash256-std-hasher",
  "hex",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "merlin",
  "num-traits 0.2.15",
  "parity-scale-codec",
@@ -3614,7 +3611,7 @@ dependencies = [
  "environmental",
  "hash-db",
  "libsecp256k1",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "sgx-externalities",
  "sgx_tstd",
@@ -3646,7 +3643,7 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log",
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
@@ -3992,7 +3989,7 @@ checksum = "d32d034c0d3db64b43c31de38e945f15b40cd4ca6d2dcfc26d4798ce8de4ab83"
 dependencies = [
  "hash-db",
  "hashbrown 0.12.1",
- "log 0.4.17",
+ "log",
  "smallvec 1.8.0",
 ]
 
@@ -4021,7 +4018,7 @@ dependencies = [
  "bytes",
  "http",
  "httparse",
- "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx?tag=sgx_1.1.3)",
+ "log",
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?tag=sgx_1.1.3)",
  "sgx_tstd",
@@ -4039,7 +4036,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.3",
  "static_assertions",
 ]

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1863,8 +1863,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "16.1.0"
-source = "git+https://github.com/scs/jsonrpc?branch=no_std#694656d8153005de90c849fce2633586849846e4"
+version = "18.0.0"
+source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#eb7cdf49c0e5d35174f972743a7e3ff460aadedc"
 dependencies = [
  "futures 0.3.8",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#622f532e605270c9d4f932aea666073e409e02f9"
+source = "git+https://github.com/paritytech/substrate.git?branch=master#6c5ac3168d7ce4810648d667969c82b1db9950ac"
 
 [[package]]
 name = "sp-std"
@@ -4039,7 +4039,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.3",
  "static_assertions",
 ]

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -80,6 +80,15 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
+version = "0.7.10"
+source = "git+https://github.com/mesalock-linux/aho-corasick-sgx#7558a97cdf02804f38ec4edd1c0bb0dc2866267f"
+dependencies = [
+ "memchr 2.2.1",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
@@ -670,11 +679,13 @@ dependencies = [
 [[package]]
 name = "env_logger"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/env_logger-sgx#521e7496876971f0851629d89a92fbec8d3468e5"
+source = "git+https://github.com/integritee-network/env_logger-sgx#55745829b2ae8a77f0915af3671ec8a9a00cace9"
 dependencies = [
  "humantime",
  "log",
+ "regex 1.3.1",
  "sgx_tstd",
+ "termcolor",
 ]
 
 [[package]]
@@ -2717,8 +2728,11 @@ name = "regex"
 version = "1.3.1"
 source = "git+https://github.com/mesalock-linux/regex-sgx#76aef86f9836532d17764523d0fa23bb7d2e31cf"
 dependencies = [
+ "aho-corasick 0.7.10",
+ "memchr 2.2.1",
  "regex-syntax 0.6.12",
  "sgx_tstd",
+ "thread_local",
 ]
 
 [[package]]
@@ -2727,7 +2741,7 @@ version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.18",
  "memchr 2.5.0",
  "regex-syntax 0.6.26",
 ]
@@ -3908,6 +3922,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "termcolor"
+version = "1.0.5"
+source = "git+https://github.com/mesalock-linux/termcolor-sgx#fee5ac79b4a90197d646f3df5e1b45ac56be718b"
+dependencies = [
+ "sgx_tstd",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.9"
 source = "git+https://github.com/mesalock-linux/thiserror-sgx?tag=sgx_1.1.3#c2f806b88616e06aab0af770366a76885d974fdc"
@@ -3944,6 +3966,15 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.20",
  "syn 1.0.98",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.0"
+source = "git+https://github.com/mesalock-linux/thread_local-rs-sgx#a8e6e6ce280c53358f7b9e6febe534cba9950547"
+dependencies = [
+ "lazy_static",
+ "sgx_tstd",
 ]
 
 [[package]]

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -54,7 +54,7 @@ ipfs-unixfs = { default-features = false, git = "https://github.com/whalelephant
 # scs / integritee
 itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master", features = ["sgx"] }
 itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master", features = ["sgx"] }
-jsonrpc-core = { default-features = false, git = "https://github.com/scs/jsonrpc", branch = "no_std" }
+jsonrpc-core = { default-features = false, git = "https://github.com/scs/jsonrpc", branch = "no_std_v18" }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", features = ["sgx"] }
 sgx-runtime = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master"}
 sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -66,7 +66,7 @@ linked-hash-map = { git = "https://github.com/mesalock-linux/linked-hash-map-sgx
 webpki = { git = "https://github.com/mesalock-linux/webpki", branch = "mesalock_sgx" }
 webpki-roots = { git = "https://github.com/mesalock-linux/webpki-roots", branch = "mesalock_sgx" }
 log = { git = "https://github.com/integritee-network/log-sgx" }
-env_logger = { git = "https://github.com/integritee-network/env_logger-sgx", default-features = false, features = ["mesalock_sgx", "humantime"] }
+env_logger = { git = "https://github.com/integritee-network/env_logger-sgx" }
 serde = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx" }
 serde_json = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx" }
 yasna = { rev = "sgx_1.1.3", default-features = false, features = ["bit-vec", "num-bigint", "chrono", "mesalock_sgx"], git = "https://github.com/mesalock-linux/yasna.rs-sgx" }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -65,8 +65,8 @@ substrate-api-client = { default-features = false, git = "https://github.com/scs
 linked-hash-map = { git = "https://github.com/mesalock-linux/linked-hash-map-sgx" }
 webpki = { git = "https://github.com/mesalock-linux/webpki", branch = "mesalock_sgx" }
 webpki-roots = { git = "https://github.com/mesalock-linux/webpki-roots", branch = "mesalock_sgx" }
-log = { git = "https://github.com/mesalock-linux/log-sgx" }
-env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx", default-features = false, features = ["mesalock_sgx"] }
+log = { git = "https://github.com/integritee-network/log-sgx" }
+env_logger = { git = "https://github.com/integritee-network/env_logger-sgx", default-features = false, features = ["mesalock_sgx", "humantime"] }
 serde = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx" }
 serde_json = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx" }
 yasna = { rev = "sgx_1.1.3", default-features = false, features = ["bit-vec", "num-bigint", "chrono", "mesalock_sgx"], git = "https://github.com/mesalock-linux/yasna.rs-sgx" }
@@ -120,8 +120,15 @@ sp-version = { default-features = false, git = "https://github.com/paritytech/su
 sp-application-crypto = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
 
 [patch.crates-io]
-env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx" }
+env_logger = { git = "https://github.com/integritee-network/env_logger-sgx" }
 getrandom = { git = "https://github.com/integritee-network/getrandom-sgx", branch = "update-v2.3"}
+log = { git = "https://github.com/integritee-network/log-sgx" }
+
+[patch."https://github.com/mesalock-linux/env_logger-sgx"]
+env_logger = { git = "https://github.com/integritee-network/env_logger-sgx" }
+
+[patch."https://github.com/mesalock-linux/log-sgx"]
+log = { git = "https://github.com/integritee-network/log-sgx"}
 
 [patch."https://github.com/paritytech/substrate"]
 sp-io = { git = "https://github.com/integritee-network/sgx-runtime", branch = "master"}

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -124,9 +124,6 @@ env_logger = { git = "https://github.com/integritee-network/env_logger-sgx" }
 getrandom = { git = "https://github.com/integritee-network/getrandom-sgx", branch = "update-v2.3"}
 log = { git = "https://github.com/integritee-network/log-sgx" }
 
-[patch."https://github.com/mesalock-linux/env_logger-sgx"]
-env_logger = { git = "https://github.com/integritee-network/env_logger-sgx" }
-
 [patch."https://github.com/mesalock-linux/log-sgx"]
 log = { git = "https://github.com/integritee-network/log-sgx"}
 

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -124,7 +124,6 @@ env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx" }
 getrandom = { git = "https://github.com/integritee-network/getrandom-sgx", branch = "update-v2.3"}
 
 [patch."https://github.com/paritytech/substrate"]
-env_logger = { git = "https://github.com/mesalock-linux/env_logger-sgx" }
 sp-io = { git = "https://github.com/integritee-network/sgx-runtime", branch = "master"}
 #sp-io = { path = "../../sgx-runtime/substrate-sgx/sp-io"}
 

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 finality-grandpa = { version = "0.15.0", default-features = false, features = ["derive-codec"] }
 itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
 itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 sgx-externalities = { default-features = false, git = "https://github.com/integritee-network/sgx-runtime", branch = "master", optional = true }
 sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "master" }
 

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -4,34 +4,9 @@ version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 
-[features]
-default = ["std"]
-std = [
-    "codec/std",
-    "log/std",
-    "thiserror",
-    # local
-    "itp-block-import-queue/std",
-    "itp-ocall-api/std",
-    "itp-sgx-crypto/std",
-    "itp-types/std",
-    "sidechain-primitives/std",
-    "its-state/std",
-    # substrate
-    "sp-runtime/std",
-]
-sgx = [
-    "sgx_tstd",
-    "thiserror-sgx",
-    # local
-    "itp-block-import-queue/sgx",
-    "itp-sgx-crypto/sgx",
-    "its-state/sgx",
-]
-
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
 
 # local deps
@@ -62,3 +37,28 @@ sp-core = { default-features = false, features = ["full_crypto"], git = "https:/
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
 # integritee / scs
 sgx-externalities = { git = "https://github.com/integritee-network/sgx-runtime", branch = "master" }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "log/std",
+    "thiserror",
+    # local
+    "itp-block-import-queue/std",
+    "itp-ocall-api/std",
+    "itp-sgx-crypto/std",
+    "itp-types/std",
+    "sidechain-primitives/std",
+    "its-state/std",
+    # substrate
+    "sp-runtime/std",
+]
+sgx = [
+    "sgx_tstd",
+    "thiserror-sgx",
+    # local
+    "itp-block-import-queue/sgx",
+    "itp-sgx-crypto/sgx",
+    "its-state/sgx",
+]

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-log = { version = "0.4.17", default-features = false }
+log = { version = "0.4", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 derive_more = "0.99.16"
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }

--- a/sidechain/peer-fetch/Cargo.toml
+++ b/sidechain/peer-fetch/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 # crates.io
 async-trait = { version = "0.1.50" }
 jsonrpsee = { version = "0.2.0", features = ["client", "ws-server", "macros"] }
-log = { version = "0.4.17" }
+log = { version = "0.4" }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = { version = "1.0" }

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -16,7 +16,7 @@ itp-rpc = { path = "../../core-primitives/rpc", default-features = false }
 
 # sgx enabled external libraries
 rust-base58_sgx = { package = "rust-base58", rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/rust-base58-sgx", optional = true, default-features = false, features = ["mesalock_sgx"] }
-jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std", default-features = false, optional = true }
+jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
 rust-base58 = { package = "rust-base58", version = "0.0.4", optional = true }

--- a/sidechain/state/Cargo.toml
+++ b/sidechain/state/Cargo.toml
@@ -4,45 +4,6 @@ version = "0.8.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[features]
-default = ["std"]
-std = [
-    "log/std",
-    "serde/std",
-
-    # substrate
-    "sp-std/std",
-    "sp-core/std",
-
-    # local crates
-    "itp-storage/std",
-
-    # scs crates
-    "sidechain-primitives/std",
-    "sp-io/std",
-    "sgx-externalities/std",
-
-    # optional std crates
-    "codec/std",
-    "thiserror",
-]
-sgx = [
-    # teaclave
-    "sgx_tstd",
-
-    # local crates
-    "itp-storage/sgx",
-
-    # scs crates
-    "sp-io/sgx",
-    "sgx-externalities/sgx",
-
-    # sgx versions of std crates
-    "thiserror_sgx",
-]
-
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
@@ -73,3 +34,33 @@ sp-std = { default-features = false, git = "https://github.com/paritytech/substr
 # test deps
 [dev-dependencies]
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.24" }
+
+[features]
+default = ["std"]
+std = [
+    "log/std",
+    "serde/std",
+    # substrate
+    "sp-std/std",
+    "sp-core/std",
+    # local crates
+    "itp-storage/std",
+    # scs crates
+    "sidechain-primitives/std",
+    "sp-io/std",
+    "sgx-externalities/std",
+    # optional std crates
+    "codec/std",
+    "thiserror",
+]
+sgx = [
+    # teaclave
+    "sgx_tstd",
+    # local crates
+    "itp-storage/sgx",
+    # scs crates
+    "sp-io/sgx",
+    "sgx-externalities/sgx",
+    # sgx versions of std crates
+    "thiserror_sgx",
+]


### PR DESCRIPTION
- updates `jsonrpc_core-sgx` to v18
- updates `log-sgx` to v0.4.17
- updates `env_logger-sgx` to v0.9.0
- Some clean up of the Cargo.toml


Error logs are now printed within the enclave again, with full colour and timestamp:

![grafik](https://user-images.githubusercontent.com/73821294/177831009-d114e7be-3807-4ff8-bb22-15da92eac2ad.png)

closes #825 
closes #823