### PR TITLE
Github actions integration tests use docker image instead of python local setup

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,18 +50,6 @@ jobs:
           --target deployed-worker --build-arg WORKER_MODE_ARG=${{ matrix.mode }} 
           -f build.Dockerfile .
 
-#      - name: Build Worker & Run Cargo Test
-#        uses: docker/build-push-action@v3
-#        with:
-#          build-args: |
-#            WORKER_MODE_ARG=${{ matrix.mode }}
-#          cache-to: type=local,dest=/tmp/docker/cache,mode=max
-#          context: .
-#          file: build.Dockerfile
-#          load: true # Required in order to make the resulting image available in `docker images`, so we can use it in a subsequent `docker run`.
-#          tags: integritee-worker-${{ matrix.mode }}-${{ github.sha }}
-#          target: deployed-worker
-
       - name: Build CLI client
         env:
           DOCKER_BUILDKIT: 1
@@ -69,17 +57,6 @@ jobs:
           docker build -t integritee-cli-client-${{ matrix.mode }}-${{ github.sha }} 
           --target deployed-client --build-arg WORKER_MODE_ARG=${{ matrix.mode }} 
           -f build.Dockerfile .
-
-#        uses: docker/build-push-action@v3
-#        with:
-#          build-args: |
-#            WORKER_MODE_ARG=${{ matrix.mode }}
-#          cache-from: type=local,src=/tmp/docker/cache
-#          context: .
-#          file: build.Dockerfile
-#          outputs: |
-#            type=tar,dest=integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar
-#          target: deployed-client
 
       - run: docker images --all
 
@@ -178,10 +155,6 @@ jobs:
       - name: Load Worker & Client Images
         env:
           DOCKER_BUILDKIT: 1
-#        run: |
-#          cat integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz | docker import - integritee-worker-${{ matrix.mode }}-${{ github.sha }}
-#          cat integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz | docker import - integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}
-#          docker images --all
         run: |
           docker image load --input integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz
           docker image load --input integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -124,15 +124,19 @@ jobs:
           - test: M6
             mode: sidechain
             demo_name: demo-indirect-invocation
+            compose_profile: double-worker
           - test: M8
             mode: sidechain
             demo_name: demo-direct-call
+            compose_profile: double-worker
           - test: Sidechain
             mode: sidechain
             demo_name: demo-sidechain
+            compose_profile: double-worker
           - test: M6
             mode: offchain-worker
             demo_name: demo-indirect-invocation
+            compose_profile: double-worker
 
     steps:
       - uses: actions/checkout@v3
@@ -166,7 +170,7 @@ jobs:
       - name: Integration Test ${{ matrix.test }}-${{ matrix.mode }}
         run: |
           cd docker
-          docker-compose -f docker-compose.yml -f ${{ matrix.demo_name }}.yml up --no-build --exit-code-from ${{ matrix.demo_name }}
+          docker compose --profile ${{ matrix.compose_profile }} -f docker-compose.yml -f ${{ matrix.demo_name }}.yml up --no-build --exit-code-from ${{ matrix.demo_name }}
 
       - name: Collect Docker Logs
         continue-on-error: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -124,19 +124,15 @@ jobs:
           - test: M6
             mode: sidechain
             demo_name: demo-indirect-invocation
-            compose_profile: double-worker
           - test: M8
             mode: sidechain
             demo_name: demo-direct-call
-            compose_profile: double-worker
           - test: Sidechain
             mode: sidechain
             demo_name: demo-sidechain
-            compose_profile: double-worker
           - test: M6
             mode: offchain-worker
             demo_name: demo-indirect-invocation
-            compose_profile: double-worker
 
     steps:
       - uses: actions/checkout@v3
@@ -170,7 +166,7 @@ jobs:
       - name: Integration Test ${{ matrix.test }}-${{ matrix.mode }}
         run: |
           cd docker
-          docker compose --profile ${{ matrix.compose_profile }} -f docker-compose.yml -f ${{ matrix.demo_name }}.yml up --no-build --exit-code-from ${{ matrix.demo_name }}
+          docker compose -f docker-compose.yml -f ${{ matrix.demo_name }}.yml up --no-build --exit-code-from ${{ matrix.demo_name }}
 
       - name: Collect Docker Logs
         continue-on-error: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,8 +27,9 @@ jobs:
           access_token: ${{ secrets.GITHUB_TOKEN }}
       
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         mode: [ sidechain, offchain-worker ]
 
