### PR TITLE
Test GHA cache with build-push action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,6 +39,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           buildkitd-flags: --debug
+          driver: docker
 
       - name: Build Enclave Test Image
         uses: docker/build-push-action@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,8 +48,11 @@ jobs:
         with:
           build-args: |
             WORKER_MODE_ARG=${{ matrix.mode }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
+          push: true
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: enclave-test
 
@@ -59,7 +62,17 @@ jobs:
       - name: Build Cargo Test Image
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }} --target cargo-test --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            WORKER_MODE_ARG=${{ matrix.mode }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: build.Dockerfile
+          push: true
+          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
+          target: cargo-test
 
       - name: Run Cargo Test
         run: docker run --rm integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}
@@ -67,7 +80,17 @@ jobs:
       - name: Build Deployable Image
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build --output=type=tar,dest=/tmp/integritee-worker.tar --target=deployed-worker --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            WORKER_MODE_ARG=${{ matrix.mode }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: build.Dockerfile
+          outputs: |
+            type=tar,dest=/tmp/integritee-worker.tar
+          target: deployed-worker
       
       - name: Copy artifacts from container
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ jobs:
           buildkitd-flags: --debug
           driver: docker-container
 
-      - name: Build Complete Worker Image
+      - name: Build Worker & Run Cargo Test
         uses: docker/build-push-action@v3
         with:
           build-args: |
@@ -57,7 +57,7 @@ jobs:
       - run: docker images --all
 
       - name: Test Enclave # cargo test is not supported in the enclave, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
-        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.mode }}-${{ github.sha }}
+        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.mode }}-${{ github.sha }} test --all
 
 #      - name: Build Cargo Test Image
 #        uses: docker/build-push-action@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           buildkitd-flags: --debug
-          driver: docker
+          driver: docker-container
 
       - name: Build Enclave Test Image
         uses: docker/build-push-action@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,6 +54,8 @@ jobs:
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}:latest
           target: enclave-test
 
+      - run: docker images --all
+
       - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
         run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
 
@@ -71,6 +73,8 @@ jobs:
           load: true
           tags: integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}:latest
           target: cargo-test
+
+      - run: docker images --all
 
       - name: Run Cargo Test
         run: docker run --rm integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
@@ -51,7 +54,7 @@ jobs:
       - name: Build Cargo Test Image
         env:
           DOCKER_BUILDKIT: 1
-        run:  docker build -t integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }} --target cargo-test --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
+        run: docker build -t integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }} --target cargo-test --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
 
       - name: Run Cargo Test
         run: docker run --rm integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,11 +50,9 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
-          load: true
+          load: true # Required in order to make the resulting image available in `docker images`, so we can use it in a subsequent `docker run`.
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: enclave-test
-
-      - run: docker images --all
 
       - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
         run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
@@ -70,8 +68,7 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
-          outputs: |
-            type=image
+          load: true
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: cargo-test
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,9 +44,14 @@ jobs:
           buildkitd-flags: --debug
 
       - name: Build Enclave Test Image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: docker build -t integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }} --target enclave-test --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            WORKER_MODE_ARG=${{ matrix.mode }}
+          context: .
+          file: build.Dockerfile
+          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
+          target: enclave-test
 
       - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
         run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,7 +51,7 @@ jobs:
           context: .
           file: build.Dockerfile
           load: true # Required in order to make the resulting image available in `docker images`, so we can use it in a subsequent `docker run`.
-          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
+          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}:latest
           target: enclave-test
 
       - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
@@ -69,7 +69,7 @@ jobs:
           context: .
           file: build.Dockerfile
           load: true
-          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
+          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}:latest
           target: cargo-test
 
       - name: Run Cargo Test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,7 +41,7 @@ jobs:
           buildkitd-flags: --debug
           driver: docker-container
 
-      - name: Build Enclave Test Image
+      - name: Build Complete Worker Image
         uses: docker/build-push-action@v3
         with:
           build-args: |
@@ -51,54 +51,52 @@ jobs:
           context: .
           file: build.Dockerfile
           load: true # Required in order to make the resulting image available in `docker images`, so we can use it in a subsequent `docker run`.
