### PR TITLE
Access pallets directly and clean up helper functions

### DIFF
--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -14,9 +14,7 @@
 	limitations under the License.
 
 */
-use crate::{
-	stf_sgx_primitives::types::*, AccountId, Index, StfError, StfResult, ENCLAVE_ACCOUNT_KEY,
-};
+use crate::{AccountId, StfError, StfResult, ENCLAVE_ACCOUNT_KEY};
 use codec::{Decode, Encode};
 use itp_storage::{storage_double_map_key, storage_map_key, storage_value_key, StorageHasher};
 use itp_utils::stringify::account_id_to_string;
@@ -78,32 +76,6 @@ pub fn get_storage_by_key_hash<V: Decode>(key: Vec<u8>) -> Option<V> {
 /// Get the AccountInfo key where the account is stored.
 pub fn account_key_hash(account: &AccountId) -> Vec<u8> {
 	storage_map_key("System", "Account", account, &StorageHasher::Blake2_128Concat)
-}
-
-pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
-	let maybe_storage_map =
-		get_storage_map("System", "Account", who, &StorageHasher::Blake2_128Concat);
-	if maybe_storage_map.is_none() {
-		info!("Failed to get account info for account {}", account_id_to_string(who));
-	}
-	maybe_storage_map
-}
-
-pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
-	let expected_nonce = match get_account_info(who) {
-		None => {
-			info!(
-				"Attempted to validate account nonce of non-existent account: {}",
-				account_id_to_string(who)
-			);
-			0
-		},
-		Some(account_info) => account_info.nonce,
-	};
-	if expected_nonce == nonce {
-		return Ok(())
-	}
-	Err(StfError::InvalidNonce(nonce))
 }
 
 pub fn enclave_signer_account() -> AccountId {

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -106,18 +106,6 @@ pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 	Err(StfError::InvalidNonce(nonce))
 }
 
-pub fn account_data(account: &AccountId) -> Option<AccountData> {
-	if let Some(info) = get_account_info(account) {
-		Some(info.data)
-	} else {
-		info!(
-			"Attempted to get account data of non-existent account: {}",
-			account_id_to_string(account)
-		);
-		None
-	}
-}
-
 pub fn enclave_signer_account() -> AccountId {
 	get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).expect("No enclave account")
 }

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -106,36 +106,6 @@ pub fn validate_nonce(who: &AccountId, nonce: Index) -> StfResult<()> {
 	Err(StfError::InvalidNonce(nonce))
 }
 
