### PR TITLE
GitHub Actions: CI label checker enhancement

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -1,41 +1,24 @@
 name: Labels Check
 on:
   pull_request:
-    types: [opened, labeled, unlabeled, synchronize]
+    types: [opened, labeled, unlabeled, synchronize, ready_for_review]
 jobs:
   A-label-check:
-    if: github.base_ref == 'master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: danielchabr/pr-labels-checker@master
-        id: checkLabel
-        with:
-          hasSome: A0-core,A1-cli,A2-applibs,A3-sidechain,A4-offchain,A5-teeracle,A6-evm,A7-somethingelse
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/label-checker.yml
+    with:
+        predefined_labels: "A0-core,A1-cli,A2-applibs,A3-sidechain,A4-offchain,A5-teeracle,A6-evm,A7-somethingelse"
+
   B-label-check:
-    if: github.base_ref == 'master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: danielchabr/pr-labels-checker@master
-        id: checkLabel
-        with:
-          hasSome: B0-silent,B1-releasenotes
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/label-checker.yml
+    with:
+        predefined_labels: "B0-silent,B1-releasenotes"
+
   C-label-check:
-    if: github.base_ref == 'master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: danielchabr/pr-labels-checker@master
-        id: checkLabel
-        with:
-          hasSome: C1-low 📌,C3-medium 📣,C7-high ❗️,C9-critical ‼️
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/label-checker.yml
+    with:
+      predefined_labels: "C1-low 📌,C3-medium 📣,C7-high ❗️,C9-critical ‼️"
+
   E-label-check:
-    if: github.base_ref == 'master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: danielchabr/pr-labels-checker@master
-        id: checkLabel
-        with:
-          hasSome: E0-breaksnothing,E3-dependencies,E5-publicapi,E6-parentchain,E8-breakseverything
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/label-checker.yml
+    with:
+        predefined_labels: "E0-breaksnothing,E3-dependencies,E5-publicapi,E6-parentchain,E8-breakseverything"

--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -1,0 +1,21 @@
+name: Label checker
+on:
+  workflow_call:
+    inputs:
+      predefined_labels:
+        required: true
+        type: string
+
+jobs:
+    check_for_matching_labels:
+      runs-on: ubuntu-latest
+      if: github.base_ref == 'master' && github.event.pull_request.draft == false
+      steps:
+        - name: Label check
+          run: |
+            MATCH=$(jq -cn '${{ toJSON(github.event.pull_request.labels.*.name) }} as $USER_LABELS |
+            ${{ toJSON(inputs.predefined_labels)  }} | split(",") as $LABELS |
+            $USER_LABELS - ($USER_LABELS - $LABELS)')
+            if [[  "$MATCH" == '[]' ]]; then
+                exit 1
+            fi


### PR DESCRIPTION
The original action failed if the PR came from a fork, which is why it needed some enhancements.*

Some notes:
- The reason it uses `jq` instead of native GitHub Actions features is because a reusable workflow can only accept variables if their type is [one of: `boolean`, `number`, or `string`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_callinputsinput_idtype) and there is no builtin `hasSome()` function (unfortunately `contains()` can not look for multiple possbile values).
- Currently if PR has multiple labels from the same type (e.g, `A0` and `A1`) it will pass the check. If it should be limited to exactly one, then let me know and I'll patch it.


*: If somebody could submit a PR (a dummy commit is sufficient enough):
-  to my fork (https://github.com/OverOrion/worker/pulls)
-  targeting my master branch
- and adding the needed labels (A,B,C,E)

That would help me validate it before merging it upstream :)
Thanks in advance!