-          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}:latest
-          target: enclave-test
-
-      - run: docker images --all
-
-      - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
-        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
-
-      - name: Build Cargo Test Image
-        env:
-          DOCKER_BUILDKIT: 1
-        uses: docker/build-push-action@v3
-        with:
-          build-args: |
-            WORKER_MODE_ARG=${{ matrix.mode }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          context: .
-          file: build.Dockerfile
-          load: true
-          tags: integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}:latest
-          target: cargo-test
-
-      - run: docker images --all
-
-      - name: Run Cargo Test
-        run: docker run --rm integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}
-
-      - name: Build Deployable Image
-        env:
-          DOCKER_BUILDKIT: 1
-        uses: docker/build-push-action@v3
-        with:
-          build-args: |
-            WORKER_MODE_ARG=${{ matrix.mode }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          context: .
-          file: build.Dockerfile
-          outputs: |
-            type=tar,dest=/tmp/integritee-worker.tar
+          tags: integritee-worker-${{ matrix.mode }}-${{ github.sha }}
           target: deployed-worker
+
+      - run: docker images --all
+
+      - name: Test Enclave # cargo test is not supported in the enclave, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
+        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.mode }}-${{ github.sha }}
+
+#      - name: Build Cargo Test Image
+#        uses: docker/build-push-action@v3
+#        with:
+#          build-args: |
+#            WORKER_MODE_ARG=${{ matrix.mode }}
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
+#          context: .
+#          file: build.Dockerfile
+#          load: true
+#          tags: integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}:latest
+#          target: cargo-test
+
+#      - run: docker images --all
+#
+#      - name: Run Cargo Test
+#        run: docker run --rm integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}
+
+#      - name: Build Deployable Image
+#        env:
+#          DOCKER_BUILDKIT: 1
+#        uses: docker/build-push-action@v3
+#        with:
+#          build-args: |
+#            WORKER_MODE_ARG=${{ matrix.mode }}
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
+#          context: .
+#          file: build.Dockerfile
+#          outputs: |
+#            type=tar,dest=/tmp/integritee-worker.tar
+#          target: deployed-worker
       
       - name: Copy artifacts from container
         run: |
-          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/root/work/worker/bin/${{ env.WORKER_BIN }} .
-          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/root/work/worker/bin/${{ env.CLIENT_BIN }} .
-          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/root/work/worker/bin/${{ env.ENCLAVE_BIN }} .
+          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/usr/local/bin/${{ env.WORKER_BIN }} .
+          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/usr/local/bin/${{ env.CLIENT_BIN }} .
+          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/usr/local/bin/${{ env.ENCLAVE_BIN }} .
 
       - name: Upload worker
         uses: actions/upload-artifact@v2
@@ -118,11 +116,11 @@ jobs:
           name: enclave-signed-${{ matrix.mode }}-${{ github.sha }}
           path: ${{ env.ENCLAVE_BIN }}
 
-      - name: Upload deployable image
-        uses: actions/upload-artifact@v2
-        with:
-          name: integritee-worker-${{ matrix.mode }}-image-${{ github.sha }}
-          path: /tmp/integritee-worker.tar
+#      - name: Upload deployable image
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: integritee-worker-${{ matrix.mode }}-image-${{ github.sha }}
+#          path: /tmp/integritee-worker.tar
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,9 +35,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,9 +49,12 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
-          load: true
+          outputs: |
+            type=image
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: enclave-test
+
+      - run: docker images --all
 
       - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
         run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
@@ -67,7 +70,8 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
-          load: true
+          outputs: |
+            type=image
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: cargo-test
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,7 +69,7 @@ jobs:
           context: .
           file: build.Dockerfile
           load: true
-          tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}:latest
+          tags: integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}:latest
           target: cargo-test
 
       - name: Run Cargo Test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
-          push: true
+          load: true
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: enclave-test
 
@@ -67,7 +67,7 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
-          push: true
+          load: true
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: cargo-test
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,8 +49,7 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           file: build.Dockerfile
-          outputs: |
-            type=image
+          load: true
           tags: integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
           target: enclave-test
 

--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,10 @@ Worker_Name := bin/app
 ######## Integritee-cli settings ########
 Client_SRC_Path := cli
 STF_SRC_Path := app-libs/stf
