### PR TITLE
Fix intermittent unit test failure with web-socket client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,7 @@ version = "0.8.0"
 dependencies = [
  "env_logger",
  "itc-tls-websocket-server",
+ "itp-networking-utils",
  "itp-rpc",
  "itp-types",
  "itp-utils",
@@ -2608,6 +2609,13 @@ dependencies = [
  "substrate-api-client",
  "thiserror 1.0.31",
  "thiserror 1.0.9",
+]
+
+[[package]]
+name = "itp-networking-utils"
+version = "0.8.0"
+dependencies = [
+ "sgx_tstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "core-primitives/enclave-api/ffi",
     "core-primitives/enclave-metrics",
     "core-primitives/extrinsics-factory",
+    "core-primitives/networking-utils",
     "core-primitives/node-api-extensions",
     "core-primitives/nonce-cache",
     "core-primitives/ocall-api",

--- a/core-primitives/networking-utils/Cargo.toml
+++ b/core-primitives/networking-utils/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "itp-networking-utils"
+version = "0.8.0"
+authors = ["Integritee AG <hello@integritee.network>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+
+[features]
+default = ["std"]
+std = [
+
+]
+sgx = [
+    "sgx_tstd",
+]

--- a/core-primitives/networking-utils/src/lib.rs
+++ b/core-primitives/networking-utils/src/lib.rs
@@ -1,0 +1,26 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(all(feature = "std", feature = "sgx"))]
+compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
+
+#[cfg(all(not(feature = "std"), feature = "sgx"))]
+extern crate sgx_tstd as std;
+
+pub mod ports;

--- a/core-primitives/networking-utils/src/ports.rs
+++ b/core-primitives/networking-utils/src/ports.rs
@@ -1,0 +1,51 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use std::{net::TcpListener, ops::Range};
+
+/// Gets the first available port in a range.
+/// Returns None if no port in range is available.
+///
+pub fn get_available_port_in_range(mut port_range: Range<u16>) -> Option<u16> {
+	port_range.find(|port| port_is_available(*port))
+}
+
+fn port_is_available(port: u16) -> bool {
+	match TcpListener::bind(("127.0.0.1", port)) {
+		Ok(_) => true,
+		Err(_) => false,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::mem::drop;
+
+	#[test]
+	fn port_is_not_available_when_bound() {
+		let available_port = get_available_port_in_range(12000..13000).unwrap();
+
+		let tcp_listener = TcpListener::bind(("127.0.0.1", available_port)).unwrap();
+
+		assert!(!port_is_available(available_port));
+
+		drop(tcp_listener);
+
+		assert!(port_is_available(available_port));
+	}
+}

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -29,4 +29,5 @@ itp-rpc = { path = "../../core-primitives/rpc" }
 [dev-dependencies]
 env_logger = "0.9.0"
 itc-tls-websocket-server = { path = "../tls-websocket-server", features = ["mocks"] }
+itp-networking-utils = { path = "../../core-primitives/networking-utils" }
 rustls = { version = "0.19", features = ["dangerous_configuration"] }

--- a/core/rpc-client/src/direct_client.rs
+++ b/core/rpc-client/src/direct_client.rs
@@ -165,6 +165,7 @@ fn decode_from_rpc_response(json_rpc_response: &str) -> Result<String> {
 mod tests {
 	use super::*;
 	use itc_tls_websocket_server::{test::fixtures::test_server::create_server, WebSocketServer};
+	use itp_networking_utils::ports::get_available_port_in_range;
 	use std::vec;
 
 	#[test]
@@ -174,11 +175,15 @@ mod tests {
 		const END_MESSAGE: &str = "End of service.";
 		let responses = vec![END_MESSAGE.to_string()];
 
-		let port = 22334;
+		let port = get_available_port_in_range(21000..21500).unwrap();
 		let (server, handler) = create_server(responses, port);
 
 		let server_clone = server.clone();
-		let server_join_handle = thread::spawn(move || server_clone.run());
+		let server_join_handle = thread::spawn(move || {
+			if let Err(e) = server_clone.run() {
+				error!("Web-socket server failed: {:?}", e);
+			}
+		});
 
 		// Wait until server is up.
 		thread::sleep(std::time::Duration::from_millis(50));
@@ -208,7 +213,7 @@ mod tests {
 
 		info!("Joining server thread");
 		server.shut_down().unwrap();
-		server_join_handle.join().unwrap().unwrap();
+		server_join_handle.join().unwrap();
 
 		assert_eq!(1, messages.len());
 		assert_eq!(1, handler.messages_handled.read().unwrap().len());
@@ -221,11 +226,15 @@ mod tests {
 		let server_response = "response 1".to_string();
 		let responses = vec![server_response.clone()];
 
-		let port = 22335;
+		let port = get_available_port_in_range(21501..22000).unwrap();
 		let (server, handler) = create_server(responses, port);
 
 		let server_clone = server.clone();
-		let server_join_handle = thread::spawn(move || server_clone.run());
+		let server_join_handle = thread::spawn(move || {
+			if let Err(e) = server_clone.run() {
+				error!("Web-socket server failed: {:?}", e);
+			}
+		});
 
 		// Wait until server is up.
 		thread::sleep(std::time::Duration::from_millis(50));
@@ -235,7 +244,7 @@ mod tests {
 
 		info!("Joining server thread");
 		server.shut_down().unwrap();
-		server_join_handle.join().unwrap().unwrap();
+		server_join_handle.join().unwrap();
 
 		assert_eq!(server_response, received_response);
 		assert_eq!(1, handler.messages_handled.read().unwrap().len());


### PR DESCRIPTION
Attempt at investigating and fixing unit test failures, described in #869

* Add explicit error log when web-socket server encounters an error
* Add utility functions to get the next available port within a given range