### PR TITLE
Tn/fix multihash vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec 0.7.2",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,13 +613,15 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.3.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e37fba0087d9f3f4e269827a55dc511abf3e440cc097a0c154ff4e6584f988"
+checksum = "fc949bff6704880faf064c42a4854032ab07bfcf3a4fcb82a57470acededb69c"
 dependencies = [
- "integer-encoding",
+ "core2",
  "multibase",
- "multihash 0.8.0",
+ "multihash 0.16.2",
+ "serde 1.0.137",
+ "unsigned-varint 0.7.1",
 ]
 
 [[package]]
@@ -732,6 +769,15 @@ name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr 2.5.0",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -886,6 +932,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
+name = "data-encoding-macro"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86927b7cd2fe88fa698b87404b287ab98d1a0063a34071d92e575b72d3029aca"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,10 +974,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "difference"
-version = "2.0.0"
+name = "difflib"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -973,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "downcast"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "downcast-rs"
@@ -1175,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "float-cmp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits 0.2.15",
 ]
@@ -1622,28 +1688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "geo-types"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5696e8138fbc44f64edc88b423afbe5a8f635df003376b3a57087e61a8ae7b66"
-dependencies = [
- "num-traits 0.2.15",
-]
-
-[[package]]
-name = "geojson"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c1147be22f66284de4387c43e4abab872e525a528f4d0af4e4e0f231895ea4"
-dependencies = [
- "geo-types",
- "serde 1.0.137",
- "serde_derive 1.0.137",
- "serde_json 1.0.81",
- "thiserror 1.0.31",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "git+https://github.com/mesalock-linux/getrandom-sgx#0aa9cc20c7dea713ccaac2c44430d625a395ebae"
@@ -1855,15 +1899,6 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac 0.11.1",
  "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.3",
 ]
 
 [[package]]
@@ -2126,16 +2161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca80fdd4829ab7569b7a72db4784b2f819d42f124e189c47dba0f72861c3888a"
-dependencies = [
- "async-trait",
- "futures 0.3.21",
-]
-
-[[package]]
 name = "integer-sqrt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,7 +2179,6 @@ dependencies = [
  "clap 3.2.6",
  "env_logger",
  "frame-system",
- "geojson",
  "hdrhistogram",
  "hex",
  "integritee-node-runtime",
@@ -2165,7 +2189,6 @@ dependencies = [
  "itp-sgx-crypto",
  "itp-types",
  "itp-utils",
- "json",
  "log 0.4.17",
  "pallet-balances",
  "parity-scale-codec",
@@ -2181,10 +2204,8 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "substrate-api-client",
- "substrate-bip39",
  "substrate-client-keystore",
  "teerex-primitives",
- "tiny-bip39 1.0.0",
  "ws",
 ]
 