-Client_Rust_Flags := $(CARGO_TARGET)
 Client_SRC_Files := $(shell find $(Client_SRC_Path)/ -type f -name '*.rs') $(shell find $(STF_SRC_Path)/ -type f -name '*.rs') $(shell find $(Client_SRC_Path)/ -type f -name 'Cargo.toml')
 Client_Include_Paths := -I ./$(Client_SRC_Path) -I./include -I$(SGX_SDK)/include -I$(CUSTOM_EDL_PATH)
 Client_C_Flags := $(SGX_COMMON_CFLAGS) -fPIC -Wno-attributes $(Client_Include_Paths)
 
-Client_Rust_Path := target/$(OUTPUT_PATH)
 Client_Path := bin
 Client_Binary := integritee-cli
 Client_Name := $(Client_Path)/$(Client_Binary)
@@ -153,7 +151,6 @@ Signed_RustEnclave_Name := bin/enclave.signed.so
 .PHONY: all
 all: $(Worker_Name) $(Client_Name) $(Signed_RustEnclave_Name)
 service: $(Worker_Name)
-client: $(Client_Name)
 githooks: .git/hooks/pre-commit
 
 ######## EDL objects ########
@@ -171,7 +168,7 @@ $(Worker_Enclave_u_Object): service/Enclave_u.o
 	$(AR) rcsD $@ $^
 	cp $(Worker_Enclave_u_Object) ./lib
 
-$(Worker_Name): $(Worker_Enclave_u_Object) $(Worker_SRC_Files)
+$(Worker_Name): $(Worker_Enclave_u_Object) $(Worker_SRC_Files) $(Client_SRC_Files)
 	@echo
 	@echo "Building the integritee-service"
 	@SGX_SDK=$(SGX_SDK) SGX_MODE=$(SGX_MODE) cargo build -p integritee-service $(Worker_Rust_Flags)

--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,12 @@ Worker_Name := bin/app
 ######## Integritee-cli settings ########
 Client_SRC_Path := cli
 STF_SRC_Path := app-libs/stf
+Client_Rust_Flags := $(CARGO_TARGET)
 Client_SRC_Files := $(shell find $(Client_SRC_Path)/ -type f -name '*.rs') $(shell find $(STF_SRC_Path)/ -type f -name '*.rs') $(shell find $(Client_SRC_Path)/ -type f -name 'Cargo.toml')
 Client_Include_Paths := -I ./$(Client_SRC_Path) -I./include -I$(SGX_SDK)/include -I$(CUSTOM_EDL_PATH)
 Client_C_Flags := $(SGX_COMMON_CFLAGS) -fPIC -Wno-attributes $(Client_Include_Paths)
 
+Client_Rust_Path := target/$(OUTPUT_PATH)
 Client_Path := bin
 Client_Binary := integritee-cli
 Client_Name := $(Client_Path)/$(Client_Binary)
@@ -151,6 +153,7 @@ Signed_RustEnclave_Name := bin/enclave.signed.so
 .PHONY: all
 all: $(Worker_Name) $(Client_Name) $(Signed_RustEnclave_Name)
 service: $(Worker_Name)
+client: $(Client_Name)
 githooks: .git/hooks/pre-commit
 
 ######## EDL objects ########
@@ -168,7 +171,7 @@ $(Worker_Enclave_u_Object): service/Enclave_u.o
 	$(AR) rcsD $@ $^
 	cp $(Worker_Enclave_u_Object) ./lib
 
-$(Worker_Name): $(Worker_Enclave_u_Object) $(Worker_SRC_Files) $(Client_SRC_Files)
+$(Worker_Name): $(Worker_Enclave_u_Object) $(Worker_SRC_Files)
 	@echo
 	@echo "Building the integritee-service"
 	@SGX_SDK=$(SGX_SDK) SGX_MODE=$(SGX_MODE) cargo build -p integritee-service $(Worker_Rust_Flags)

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -72,24 +72,6 @@ RUN make
 RUN cargo test --release
 
 
