### PR TITLE
Docker build with sccache and mount type=cache

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -42,9 +42,9 @@ ENV WORKER_MODE=$WORKER_MODE_ARG
 WORKDIR $HOME/worker
 COPY . .
 
-RUN --mount=type=cache,target=/root/work/.cache/sccache make && sccache --show-stats
+RUN --mount=type=cache,id=cargo,target=/root/work/.cache/sccache make && sccache --show-stats
 
-RUN cargo test --release
+RUN --mount=type=cache,id=cargo,target=/root/work/.cache/sccache cargo test --release && sccache --show-stats
 
 
 ### Base Runner Stage

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -28,13 +28,21 @@ ENV LD_LIBRARY_PATH "${LD_LIBRARY_PATH}:${SGX_SDK}/sdk_libs"
 ENV CARGO_NET_GIT_FETCH_WITH_CLI true
 ENV SGX_MODE SW
 
+ENV HOME=/root/work
+
+RUN rustup default stable && cargo install sccache --root /usr/local/cargo
+ENV PATH "$PATH:/usr/local/cargo/bin"
+ENV SCCACHE_CACHE_SIZE="3G"
+ENV SCCACHE_DIR=$HOME/.cache/sccache
+ENV RUSTC_WRAPPER="/usr/local/cargo/bin/sccache"
+
 ARG WORKER_MODE_ARG
 ENV WORKER_MODE=$WORKER_MODE_ARG
 
-WORKDIR /root/work/worker
+WORKDIR $HOME/worker
 COPY . .
 
-RUN make
+RUN --mount=type=cache,target=/root/work/.cache/sccache make && sccache --show-stats
 
 RUN cargo test --release
 

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -102,6 +102,7 @@ pub const CERTEXPIRYDAYS: i64 = 90i64;
 pub type Hash = sp_core::H256;
 pub type AuthorityPair = sp_core::ed25519::Pair;
 
+/// Initialize the enclave.
 #[no_mangle]
 pub unsafe extern "C" fn init(
 	mu_ra_addr: *const u8,


### PR DESCRIPTION
Another attempt at speeding up the build.

This time using `sccache` and BuildKit's `--mount type=cache ...`

**Update**: From https://github.com/moby/buildkit/issues/1673, I take it that for CI it will do nothing, since the cache is only kept on the (ephemeral) host. So this `sccache` will only speed-up local builds on dev machines. And probably slows down CI, since you have the whole cache setup, but cannot profit from it.