### PR TITLE
Do not enforce teeracle and sidechain pallet inclusion in node-runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ else
 	WORKER_FEATURES = --features=default,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 endif
 
-CLIENT_FEATURES = --features=$(ADDITIONAL_FEATURES)
+CLIENT_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 
 # check if running on Jenkins
 ifdef BUILD_ID

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -54,3 +54,7 @@ evm = [
     "ita-stf/evm_std",
     "pallet-evm"
 ]
+teeracle = []
+sidechain = []
+offchain-worker = []
+production = []

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -16,10 +16,7 @@
 */
 
 extern crate chrono;
-use crate::{
-	base_cli::BaseCli, trusted_commands::TrustedArgs,
-	Cli,
-};
+use crate::{base_cli::BaseCli, trusted_commands::TrustedArgs, Cli};
 use clap::Subcommand;
 
 #[derive(Subcommand)]

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -17,7 +17,7 @@
 
 extern crate chrono;
 use crate::{
-	base_cli::BaseCli, exchange_oracle::ExchangeOracleSubCommand, trusted_commands::TrustedArgs,
+	base_cli::BaseCli, trusted_commands::TrustedArgs,
 	Cli,
 };
 use clap::Subcommand;
@@ -32,14 +32,16 @@ pub enum Commands {
 	Trusted(TrustedArgs),
 
 	/// Subcommands for the exchange oracle.
+	#[cfg(feature = "teeracle")]
 	#[clap(subcommand)]
-	ExchangeOracle(ExchangeOracleSubCommand),
+	ExchangeOracle(crate::exchange_oracle::ExchangeOracleSubCommand),
 }
 
 pub fn match_command(cli: &Cli) {
 	match &cli.command {
 		Commands::Base(cmd) => cmd.run(cli),
 		Commands::Trusted(cmd) => cmd.run(cli),
+		#[cfg(feature = "teeracle")]
 		Commands::ExchangeOracle(cmd) => cmd.run(cli),
 	};
 }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -19,6 +19,9 @@ extern crate chrono;
 use crate::{base_cli::BaseCli, trusted_commands::TrustedArgs, Cli};
 use clap::Subcommand;
 
+#[cfg(feature = "teeracle")]
+crate::exchange_oracle::ExchangeOracleSubCommand;
+
 #[derive(Subcommand)]
 pub enum Commands {
 	#[clap(flatten)]
@@ -31,7 +34,7 @@ pub enum Commands {
 	/// Subcommands for the exchange oracle.
 	#[cfg(feature = "teeracle")]
 	#[clap(subcommand)]
-	ExchangeOracle(crate::exchange_oracle::ExchangeOracleSubCommand),
+	ExchangeOracle(ExchangeOracleSubCommand),
 }
 
 pub fn match_command(cli: &Cli) {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -20,7 +20,7 @@ use crate::{base_cli::BaseCli, trusted_commands::TrustedArgs, Cli};
 use clap::Subcommand;
 
 #[cfg(feature = "teeracle")]
-crate::exchange_oracle::ExchangeOracleSubCommand;
+use crate::exchange_oracle::ExchangeOracleSubCommand;
 
 #[derive(Subcommand)]
 pub enum Commands {

--- a/cli/src/exchange_oracle/commands/add_to_whitelist.rs
+++ b/cli/src/exchange_oracle/commands/add_to_whitelist.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use crate::{
 	command_utils::{get_chain_api, get_pair_from_str, mrenclave_from_base58},
 	Cli,

--- a/cli/src/exchange_oracle/commands/listen_to_exchange.rs
+++ b/cli/src/exchange_oracle/commands/listen_to_exchange.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 use crate::{command_utils::get_chain_api, Cli};
 use codec::Decode;
 use itp_node_api::api_client::ParentchainApi;

--- a/cli/src/exchange_oracle/commands/mod.rs
+++ b/cli/src/exchange_oracle/commands/mod.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 mod add_to_whitelist;
 mod listen_to_exchange;
 

--- a/cli/src/exchange_oracle/mod.rs
+++ b/cli/src/exchange_oracle/mod.rs
@@ -1,3 +1,20 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
 //! Add cli commands for the exchange-rate oracle
 //!
 //! Todo: This shall be a standalone crate in app-libs/exchange-oracle. However, this needs:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -33,6 +33,7 @@ mod command_utils;
 mod commands;
 #[cfg(feature = "evm")]
 mod evm;
+#[cfg(feature = "teeracle")]
 mod exchange_oracle;
 mod trusted_base_cli;
 mod trusted_command_utils;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -625,6 +625,7 @@ fn print_events(events: Events, _sender: Sender<String>) {
 					},
 				}
 			},
+			#[cfg(feature = "teeracle")]
 			Event::Teeracle(re) => {
 				debug!("{:?}", re);
 				match &re {
@@ -667,6 +668,7 @@ fn print_events(events: Events, _sender: Sender<String>) {
 					},
 				}
 			},
+			#[cfg(feature = "sidechain")]
 			Event::Sidechain(re) => match &re {
 				my_node_runtime::pallet_sidechain::Event::ProposedSidechainBlock(
 					sender,


### PR DESCRIPTION
- updates cli (teeracle-cli is now excluded in non-teeracle compile features)
- updates `print_events` in main.rs with additional compile features


Discovered while doing rebase for Ajuna. Ajuna node runtime does not include pallet_teeracle ( https://github.com/integritee-network/worker/blob/ef5cce1aa12c7ec169b0b64cde19331534afb066/cli/src/exchange_oracle/commands/listen_to_exchange.rs#L48). 

This should not be enforced.

Follow up issue: #981 