-#### Enclave Test Stage
-###################################################
-#FROM builder AS enclave-test
-#
-#WORKDIR /root/work/worker/bin
-#
-#CMD ./integritee-service test --all
-
-
-### Cargo Test Stage
-##################################################
-#FROM builder AS cargo-test
-#
-#WORKDIR /root/work/worker
-#
-#CMD cargo test --release
-
-
 ### Base Runner Stage
 ##################################################
 FROM ubuntu:20.04 AS runner

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -19,9 +19,11 @@
 FROM integritee/integritee-dev:0.1.9 AS planner
 LABEL maintainer="zoltan@integritee.network"
 
-RUN cargo install cargo-chef
-
 WORKDIR /root/work/worker
+
+RUN rustup default nightly-2022-03-10
+RUN rustup show
+RUN cargo install cargo-chef
 
 COPY . .
 
@@ -50,19 +52,19 @@ ENV WORKER_MODE=$WORKER_MODE_ARG
 
 WORKDIR /root/work/worker
 
+RUN rustup default nightly-2022-03-10
+RUN rustup show
 RUN cargo install cargo-chef
 
 COPY --from=planner /root/work/worker/recipe-root.json recipe-root.json
 COPY --from=planner /root/work/worker/enclave-runtime/recipe-enclave.json enclave-runtime/recipe-enclave.json
 
-RUN rustup show
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo chef cook --release --target wasm32-unknown-unknown --recipe-path recipe-root.json
+RUN cargo chef cook --release --recipe-path recipe-root.json
 
 WORKDIR /root/work/worker/enclave-runtime
-RUN rustup show
 RUN rustup target add wasm32-unknown-unknown
-RUN cargo chef cook --release --target wasm32-unknown-unknown --recipe-path recipe-enclave.json
+RUN cargo chef cook --release --recipe-path recipe-enclave.json
 
 WORKDIR /root/work/worker
 COPY . .

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -69,10 +69,8 @@ RUN cargo chef cook --release --recipe-path recipe-enclave.json
 WORKDIR /root/work/worker
 COPY . .
 
-#RUN --mount=type=cache,target=/usr/local/cargo/registry \
-#	--mount=type=cache,target=/root/work/worker/target \
-#	make
 RUN make
+
 
 ### Enclave Test Stage
 ##################################################
@@ -90,6 +88,7 @@ FROM builder AS cargo-test
 WORKDIR /root/work/worker
 
 CMD cargo test --release
+
 
 ### Base Runner Stage
 ##################################################

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -22,7 +22,6 @@ LABEL maintainer="zoltan@integritee.network"
 WORKDIR /root/work/worker
 
 RUN rustup default nightly-2022-03-10
-RUN rustup show
 RUN cargo install cargo-chef
 
 COPY . .
@@ -53,7 +52,6 @@ ENV WORKER_MODE=$WORKER_MODE_ARG
 WORKDIR /root/work/worker
 
 RUN rustup default nightly-2022-03-10
-RUN rustup show
 RUN cargo install cargo-chef
 
 COPY --from=planner /root/work/worker/recipe-root.json recipe-root.json

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -69,23 +69,25 @@ COPY . .
 
 RUN make
 
+RUN cargo test --release
 
-### Enclave Test Stage
-##################################################
-FROM builder AS enclave-test
 
-WORKDIR /root/work/worker/bin
-
-CMD ./integritee-service test --all
+#### Enclave Test Stage
+###################################################
+#FROM builder AS enclave-test
+#
+#WORKDIR /root/work/worker/bin
+#
+#CMD ./integritee-service test --all
 
 
 ### Cargo Test Stage
 ##################################################
-FROM builder AS cargo-test
-
-WORKDIR /root/work/worker
-
-CMD cargo test --release
+#FROM builder AS cargo-test
+#
+#WORKDIR /root/work/worker
+#
+#CMD cargo test --release
 
 
 ### Base Runner Stage

--- a/service/src/enclave/mod.rs
+++ b/service/src/enclave/mod.rs
@@ -1,2 +1,19 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 pub mod api;
 pub mod tls_ra;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -105,7 +105,6 @@ mod utils;
 mod worker;
 mod worker_peers_updater;
 
-/// how many blocks will be synced before storing the chain db to disk
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type EnclaveWorker =


### PR DESCRIPTION
Test cargo chef and GHA cache to speedup builds. Results show some success, but not as much as we would like. GHA cache with the `build-push` action still makes the build slower over all, compared to simple `docker build`.