@@ -39,57 +40,68 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           buildkitd-flags: --debug
+          driver: docker-container
 
-      - name: Build Enclave Test Image
+      - name: Build Worker & Run Cargo Test
         env:
           DOCKER_BUILDKIT: 1
-        run: docker build -t integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }} --target enclave-test --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
+        run: >
+          docker build -t integritee-worker-${{ matrix.mode }}-${{ github.sha }} 
+          --target deployed-worker --build-arg WORKER_MODE_ARG=${{ matrix.mode }} 
+          -f build.Dockerfile .
 
-      - name: Test Enclave # cargo test is not supported, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
-        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-enclave-test-${{ matrix.mode }}-${{ github.sha }}
+#      - name: Build Worker & Run Cargo Test
+#        uses: docker/build-push-action@v3
+#        with:
+#          build-args: |
+#            WORKER_MODE_ARG=${{ matrix.mode }}
+#          cache-to: type=local,dest=/tmp/docker/cache,mode=max
+#          context: .
+#          file: build.Dockerfile
+#          load: true # Required in order to make the resulting image available in `docker images`, so we can use it in a subsequent `docker run`.
+#          tags: integritee-worker-${{ matrix.mode }}-${{ github.sha }}
+#          target: deployed-worker
 
-      - name: Build Cargo Test Image
+      - name: Build CLI client
         env:
           DOCKER_BUILDKIT: 1
-        run:  docker build -t integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }} --target cargo-test --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
+        run: >
+          docker build -t integritee-cli-client-${{ matrix.mode }}-${{ github.sha }} 
+          --target deployed-client --build-arg WORKER_MODE_ARG=${{ matrix.mode }} 
+          -f build.Dockerfile .
 
-      - name: Run Cargo Test
-        run: docker run --rm integritee-worker-ctest-${{ matrix.mode }}-${{ github.sha }}
+#        uses: docker/build-push-action@v3
+#        with:
+#          build-args: |
+#            WORKER_MODE_ARG=${{ matrix.mode }}
+#          cache-from: type=local,src=/tmp/docker/cache
+#          context: .
+#          file: build.Dockerfile
+#          outputs: |
+#            type=tar,dest=integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar
+#          target: deployed-client
 
-      - name: Build Deployable Image
-        env:
-          DOCKER_BUILDKIT: 1
-        run: docker build --output=type=tar,dest=/tmp/integritee-worker.tar --target=deployed-worker --build-arg WORKER_MODE_ARG=${{ matrix.mode }} -f build.Dockerfile .
-      
-      - name: Copy artifacts from container
+      - run: docker images --all
+
+      - name: Test Enclave # cargo test is not supported in the enclave, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
+        run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.mode }}-${{ github.sha }} test --all
+
+      - name: Export worker image(s)
         run: |
-          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/root/work/worker/bin/${{ env.WORKER_BIN }} .
-          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/root/work/worker/bin/${{ env.CLIENT_BIN }} .
-          docker cp ${{ env.BUILD_CONTAINER_NAME }}:/root/work/worker/bin/${{ env.ENCLAVE_BIN }} .
+          docker image save integritee-worker-${{ matrix.mode }}-${{ github.sha }} | gzip > integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz
+          docker image save integritee-cli-client-${{ matrix.mode }}-${{ github.sha }} | gzip > integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz
 
-      - name: Upload worker
+      - name: Upload worker image
         uses: actions/upload-artifact@v2
         with:
-          name: integritee-worker-${{ matrix.mode }}-${{ github.sha }}
-          path: ${{ env.WORKER_BIN }}
+          name: integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz
+          path: integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz
 
-      - name: Upload client
+      - name: Upload CLI client image
         uses: actions/upload-artifact@v2
         with:
-          name: integritee-client-${{ matrix.mode }}-${{ github.sha }}
-          path: ${{ env.CLIENT_BIN }}
-
-      - name: Upload enclave
-        uses: actions/upload-artifact@v2
-        with:
-          name: enclave-signed-${{ matrix.mode }}-${{ github.sha }}
-          path: ${{ env.ENCLAVE_BIN }}
-
-      - name: Upload deployable image
-        uses: actions/upload-artifact@v2
-        with:
-          name: integritee-worker-${{ matrix.mode }}-image-${{ github.sha }}
-          path: /tmp/integritee-worker.tar
+          name: integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz
+          path: integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz
 
   clippy:
     runs-on: ubuntu-latest
