### PR TITLE
Remove needless `Invalid OperationStatus` response for Getter queries

### DIFF
--- a/core-primitives/top-pool/src/validated_pool.rs
+++ b/core-primitives/top-pool/src/validated_pool.rs
@@ -629,11 +629,6 @@ where
 			return vec![]
 		}
 
-		log::debug!(target: "txpool", "Removing invalid operations: {:?}", hashes);
-
-		// temporarily ban invalid operations
-		self.rotator.ban(&Instant::now(), hashes.iter().cloned());
-
 		let invalid = self.pool.write().unwrap().remove_subtree(hashes, shard);
 
 		log::debug!(target: "txpool", "Removed invalid operations: {:?}", invalid);
@@ -644,6 +639,8 @@ where
 				//listener.in_block(&tx.hash);
 			}
 		} else {
+			// temporarily ban invalid operations
+			self.rotator.ban(&Instant::now(), hashes.iter().cloned());
 			for tx in &invalid {
 				listener.invalid(&tx.hash);
 			}

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -221,7 +221,7 @@ pub mod tests {
 	}
 
 	#[test]
-	fn sending_state_successfully_sends_update_and_keeps_connection_open() {
+	fn sending_state_successfully_sends_update_and_removes_connection_token() {
 		let connection_hash = String::from("conn_hash");
 		let connection_registry = create_registry_with_single_connection(connection_hash.clone());
 
@@ -232,27 +232,8 @@ pub mod tests {
 		let result = rpc_responder.send_state(connection_hash.clone(), "new_state".encode());
 		assert!(result.is_ok());
 
-		verify_open_connection(&connection_hash, connection_registry);
+		verify_closed_connection(&connection_hash, connection_registry);
 		assert_eq!(1, websocket_responder.number_of_updates());
-	}
-
-	#[test]
-	fn sending_state_twice_works() {
-		let connection_hash = String::from("conn_hash");
-		let connection_registry = create_registry_with_single_connection(connection_hash.clone());
-
-		let websocket_responder = Arc::new(TestResponseChannel::default());
-		let rpc_responder =
-			RpcResponder::new(connection_registry.clone(), websocket_responder.clone());
-
-		let first_result = rpc_responder.send_state(connection_hash.clone(), "new_state".encode());
-		assert!(first_result.is_ok());
-
-		let second_result =
-			rpc_responder.send_state(connection_hash.clone(), "new_state_2".encode());
-		assert!(second_result.is_ok());
-
-		assert_eq!(2, websocket_responder.number_of_updates());
 	}
 
 	#[test]

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -124,8 +124,6 @@ where
 
 		self.encode_and_send_response(connection_token, &response)?;
 
-		self.connection_registry.store(hash, connection_token, response);
-
 		debug!("sending state successful");
 		Ok(())
 	}

--- a/sidechain/top-pool-executor/src/getter_operator.rs
+++ b/sidechain/top-pool-executor/src/getter_operator.rs
@@ -121,6 +121,6 @@ where
 		shard: &ShardIdentifier,
 		getter: TrustedOperationOrHash<H256>,
 	) -> Result<Vec<H256>> {
-		Ok(self.top_pool_author.remove_top(vec![getter], *shard, false)?)
+		Ok(self.top_pool_author.remove_top(vec![getter], *shard, true)?)
 	}
 }


### PR DESCRIPTION
fixes #481 by removing the secondary, unwanted `Invalid` OperationStatus response for a getter query.


Previous Getter responses:

First response:
`[2022-08-25T08:29:53Z DEBUG integritee_cli::trusted_operation] successfully decoded rpc response: RpcReturnValue { value: [1, 64, 152, 146, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], do_watch: false, status: TrustedOperationStatus(Submitted) }`
Second response:
`[2022-08-25T08:29:53Z DEBUG integritee_cli::trusted_operation] successfully decoded rpc response: RpcReturnValue { value: [1, 64, 152, 146, 152, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], do_watch: false, status: TrustedOperationStatus(Invalid) }`

Often perceived Error on the cli side:
``` 
* Send 25000000000 funds from Alice's incognito account to Bob's incognito account
send trusted call transfer from 5Dt1Wg85pXGLstt36t6TDdvXXoCtG6zkUL17KkyVaPYSrzGH to 5ERtCtRUchxue9PUysGKCpxPCVTzzJa3zzCKHLk5kUmCB6n4: 25000000000
thread '<unnamed>' panicked at 'Failed to send: SendError { .. }', core/rpc-client/src/ws_client.rs:126:43
```

This should now not be the case any more (checked the logs of the CI tests, there were indeed none)



PS: Minimal effort only. The big (yeah, totally necessary) clean-up will come with another issue: https://github.com/integritee-network/worker/issues/916