-/// increment nonce after a successful call execution
-pub fn increment_nonce(account: &AccountId) {
-	//FIXME: Proper error handling - should be taken into
-	// consideration after implementing pay fee check
-	if let Some(mut acc_info) = get_account_info(account) {
-		debug!("incrementing account nonce");
-		acc_info.nonce += 1;
-		sp_io::storage::set(&account_key_hash(account), &acc_info.encode());
-		debug!(
-			"updated account {} nonce: {:?}",
-			account_id_to_string(account),
-			get_account_info(account).unwrap().nonce
-		);
-	} else {
-		error!(
-			"tried to increment nonce of a non-existent account: {}",
-			account_id_to_string(account)
-		)
-	}
-}
-
-pub fn account_nonce(account: &AccountId) -> Index {
-	if let Some(info) = get_account_info(account) {
-		info.nonce
-	} else {
-		info!("Attempted to get nonce of non-existent account: {}", account_id_to_string(account));
-		0_u32
-	}
-}
-
 pub fn account_data(account: &AccountId) -> Option<AccountData> {
 	if let Some(info) = get_account_info(account) {
 		Some(info.data)

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -15,7 +15,7 @@
 
 */
 use crate::{
-	stf_sgx_primitives::types::*, AccountId, Index, StfError, StfResult, ENCLAVE_ACCOUNT_KEY, H256,
+	stf_sgx_primitives::types::*, AccountId, Index, StfError, StfResult, ENCLAVE_ACCOUNT_KEY,
 };
 use codec::{Decode, Encode};
 use itp_storage::{storage_double_map_key, storage_map_key, storage_value_key, StorageHasher};
@@ -120,20 +120,6 @@ pub fn account_data(account: &AccountId) -> Option<AccountData> {
 
 pub fn enclave_signer_account() -> AccountId {
 	get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).expect("No enclave account")
-}
-
-// FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
-pub fn get_parentchain_blockhash() -> Option<H256> {
-	get_storage_value("Parentchain", "BlockHash")
-}
-
-// FIXME: Use Option<ParentchainHeader:Hash> as return type after fixing sgx-runtime issue #37
-pub fn get_parentchain_parenthash() -> Option<H256> {
-	get_storage_value("Parentchain", "ParentHash")
-}
-
-pub fn get_parentchain_number() -> Option<BlockNumber> {
-	get_storage_value("Parentchain", "Number")
 }
 
 /// Ensures an account is a registered enclave account.

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -118,10 +118,6 @@ pub fn account_data(account: &AccountId) -> Option<AccountData> {
 	}
 }
 
-pub fn root() -> AccountId {
-	get_storage_value("Sudo", "Key").expect("No root account")
-}
-
 pub fn enclave_signer_account() -> AccountId {
 	get_storage_value("Sudo", ENCLAVE_ACCOUNT_KEY).expect("No enclave account")
 }
@@ -152,13 +148,5 @@ pub fn ensure_enclave_signer_account(account: &AccountId) -> StfResult<()> {
 			account_id_to_string(account)
 		);
 		Err(StfError::RequireEnclaveSignerAccount)
-	}
-}
-
-pub fn ensure_root(account: AccountId) -> StfResult<()> {
-	if root() == account {
-		Ok(())
-	} else {
-		Err(StfError::MissingPrivileges(account))
 	}
 }

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -63,8 +63,6 @@ pub enum StfError {
 	Dispatch(String),
 	#[display(fmt = "Not enough funds to perform operation")]
 	MissingFunds,
-	#[display(fmt = "Account does not exist {:?}", _0)]
-	InexistentAccount(AccountId),
 	#[display(fmt = "Invalid Nonce {:?}", _0)]
 	InvalidNonce(Index),
 	StorageHashMismatch,

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -110,21 +110,19 @@ impl Stf {
 					Some(info.data.reserved.encode())
 				},
 				TrustedGetter::nonce(who) => {
-					let info = System::account(&who);
+					let nonce = System::account_nonce(&who);
 					debug!("TrustedGetter nonce");
-					debug!("AccountInfo for {} is {:?}", account_id_to_string(&who), info);
-					debug!("Account nonce is {}", info.nonce);
-					Some(info.nonce.encode())
+					debug!("Account nonce is {}", nonce);
+					Some(nonce.encode())
 				},
 				#[cfg(feature = "evm")]
 				TrustedGetter::evm_nonce(who) => {
 					let evm_account = get_evm_account(&who);
 					let evm_account = HashedAddressMapping::into_account_id(evm_account);
-					let info = System::account(&who);
+					let nonce = System::account_nonce(&evm_account);
 					debug!("TrustedGetter evm_nonce");
-					debug!("AccountInfo for {} is {:?}", account_id_to_string(&evm_account), info);
-					debug!("Account nonce is {}", info.nonce);
-					Some(info.nonce.encode())
+					debug!("Account nonce is {}", nonce);
+					Some(nonce.encode())
 				},
 				#[cfg(feature = "evm")]
 				TrustedGetter::evm_account_codes(_who, evm_account) =>

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -181,10 +181,7 @@ impl Stf {
 			validate_nonce(&sender, call.nonce)?;
 			match call.call {
 				TrustedCall::balance_set_balance(root, who, free_balance, reserved_balance) => {
-					ensure!(
-						Sudo::key().map_or(false, |k| root == k),
-						StfError::MissingPrivileges(sender)
-					);
+					ensure!(is_root(&root), StfError::MissingPrivileges(root));
 					debug!(
 						"balance_set_balance({}, {}, {})",
 						account_id_to_string(&who),
@@ -527,6 +524,9 @@ pub fn shards_key_hash() -> Vec<u8> {
 	vec![]
 }
 
+pub fn is_root(account: &AccountId) -> bool {
+	Sudo::key().map_or(false, |k| account == &k)
+}
 /// Trait extension to simplify sidechain data access from the STF.
 ///
 /// This should be removed when the refactoring of the STF has been done: #269

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -20,15 +20,15 @@ use crate::test_genesis::test_genesis_setup;
 
 use crate::{
 	helpers::{
-		account_data, account_nonce, enclave_signer_account, ensure_enclave_signer_account,
-		ensure_root, get_account_info, increment_nonce, root, validate_nonce,
+		account_data, enclave_signer_account, ensure_enclave_signer_account, ensure_root,
+		get_account_info, root, validate_nonce,
 	},
 	AccountData, AccountId, Getter, Index, ParentchainHeader, PublicGetter, ShardIdentifier, State,
 	StateTypeDiff, Stf, StfError, StfResult, TrustedCall, TrustedCallSigned, TrustedGetter,
 	ENCLAVE_ACCOUNT_KEY,
 };
 use codec::Encode;
-use ita_sgx_runtime::Runtime;
+use ita_sgx_runtime::{Runtime, System};
 use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_storage::storage_value_key;
 use itp_types::OpaqueCall;
@@ -310,7 +310,7 @@ impl Stf {
 						value
 					);
 					let nonce_evm_account =
-						account_nonce(&HashedAddressMapping::into_account_id(source));
+						System::account_nonce(&HashedAddressMapping::into_account_id(source));
 					ita_sgx_runtime::EvmCall::<Runtime>::create {
 						source,
 						init,
@@ -365,7 +365,7 @@ impl Stf {
 					Ok(())
 				},
 			}?;
-			increment_nonce(&sender);
+			System::inc_account_nonce(&sender);
 			Ok(())
 		})
 	}
@@ -500,7 +500,7 @@ impl Stf {
 
 	pub fn account_nonce(ext: &mut impl SgxExternalitiesTrait, account: &AccountId) -> Index {
 		ext.execute_with(|| {
-			let nonce = account_nonce(account);
+			let nonce = System::account_nonce(account);
 			debug!("Account {} nonce is {}", account_id_to_string(&account), nonce);
 			nonce
 		})

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -19,7 +19,7 @@
 use crate::test_genesis::test_genesis_setup;
 
 use crate::{
-	helpers::{enclave_signer_account, ensure_enclave_signer_account, validate_nonce},
+	helpers::{enclave_signer_account, ensure_enclave_signer_account},
 	AccountData, AccountId, Getter, Index, ParentchainHeader, PublicGetter, ShardIdentifier, State,
 	StateTypeDiff, Stf, StfError, StfResult, TrustedCall, TrustedCallSigned, TrustedGetter,
 	ENCLAVE_ACCOUNT_KEY,
@@ -162,7 +162,10 @@ impl Stf {
 		let call_hash = blake2_256(&call.encode());
 		ext.execute_with(|| {
 			let sender = call.call.sender_account().clone();
-			validate_nonce(&sender, call.nonce)?;
+			ensure!(
+				call.nonce == System::account_nonce(&sender),
+				StfError::InvalidNonce(call.nonce)
+			);
 			match call.call {
 				TrustedCall::balance_set_balance(root, who, free_balance, reserved_balance) => {
 					ensure!(is_root(&root), StfError::MissingPrivileges(root));

--- a/app-libs/stf/src/stf_sgx_tests.rs
+++ b/app-libs/stf/src/stf_sgx_tests.rs
@@ -27,7 +27,7 @@ pub fn enclave_account_initialization_works() {
 	let mut state = Stf::init_state(enclave_account.clone());
 	let _root = Stf::get_root(&mut state);
 
-	let account_data = Stf::account_data(&mut state, &enclave_account).unwrap();
+	let account_data = Stf::account_data(&mut state, &enclave_account);
 
 	assert_eq!(0, Stf::account_nonce(&mut state, &enclave_account));
 	assert_eq!(enclave_account, Stf::get_enclave_account(&mut state));
@@ -59,6 +59,6 @@ pub fn test_root_account_exists_after_initialization() {
 	let mut state = Stf::init_state(enclave_account.clone());
 	let root_account = Stf::get_root(&mut state);
 
-	let account_data = Stf::account_data(&mut state, &root_account).unwrap();
+	let account_data = Stf::account_data(&mut state, &root_account);
 	assert!(account_data.free > 0);
 }

--- a/app-libs/stf/src/test_genesis.rs
+++ b/app-libs/stf/src/test_genesis.rs
@@ -15,8 +15,8 @@
 
 */
 
-use crate::{helpers::get_account_info, StfError};
-use ita_sgx_runtime::{Balance, Runtime};
+use crate::StfError;
+use ita_sgx_runtime::{Balance, Runtime, System};
 use itp_sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 use itp_storage::storage_value_key;
 use log::*;
@@ -114,11 +114,8 @@ pub fn endow(
 			.unwrap();
 
 			let print_public: [u8; 32] = account.clone().into();
-			if let Some(info) = get_account_info(&print_public.into()) {
-				debug!("{:?} balance is {}", print_public, info.data.free);
-			} else {
-				debug!("{:?} balance is zero", print_public);
-			}
+			let account_info = System::account(&&print_public.into());
+			debug!("{:?} balance is {}", print_public, account_info.data.free);
 		}
 	});
 }

--- a/enclave-runtime/src/test/evm_pallet_tests.rs
+++ b/enclave-runtime/src/test/evm_pallet_tests.rs
@@ -16,13 +16,13 @@
 
 use crate::test::fixtures::test_setup::test_setup;
 use core::str::FromStr;
-use ita_sgx_runtime::{AddressMapping, HashedAddressMapping, Index};
+use ita_sgx_runtime::{AddressMapping, HashedAddressMapping, Index, System};
 use ita_stf::{
 	evm_helpers::{
 		create_code_hash, evm_create2_address, evm_create_address, get_evm_account_codes,
 		get_evm_account_storages,
 	},
-	helpers::{account_data, account_nonce},
+	helpers::account_data,
 	test_genesis::{endow, endowed_account as funded_pair},
 	KeyPair, State, Stf, TrustedCall,
 };
@@ -282,7 +282,7 @@ pub fn test_evm_create() {
 	.sign(&sender.clone().into(), 0, &mrenclave, &shard);
 
 	// Should be the first call of the evm account
-	let nonce = state.execute_with(|| account_nonce(&sender_evm_substrate_addr));
+	let nonce = state.execute_with(|| System::account_nonce(&sender_evm_substrate_addr));
 	assert_eq!(nonce, 0);
 	let execution_address = evm_create_address(sender_evm_acc, nonce);
 	Stf::execute(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
@@ -297,7 +297,7 @@ pub fn test_evm_create() {
 
 	// Ensure the nonce of the evm account has been increased by one
 	// Should be the first call of the evm account
-	let nonce = state.execute_with(|| account_nonce(&sender_evm_substrate_addr));
+	let nonce = state.execute_with(|| System::account_nonce(&sender_evm_substrate_addr));
 	assert_eq!(nonce, 1);
 }
 

--- a/enclave-runtime/src/test/evm_pallet_tests.rs
+++ b/enclave-runtime/src/test/evm_pallet_tests.rs
@@ -22,7 +22,6 @@ use ita_stf::{
 		create_code_hash, evm_create2_address, evm_create_address, get_evm_account_codes,
 		get_evm_account_storages,
 	},
-	helpers::account_data,
 	test_genesis::{endow, endowed_account as funded_pair},
 	KeyPair, State, Stf, TrustedCall,
 };
@@ -54,7 +53,10 @@ pub fn test_evm_call() {
 	let destination_evm_acc = H160::from_str("1000000000000000000000000000000000000001").unwrap();
 	let destination_evm_substrate_addr =
 		ita_sgx_runtime::HashedAddressMapping::into_account_id(destination_evm_acc);
-	assert!(state.execute_with(|| account_data(&destination_evm_substrate_addr).is_none()));
+	assert_eq!(
+		state.execute_with(|| System::account(&destination_evm_substrate_addr).data.free),
+		0
+	);
 
 	let transfer_value: u128 = 1_000_000_000;
 
@@ -78,7 +80,7 @@ pub fn test_evm_call() {
 	// then
 	assert_eq!(
 		transfer_value,
-		state.execute_with(|| account_data(&destination_evm_substrate_addr).unwrap().free)
+		state.execute_with(|| System::account(&destination_evm_substrate_addr).data.free)
 	);
 }
 

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -221,7 +221,7 @@ pub fn produce_sidechain_block_and_import_it() {
 	);
 
 	let mut state = state_handler.load(&shard_id).unwrap();
-	let free_balance = Stf::account_data(&mut state, &receiver.public().into()).unwrap().free;
+	let free_balance = Stf::account_data(&mut state, &receiver.public().into()).free;
 	assert_eq!(free_balance, transfered_amount);
 }
 

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -439,7 +439,7 @@ fn test_create_state_diff() {
 
 	// state diff should consist of the following updates:
 	// (last_hash, sidechain block_number, sender_funds, receiver_funds, [no clear, after polkadot_v0.9.26 update], events)
-	assert_eq!(state_diff.len(), 6);
+	assert_eq!(state_diff.len(), 5);
 	assert_eq!(receiver_acc_info.data.free, 1000);
 	assert_eq!(sender_acc_info.data.free, 1000);
 }

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -30,9 +30,7 @@ use crate::{
 use codec::{Decode, Encode};
 use ita_sgx_runtime::Parentchain;
 use ita_stf::{
-	helpers::{account_key_hash, get_account_info},
-	stf_sgx_tests,
-	test_genesis::{endowed_account as funded_pair, unendowed_account},
+	helpers::account_key_hash, stf_sgx_tests, test_genesis::endowed_account as funded_pair,
 	AccountInfo, ShardIdentifier, State, StatePayload, StateTypeDiff, Stf, TrustedCall,
 	TrustedCallSigned, TrustedGetter, TrustedOperation,
 };

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -436,7 +436,7 @@ fn test_create_state_diff() {
 		get_from_state_diff(&state_diff, &account_key_hash(&receiver.into()));
 
 	// state diff should consist of the following updates:
-	// (last_hash, sidechain block_number, sender_funds, receiver_funds, [no clear, after polkadot_v0.9.26 update], events)
+	// (last_hash, sidechain block_number, sender_funds, receiver_funds, [no clear, after polkadot_v0.9.26 update])
 	assert_eq!(state_diff.len(), 5);
 	assert_eq!(receiver_acc_info.data.free, 1000);
 	assert_eq!(sender_acc_info.data.free, 1000);


### PR DESCRIPTION
During my work with the Events, I noticed that we can access the pallet getters and their functions directly. This makes the use of many helper functions obsolete. 

Future steps: Let's not return an `Option` for `get_state`. This should now not necessary any more as well.

Changes:
- Access pallet functions directly: 
    for example, nonce access of accounts via substrate pallet frame (https://github.com/paritytech/substrate/blob/324a18e3c5cbf333672c54f9367f530ea976928d/frame/system/src/lib.rs#L1488-L1496)):
 ```rust 
System::inc_account_nonce(&sender);
```
instead of helper function
```rust
/// increment nonce after a successful call execution
pub fn increment_nonce(account: &AccountId) {
	//FIXME: Proper error handling - should be taken into
	// consideration after implementing pay fee check
	if let Some(mut acc_info) = get_account_info(account) {
		debug!("incrementing account nonce");
		acc_info.nonce += 1;
		sp_io::storage::set(&account_key_hash(account), &acc_info.encode());
		debug!(
			"updated account {} nonce: {:?}",
			account_id_to_string(account),
			get_account_info(account).unwrap().nonce
		);
	} else {
		error!(
			"tried to increment nonce of a non-existent account: {}",
			account_id_to_string(account)
		)
	}

```
- Access pallet storage directly via pallet defined getters
    for example, `Account` (https://github.com/paritytech/substrate/blob/324a18e3c5cbf333672c54f9367f530ea976928d/frame/system/src/lib.rs#L550-L557):
    is now:
```rust 
System::account(&account);
```
instead of helper function
```rust
pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
	let maybe_storage_map =
		get_storage_map("System", "Account", who, &StorageHasher::Blake2_128Concat);
	if maybe_storage_map.is_none() {
		info!("Failed to get account info for account {}", account_id_to_string(who));
	}
	maybe_storage_map
}
```