@@ -126,144 +138,85 @@ jobs:
         uses: andymckay/cancel-action@0.2
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-test
-    container: "integritee/integritee-dev:0.1.9"
+    env:
+      WORKER_IMAGE_TAG: integritee-worker:dev
+      CLIENT_IMAGE_TAG: integritee-cli:dev
     strategy:
       fail-fast: false
       matrix:
         include:
           - test: M6
             mode: sidechain
-            demo_name: m6_demo_shielding_unshielding
-            demo_script: m6.sh
+            demo_name: demo-indirect-invocation
           - test: M8
             mode: sidechain
-            demo_name: m8_demo_direct_call
-            demo_script: m8.sh
+            demo_name: demo-direct-call
           - test: Sidechain
             mode: sidechain
-            demo_name: sidechain_demo
-            demo_script: sidechain.sh
+            demo_name: demo-sidechain
           - test: M6
             mode: offchain-worker
-            demo_name: m6_demo_shielding_unshielding
-            demo_script: m6.sh
+            demo_name: demo-indirect-invocation
 
-    env:
-      BIN_DIR: bin
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v3
-        with:
-          python-version: '3.7'
-
-      - name: Download Worker
+      - name: Download Worker Image
         uses: actions/download-artifact@v2
         with:
-          name: integritee-worker-${{ matrix.mode }}-${{ github.sha }}
-          path: ${{ env.BIN_DIR }}
+          name: integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz
+          path: .
 
-      - name: Download Client
+      - name: Download CLI client Image
         uses: actions/download-artifact@v2
         with:
-          name: integritee-client-${{ matrix.mode }}-${{ github.sha }}
-          path: ${{ env.BIN_DIR }}
+          name: integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz
+          path: .
 
-      - name: Download Enclave
-        uses: actions/download-artifact@v2
-        with:
-          name: enclave-signed-${{ matrix.mode }}-${{ github.sha }}
-          path: ${{ env.BIN_DIR }}
-
-        # If you want to debug ci and you don't want to build the binaries, you can replace the downloads above with
-        # the actions below to download binaries from an earlier run.
-#      - name: Download Worker
-#        uses: dawidd6/action-download-artifact@v2
-#        with:
-#          github_token: ${{secrets.GITHUB_TOKEN}}
-#          workflow: build_and_test.yml
-#          run_id: 1033249727
-#          name: integritee-worker-da8d4b442d3f2b09dbafb097d4d7a1bce409d518
-#          path: ${{ env.BIN_DIR }}
-#
-#      - name: Download Client
-#        uses: dawidd6/action-download-artifact@v2
-#        with:
-#          github_token: ${{secrets.GITHUB_TOKEN}}
-#          workflow: build_and_test.yml
-#          run_id: 1033249727
-#          name: integritee-client-da8d4b442d3f2b09dbafb097d4d7a1bce409d518
-#          path: ${{ env.BIN_DIR }}
-#
-#      - name: Download Enclave
-#        uses: dawidd6/action-download-artifact@v2
-#        with:
-#          github_token: ${{secrets.GITHUB_TOKEN}}
-#          workflow: build_and_test.yml
-#          run_id: 1033249727
-#          name: enclave-signed-da8d4b442d3f2b09dbafb097d4d7a1bce409d518
-#          path: ${{ env.BIN_DIR }}
-
-      - name: Download integritee-node
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
-          workflow: ci.yml
-          name: integritee-node-dev-a1a80ab709c3c94f3174c7218f86b4de390d6dc5
-          # in fact this action should download the latest artifact, but sometimes fails. Then we need to
-          # set the `run_id` to force a download of an updated binary.
-          run_id: 2740081205
-          path: node
-          repo: integritee-network/integritee-node
-
-      - name: Prepare working directory
-        run: |
-          mkdir -p ${{ env.LOG_DIR}}
-          chmod +x node/integritee-node
-          cd ${{ env.BIN_DIR }}
-          chmod +x ${{ env.WORKER_BIN }}
-          chmod +x ${{ env.CLIENT_BIN }}
-          chmod +x ${{ env.ENCLAVE_BIN }}
-
-      - name: "Setup Keys"
+      - name: Load Worker & Client Images
         env:
