### PR TITLE
Convert Sender to a move parameter

### DIFF
--- a/core/rpc-client/src/direct_client.rs
+++ b/core/rpc-client/src/direct_client.rs
@@ -66,7 +66,7 @@ impl DirectApi for DirectClient {
 		let (port_in, port_out) = channel();
 
 		info!("[WorkerApi Direct]: (get) Sending request: {:?}", request);
-		WsClient::connect_one_shot(&self.url, request, &port_in)?;
+		WsClient::connect_one_shot(&self.url, request, port_in)?;
 		port_out.recv().map_err(Error::MspcReceiver)
 	}
 

--- a/core/rpc-client/src/ws_client.rs
+++ b/core/rpc-client/src/ws_client.rs
@@ -82,7 +82,7 @@ impl WsClient {
 	}
 
 	/// Connects a web-socket client for a one-shot request.
-	pub fn connect_one_shot(url: &str, request: &str, result: &MpscSender<String>) -> Result<()> {
+	pub fn connect_one_shot(url: &str, request: &str, result: MpscSender<String>) -> Result<()> {
 		connect(url.to_string(), |out| {
 			WsClient::new(out, request.to_string(), result.clone(), false)
 		})


### PR DESCRIPTION
Currently there is a sender instance remaining on the caller location. This prevents recv() to return as there is still a Sender alive.
- Moving `port_in` into the function instead of passing a reference solves the problem as `port_in` gets dropped inside the function, then `recv()` ends.
  - This causes an unnecessary copy but I think it is worth the price
- Explicitly calling `drop(port_in)` on the caller site would also work, but I think it makes sense to change the API in order to prevent these kinds of issues more generally.