@@ -2268,7 +2289,6 @@ dependencies = [
  "lazy_static",
  "log 0.4.17",
  "mockall",
- "multihash 0.8.0",
  "pallet-balances",
  "parentchain-test",
  "parity-scale-codec",
@@ -2458,7 +2478,7 @@ dependencies = [
  "substrate-api-client",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -3257,12 +3277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "jsonrpc-core"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
+checksum = "5641e476bbaf592a3939a7485fa079f427b4db21407d5ebfd5bba4e07a1f6f4c"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -3841,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+checksum = "262d56735932ee0240d515656e5a7667af3af2a5b0af4da558c4cff2b2aeb0c7"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -3853,22 +3867,13 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.6.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c35dac080fd6e16a99924c8dfdef0af89d797dd851adab25feaffacf7850d6"
+checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
 dependencies = [
  "base-x",
-]
-
-[[package]]
-name = "multihash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62469025f45dee2464ef9fc845f4683c543993792c1993e7d903c17a4546b74"
-dependencies = [
- "sha1 0.5.0",
- "sha2 0.7.1",
- "tiny-keccak 1.5.0",
+ "data-encoding",
+ "data-encoding-macro",
 ]
 
 [[package]]
@@ -3878,8 +3883,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
 dependencies = [
  "generic-array 0.14.5",
- "multihash-derive",
+ "multihash-derive 0.7.2",
  "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3db354f401db558759dfc1e568d010a5d4146f4d3f637be1275ec4a3cf09689"
+dependencies = [
+ "blake2b_simd",
+ "blake2s_simd",
+ "blake3",
+ "core2",
+ "digest 0.10.3",
+ "multihash-derive 0.8.0",
+ "sha2 0.10.2",
+ "sha3",
+ "unsigned-varint 0.7.1",
 ]
 
 [[package]]
@@ -3887,6 +3909,20 @@ name = "multihash-derive"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "424f6e86263cd5294cbd7f1e95746b95aca0e0d66bff31e5a40d6baa87b4aa99"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -4815,15 +4851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.3",
-]
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4927,12 +4954,13 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "predicates"
-version = "1.0.8"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
- "difference",
+ "difflib",
  "float-cmp",
+ "itertools",
  "normalize-line-endings",
  "predicates-core",
  "regex 1.5.6",
@@ -6079,12 +6107,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171698ce4ec7cbb93babeb3190021b4d72e96ccb98e33d277ae4ea959d6f2d9e"
-
-[[package]]
-name = "sha1"
 version = "0.6.0"
 source = "git+https://github.com/mesalock-linux/rust-sha1-sgx?tag=sgx_1.1.3#482a4d489e860d63a21662aaea988f600f8e20a4"
 dependencies = [
@@ -6464,7 +6486,7 @@ dependencies = [
  "ss58-registry",
  "substrate-bip39",
  "thiserror 1.0.31",
- "tiny-bip39 0.8.2",
+ "tiny-bip39",
  "wasmi",
  "zeroize",
 ]
@@ -7229,34 +7251,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-bip39"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
-dependencies = [
- "anyhow",
- "hmac 0.12.1",
- "once_cell 1.12.0",
- "pbkdf2 0.11.0",
- "rand 0.8.5",
- "rustc-hash",
- "sha2 0.10.2",
- "thiserror 1.0.31",
- "unicode-normalization 0.1.19",
- "wasm-bindgen",
- "zeroize",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7544,7 +7538,7 @@ dependencies = [
  "rand 0.7.3 (git+https://github.com/mesalock-linux/rand-sgx?tag=sgx_1.1.3)",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?tag=sgx_1.1.3)",
  "sgx_tstd",
- "sha1 0.6.0",
+ "sha1",
  "thiserror 1.0.9",
  "url 2.1.1",
  "utf-8 0.7.4",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,16 +8,12 @@ edition = "2018"
 log = "0.4"
 env_logger = "0.9"
 hex = "0.4.2"
-json = "0.12.0"
-substrate-bip39 = "0.4.2"
-tiny-bip39 = "1.0"
 serde_json = "1.0"
 clap = { version = "3.1.6", features = ["derive"]}
 primitive-types = { version = "0.11.1", features = ["codec"] }
 base58 			        = "0.2"
 chrono = "*"
 blake2-rfc      = { version = "0.2.18" }
-geojson = "0.23"
 ws = { version = "0.9.1", features = ["ssl"] }
 serde = { version = "1.0", features = ["derive"] }
 codec = { version = "3.0.0", package = "parity-scale-codec", features = ["derive"] }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,9 +11,9 @@ hex = "0.4.2"
 serde_json = "1.0"
 clap = { version = "3.1.6", features = ["derive"]}
 primitive-types = { version = "0.11.1", features = ["codec"] }
-base58 			        = "0.2"
+base58 = "0.2"
 chrono = "*"
-blake2-rfc      = { version = "0.2.18" }
+blake2-rfc = { version = "0.2.18" }
 ws = { version = "0.9.1", features = ["ssl"] }
 serde = { version = "1.0", features = ["derive"] }
 codec = { version = "3.0.0", package = "parity-scale-codec", features = ["derive"] }

--- a/core-primitives/enclave-api/Cargo.toml
+++ b/core-primitives/enclave-api/Cargo.toml
@@ -27,4 +27,4 @@ itp-types = { git = "https://github.com/integritee-network/pallets.git", branch 
 
 
 [dev-dependencies]
-mockall = { version = "0.10.1" }
+mockall = "0.11"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -27,8 +27,7 @@ futures = "0.3"
 
 # ipfs
 ipfs-api = "0.11.0"
-multihash = "0.8"
-cid = "<0.3.1"
+cid = "0.8"
 sha2 = { version = "0.7", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -77,7 +77,7 @@ production = ['itp-settings/production']
 [dev-dependencies]
 # crates.io
 anyhow = "1.0.40"
-mockall = "0.10.1"
+mockall = "0.11"
 # local
 itp-test = { path = "../core-primitives/test" }
 its-peer-fetch = { path = "../sidechain/peer-fetch", features = ["mocks"] }

--- a/sidechain/storage/Cargo.toml
+++ b/sidechain/storage/Cargo.toml
@@ -21,7 +21,7 @@ sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polka
 
 [dev-dependencies]
 # crate.io
-mockall = { version = "0.10.1" }
+mockall = "0.11"
 temp-dir = "0.1"
 # local
 sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "master" }


### PR DESCRIPTION
Removes some unused dependencies and fixes these two Cargo audit warnings:
```
Crate:     multihash
Version:   0.8.0
Title:     Unexpected panic in multihash `from_slice` parsing code
Date:      2020-11-08
ID:        RUSTSEC-2020-0068
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0068
Solution:  Upgrade to >=0.11.3
Dependency tree:
multihash 0.8.0
├── integritee-service 0.8.0
└── cid 0.3.0
    └── integritee-service 0.8.0

Crate:     difference
Version:   2.0.0
Warning:   unmaintained
Title:     difference is unmaintained
Date:      2020-12-20
ID:        RUSTSEC-2020-0095
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0095
Dependency tree:
difference 2.0.0
└── predicates 1.0.8
    └── mockall 0.10.2
        ├── its-storage 0.8.0
        │   ├── its-peer-fetch 0.8.0
        │   │   ├── itc-rpc-server 0.8.0
        │   │   │   └── integritee-service 0.8.0
        │   │   └── integritee-service 0.8.0
        │   ├── itc-rpc-server 0.8.0
        │   └── integritee-service 0.8.0
        ├── itp-enclave-api 0.8.0
        │   ├── itc-rpc-server 0.8.0
        │   └── integritee-service 0.8.0
        └── integritee-service 0.8.0
```