-          KEY: ${{ secrets.IAS_PRIMARY_KEY }}
-          SPID: ${{ secrets.IAS_SPID }}
-          TLS_CERTIFICATE: ${{ secrets.TLS_WS_SERVER_CERTIFICATE }}
-          TLS_PRIVATE_KEY: ${{ secrets.TLS_WS_SERVER_PRIVATE_KEY }}
+          DOCKER_BUILDKIT: 1
+#        run: |
+#          cat integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz | docker import - integritee-worker-${{ matrix.mode }}-${{ github.sha }}
+#          cat integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz | docker import - integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}
+#          docker images --all
         run: |
-          cd ${{ env.BIN_DIR }}
-          echo "${{ env.KEY }}" > key.txt
-          echo "${{ env.SPID }}" > spid.txt
-          echo "${{ env.TLS_CERTIFICATE }}" > end.fullchain
-          echo "${{ env.TLS_PRIVATE_KEY }}" > end.rsa
-          chmod 644 end.fullchain
-          chmod 644 end.rsa
+          docker image load --input integritee-worker-${{ matrix.mode }}-${{ github.sha }}.tar.gz
+          docker image load --input integritee-cli-client-${{ matrix.mode }}-${{ github.sha }}.tar.gz
+          docker images --all
 
-      - name: Run local setup
-        # * `set -eo pipefail` is needed to return an error even if piped to `tee`.
-        shell: bash --noprofile --norc -eo pipefail {0}
+      - name: Re-name Image Tags
         run: |
-          touch ${{ env.LOG_DIR }}/local-setup.log
-          ./local-setup/launch.py local-setup/github-action-config.json 2>&1 | tee -i ${{ env.LOG_DIR }}/local-setup.log &
-          sleep 150
+          docker tag integritee-worker-${{ matrix.mode }}-${{ github.sha }} ${{ env.WORKER_IMAGE_TAG }}
+          docker tag integritee-cli-client-${{ matrix.mode }}-${{ github.sha }} ${{ env.CLIENT_IMAGE_TAG }} 
+          docker images --all
 
-      - name: ${{ matrix.demo_name }}-${{ matrix.mode }}
-        # * the change the symbolic link which points to the target/release... folder.
-        # * need overwrite default shell to bash to get access to the `source` cmd.
-        shell: bash --noprofile --norc -eo pipefail {0}
+      - name: Integration Test ${{ matrix.test }}-${{ matrix.mode }}
         run: |
-          source ./scripts/init_env.sh && ./scripts/${{ matrix.demo_script }}
+          cd docker
+          docker-compose -f docker-compose.yml -f ${{ matrix.demo_name }}.yml up --no-build --exit-code-from ${{ matrix.demo_name }}
+
+      - name: Collect Docker Logs
+        continue-on-error: true
+        if: always()
+        uses: jwalton/gh-docker-logs@v2.2.0
+        with:
+          #images: '${{ env.WORKER_IMAGE_TAG }},${{ env.CLIENT_IMAGE_TAG }}'
+          tail: all
+          dest: './logs'
+
+      - name: Tar logs
+        if: always()
+        run: tar cvzf ./logs-${{ matrix.test }}-${{ matrix.mode }}.tgz ./logs
 
       - name: Upload logs
-        continue-on-error: true
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.test }}-${{ matrix.mode }}_logs
-          path: ${{ env.LOG_DIR }}
+          name: logs-${{ matrix.test }}-${{ matrix.mode }}.tgz
+          path: ./logs-${{ matrix.test }}-${{ matrix.mode }}.tgz
 
   release:
     name: Draft Release

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,10 +11,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  WORKER_BIN: integritee-service
-  CLIENT_BIN: integritee-cli
-  ENCLAVE_BIN: enclave.signed.so
-  LOG_DIR: log
+  LOG_DIR: logs
   BUILD_CONTAINER_NAME: integritee_worker_enclave_test
 
 jobs:
@@ -178,18 +175,14 @@ jobs:
         with:
           #images: '${{ env.WORKER_IMAGE_TAG }},${{ env.CLIENT_IMAGE_TAG }}'
           tail: all
-          dest: './logs'
-
-      - name: Tar logs
-        if: always()
-        run: tar cvzf ./logs-${{ matrix.test }}-${{ matrix.mode }}.tgz ./logs
+          dest: ./${{ env.LOG_DIR }}
 
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-${{ matrix.test }}-${{ matrix.mode }}.tgz
-          path: ./logs-${{ matrix.test }}-${{ matrix.mode }}.tgz
+          name: logs-${{ matrix.test }}-${{ matrix.mode }}
+          path: ./${{ env.LOG_DIR }}
 
   release:
     name: Draft Release

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -31,30 +31,13 @@ ENV SGX_MODE SW
 ARG WORKER_MODE_ARG
 ENV WORKER_MODE=$WORKER_MODE_ARG
 
-COPY . /root/work/worker/
 WORKDIR /root/work/worker
+COPY . .
 
-#RUN --mount=type=cache,target=/usr/local/cargo/registry \
-#	--mount=type=cache,target=/root/work/worker/target \
-#	make
 RUN make
 
-### Enclave Test Stage
-##################################################
-FROM builder AS enclave-test
+RUN cargo test --release
 
-WORKDIR /root/work/worker/bin
-
-CMD ./integritee-service test --all
-
-
-### Cargo Test Stage
-##################################################
-FROM builder AS cargo-test
-
-WORKDIR /root/work/worker
-
-CMD cargo test --release
 
 ### Base Runner Stage
 ##################################################

--- a/core/rpc-client/src/direct_client.rs
+++ b/core/rpc-client/src/direct_client.rs
@@ -68,6 +68,7 @@ impl DirectApi for DirectClient {
 
 		info!("[WorkerApi Direct]: (get) Sending request: {:?}", request);
 		WsClient::connect_one_shot(&self.url, request, port_in)?;
+		debug!("Waiting for web-socket result..");
 		port_out.recv().map_err(Error::MspcReceiver)
 	}
 

--- a/core/rpc-client/src/ws_client.rs
+++ b/core/rpc-client/src/ws_client.rs
@@ -84,6 +84,7 @@ impl WsClient {
 		result: &MpscSender<String>,
 		control: Arc<WsClientControl>,
 	) -> Result<()> {
+		debug!("Connecting web-socket connection with watch");
 		connect(url.to_string(), |out| {
 			control.subscribe_sender(out.clone()).expect("Failed sender subscription");
 			WsClient::new(out, request.to_string(), result.clone(), true)
@@ -92,7 +93,9 @@ impl WsClient {
 
 	/// Connects a web-socket client for a one-shot request.
 	pub fn connect_one_shot(url: &str, request: &str, result: MpscSender<String>) -> Result<()> {
+		debug!("Connecting one-shot web-socket connection");
 		connect(url.to_string(), |out| {
+			debug!("Create new web-socket client");
 			WsClient::new(out, request.to_string(), result.clone(), false)
 		})
 	}

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,7 +30,7 @@ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker compose.ym
 ```
 Run 
 ```
-docker compose --profile single-worker -f docker-compose.yml -f demo-indirect-invocation.yml up --exit-code-from demo-indirect-invocation
+docker compose -f docker-compose.yml -f demo-indirect-invocation.yml up --exit-code-from demo-indirect-invocation
 ```
 ### Demo direct call (M8)
 
@@ -40,7 +40,7 @@ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.ym
 ```
 Run
 ```
-docker compose --profile double-worker -f docker-compose.yml -f demo-direct-call.yml up --exit-code-from demo-direct-call
+docker compose -f docker-compose.yml -f demo-direct-call.yml up --exit-code-from demo-direct-call
 ```
 
 ### Demo sidechain
@@ -50,7 +50,7 @@ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.ym
 ```
 Run
 ```
-docker compose --profile double-worker -f docker-compose.yml -f demo-sidechain.yml up --exit-code-from demo-sidechain
+docker compose -f docker-compose.yml -f demo-sidechain.yml up --exit-code-from demo-sidechain
 ```
 
 ## Run the benchmarks
@@ -60,7 +60,7 @@ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.ym
 ```
 and then run with
 ```
-docker compose --profile double-worker -f docker-compose.yml -f benchmark.yml up --exit-code-from sidechain-benchmark
+docker compose -f docker-compose.yml -f benchmark.yml up --exit-code-from sidechain-benchmark
 ```
 
 ## Run the fork simulator

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,78 +26,78 @@ Starts all services (node and workers), using the `integritee-worker:dev` images
 ### Demo indirect invocation (M6)
 Build
 ```
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml -f demo-indirect-invocation.yml build --build-arg WORKER_MODE_ARG=offchain-worker
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker compose.yml -f demo-indirect-invocation.yml build --build-arg WORKER_MODE_ARG=offchain-worker
 ```
 Run 
 ```
-docker-compose -f docker-compose.yml -f demo-indirect-invocation.yml up --exit-code-from demo-indirect-invocation
+docker compose --profile single-worker -f docker-compose.yml -f demo-indirect-invocation.yml up --exit-code-from demo-indirect-invocation
 ```
 ### Demo direct call (M8)
 
 Build
 ```
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml -f demo-direct-call.yml build --build-arg WORKER_MODE_ARG=sidechain
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml -f demo-direct-call.yml build --build-arg WORKER_MODE_ARG=sidechain
 ```
 Run
 ```
-docker-compose -f docker-compose.yml -f demo-direct-call.yml up --exit-code-from demo-direct-call
+docker compose --profile double-worker -f docker-compose.yml -f demo-direct-call.yml up --exit-code-from demo-direct-call
 ```
 
 ### Demo sidechain
 Build
 ```
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml -f demo-sidechain.yml build --build-arg WORKER_MODE_ARG=sidechain
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml -f demo-sidechain.yml build --build-arg WORKER_MODE_ARG=sidechain
 ```
 Run
 ```
-docker-compose -f docker-compose.yml -f demo-sidechain.yml up --exit-code-from demo-sidechain
+docker compose --profile double-worker -f docker-compose.yml -f demo-sidechain.yml up --exit-code-from demo-sidechain
 ```
 
 ## Run the benchmarks
 Build with
 ```
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml -f benchmark.yml build
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml -f benchmark.yml build
 ```
 and then run with
 ```
-docker-compose -f docker-compose.yml -f benchmark.yml up --exit-code-from sidechain-benchmark
+docker compose --profile double-worker -f docker-compose.yml -f benchmark.yml up --exit-code-from sidechain-benchmark
 ```
 
 ## Run the fork simulator
 The fork simulation uses `pumba` which in turn uses the Linux traffic control (TC). This is only available on Linux hosts, not on Windows with WSL unfortunately.
-Build the docker-compose setup with
+Build the docker compose setup with
 ```
-COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.yml -f fork-inducer.yml -f demo-sidechain.yml build --build-arg WORKER_MODE_ARG=sidechain
+COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml -f fork-inducer.yml -f demo-sidechain.yml build --build-arg WORKER_MODE_ARG=sidechain
 ```
 
-This requires the docker BuildKit (docker version >= 18.09) and support for it in docker-compose (version >= 1.25.0)
+This requires the docker BuildKit (docker version >= 18.09) and support for it in docker compose (version >= 1.25.0)
 
 Run the 2-worker setup with a fork inducer (pumba) that delays the traffic on worker 2
 ```
-docker-compose -f docker-compose.yml -f fork-inducer.yml -f integration-test.yml up --exit-code-from demo-sidechain
+docker compose -f docker-compose.yml -f fork-inducer.yml -f integration-test.yml up --exit-code-from demo-sidechain
 ```
 
 This should show that the integration test fails, because we had an unhandled fork in the sidechain. Clean up the containers after each run with:
 ```
-docker-compose -f docker-compose.yml -f fork-inducer.yml -f demo-sidechain.yml down
+docker compose -f docker-compose.yml -f fork-inducer.yml -f demo-sidechain.yml down
 ```
 
-We need these different compose files to separate the services that we're using. E.g. we want the integration test and fork simulator to be optional. The same could be solved using `profiles` - but that requires a more up-to-date version of `docker-compose`.
+We need these different compose files to separate the services that we're using. E.g. we want the integration test and fork simulator to be optional. The same could be solved using `profiles` - but that requires a more up-to-date version of `docker compose`.
 
 ## FAQ
 ### What do I have to do to stop everything properly?
-With `Ctrl-C` you stop the containers and with `docker-compose down` you clean up/remove the containers. Note that `docker-compose down` will also remove any logs docker has saved, since it will remove all the container context.
+With `Ctrl-C` you stop the containers and with `docker compose down` you clean up/remove the containers. Note that `docker compose down` will also remove any logs docker has saved, since it will remove all the container context.
 
 ### What do I have to do if I make changes to the code?
-You need to re-build the worker image, using `docker-compose build`.
+You need to re-build the worker image, using `docker compose build`.
 
 ### How can I change the log level?
 You can change the environment variable `RUST_LOG=` in the `docker-compose.yml` for each worker individually.
 
 ### The log from the node are quite a nuisance. Why are they all together.
-You can suppress the log output for a container by setting the logging driver. This can be set to either `none` (completely disables all logs), or `local` (docker will record the logs, depending on you docker-compose version, it will also log to `stdout`) in the `docker-compose.yml`:
+You can suppress the log output for a container by setting the logging driver. This can be set to either `none` (completely disables all logs), or `local` (docker will record the logs, depending on your docker compose version, it will also log to `stdout`) in the `docker-compose.yml`:
 ```
 logging:
     driver: local
 ```
-Mind the indent. Explanations for all the logging drivers in `docker-compose` can be found [here](https://docs.docker.com/config/containers/logging/local/).
+Mind the indent. Explanations for all the logging drivers in `docker compose` can be found [here](https://docs.docker.com/config/containers/logging/local/).

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,7 +40,7 @@ COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose -f docker-compose.ym
 ```
 Run
 ```
-docker-compose -f docker-compose.yml -f integration-test.yml up --exit-code-from demo-direct-call
+docker-compose -f docker-compose.yml -f demo-direct-call.yml up --exit-code-from demo-direct-call
 ```
 
 ### Demo sidechain

--- a/docker/benchmark.yml
+++ b/docker/benchmark.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   sidechain-benchmark:
     image: integritee-cli:dev

--- a/docker/demo-direct-call.yml
+++ b/docker/demo-direct-call.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   demo-direct-call:
     image: integritee-cli:dev

--- a/docker/demo-indirect-invocation.yml
+++ b/docker/demo-indirect-invocation.yml
@@ -8,6 +8,8 @@ services:
       dockerfile: build.Dockerfile
       target: deployed-client
     depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    environment:
+      - RUST_LOG=warn,ws=warn,itc_rpc_client=debug
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s    

--- a/docker/demo-indirect-invocation.yml
+++ b/docker/demo-indirect-invocation.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   demo-indirect-invocation:
     image: integritee-cli:dev

--- a/docker/demo-indirect-invocation.yml
+++ b/docker/demo-indirect-invocation.yml
@@ -9,7 +9,7 @@ services:
       target: deployed-client
     depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
     environment:
-      - RUST_LOG=warn,ws=warn,itc_rpc_client=debug
+      - RUST_LOG=warn,ws=warn,itc_rpc_client=warn
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s    

--- a/docker/demo-sidechain.yml
+++ b/docker/demo-sidechain.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   demo-sidechain:
     image: integritee-cli:dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,9 +10,6 @@ services:
   integritee-worker-1:
     image: integritee-worker:dev
     container_name: integritee-worker-1
-    profiles:
-      - single-worker
-      - double-worker
     build:
       context: ..
       dockerfile: build.Dockerfile
@@ -30,8 +27,6 @@ services:
   integritee-worker-2:
     image: integritee-worker:dev
     container_name: integritee-worker-2
-    profiles:
-      - double-worker
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   integritee-node:
     image: "integritee/integritee-node-dev:1.0.14"
@@ -11,6 +10,9 @@ services:
   integritee-worker-1:
     image: integritee-worker:dev
     container_name: integritee-worker-1
+    profiles:
+      - single-worker
+      - double-worker
     build:
       context: ..
       dockerfile: build.Dockerfile
@@ -28,6 +30,8 @@ services:
   integritee-worker-2:
     image: integritee-worker:dev
     container_name: integritee-worker-2
+    profiles:
+      - double-worker
     build:
       context: ..
       dockerfile: build.Dockerfile

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     networks:
       - integritee-test-network
     command: --dev --rpc-methods unsafe --ws-external --rpc-external --ws-port 9912
-    logging:
-      driver: none
+    #logging:
+      #driver: local
   integritee-worker-1:
     image: integritee-worker:dev
     container_name: integritee-worker-1

--- a/docker/fork-inducer.yml
+++ b/docker/fork-inducer.yml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   worker-ping:
     image: worker-ping:dev

--- a/service/src/enclave/mod.rs
+++ b/service/src/enclave/mod.rs
@@ -1,2 +1,19 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 pub mod api;
 pub mod tls_ra;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -105,7 +105,6 @@ mod utils;
 mod worker;
 mod worker_peers_updater;
 
-/// how many blocks will be synced before storing the chain db to disk
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type EnclaveWorker =


### PR DESCRIPTION
Change CI integration tests to using docker images and a docker-compose setup. 
This makes the local python setup obsolete.

Closes #860 