### PR TITLE
Implement `next_key` in SGX `sp-io`

### DIFF
--- a/core-primitives/substrate-sgx/externalities/src/lib.rs
+++ b/core-primitives/substrate-sgx/externalities/src/lib.rs
@@ -24,7 +24,7 @@ extern crate sgx_tstd as std;
 use codec::{Decode, Encode};
 use derive_more::{Deref, DerefMut, From};
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, vec::Vec};
+use std::{collections::BTreeMap, ops::Bound, vec::Vec};
 
 pub use scope_limited::{set_and_run_with_externalities, with_externalities};
 
@@ -105,12 +105,8 @@ impl SgxExternalitiesTrait for SgxExternalities {
 
 	/// get the next key in state after the given one (excluded) in lexicographic order
 	fn next_storage_key(&self, key: &[u8]) -> Option<Vec<u8>> {
-		use std::ops::Bound;
 		let range = (Bound::Excluded(key), Bound::Unbounded);
-		self.state
-			.range::<[u8], _>(range)
-			.map(|(k, v)| (k.as_slice(), v))
-			.find_map(|(k, _v)| Some(k.to_vec())) // directly return k as _v is never None in our case
+		self.state.range::<[u8], _>(range).next().map(|(k, _v)| k.to_vec()) // directly return k as _v is never None in our case
 	}
 
 	/// prunes the state diff

--- a/core-primitives/substrate-sgx/sp-io/src/lib.rs
+++ b/core-primitives/substrate-sgx/sp-io/src/lib.rs
@@ -963,7 +963,7 @@ mod tests {
 	}
 
 	#[test]
-	fn storage_next_key_works() {
+	fn storage_set_and_next_key_works() {
 		let mut ext = SgxExternalities::default();
 
 		ext.execute_with(|| {
@@ -973,6 +973,7 @@ mod tests {
 		});
 
 		ext.execute_with(|| {
+			assert_eq!(storage::next_key(&[]), Some(b"doe".to_vec()));
 			assert_eq!(storage::next_key(b"d".to_vec().as_slice()), Some(b"doe".to_vec()));
 			assert_eq!(
 				storage::next_key(b"dog".to_vec().as_slice()),
@@ -985,5 +986,22 @@ mod tests {
 			assert_eq!(storage::next_key(b"dogglesworth".to_vec().as_slice()), None);
 			assert_eq!(storage::next_key(b"e".to_vec().as_slice()), None);
 		});
+	}
+
+	#[test]
+	fn storage_next_key_in_empty_externatility_works() {
+		let mut ext = SgxExternalities::default();
+		ext.execute_with(|| {
+			assert_eq!(storage::next_key(&[]), None);
+			assert_eq!(storage::next_key(b"dog".to_vec().as_slice()), None);
+		});
+	}
+
+	#[test]
+	#[should_panic(
+		expected = "`next_key` cannot be called outside of an Externalities-provided environment."
+	)]
+	fn storage_next_key_without_externalities_panics() {
+		storage::next_key(b"d".to_vec().as_slice());
 	}
 }

--- a/core-primitives/substrate-sgx/sp-io/src/lib.rs
+++ b/core-primitives/substrate-sgx/sp-io/src/lib.rs
@@ -252,8 +252,9 @@ pub mod storage {
 
 	/// Get the next key in storage after the given one in lexicographic order.
 	pub fn next_key(key: &[u8]) -> Option<Vec<u8>> {
-		warn!("storage::next_key unimplemented");
-		Some([0u8; 32].to_vec())
+		debug!("next_key('{}')", encode_hex(key));
+		with_externalities(|ext| ext.next_storage_key(key))
+			.expect("`next_key` cannot be called outside of an Externalities-provided environment.")
 	}
 
 	/// Start a new nested transaction.
@@ -959,5 +960,30 @@ mod tests {
 	)]
 	fn storage_set_without_externalities_panics() {
 		storage::set(b"hello", b"world");
+	}
+
+	#[test]
+	fn storage_next_key_works() {
+		let mut ext = SgxExternalities::default();
+
+		ext.execute_with(|| {
+			storage::set(b"doe".to_vec().as_slice(), b"reindeer".to_vec().as_slice());
+			storage::set(b"dog".to_vec().as_slice(), b"puppy".to_vec().as_slice());
+			storage::set(b"dogglesworth".to_vec().as_slice(), b"cat".to_vec().as_slice());
+		});
+
+		ext.execute_with(|| {
+			assert_eq!(storage::next_key(b"d".to_vec().as_slice()), Some(b"doe".to_vec()));
+			assert_eq!(
+				storage::next_key(b"dog".to_vec().as_slice()),
+				Some(b"dogglesworth".to_vec())
+			);
+			assert_eq!(
+				storage::next_key(b"doga".to_vec().as_slice()),
+				Some(b"dogglesworth".to_vec())
+			);
+			assert_eq!(storage::next_key(b"dogglesworth".to_vec().as_slice()), None);
+			assert_eq!(storage::next_key(b"e".to_vec().as_slice()), None);
+		});
 	}
 }


### PR DESCRIPTION
This PR tries to add a basic implementation of `next_key` in SGX sp-io which would have caused problems when doing iterator-based queries. Also see https://github.com/litentry/tee-worker/issues/84

In my (integration) tests with sgx runtime, `iter_values` and `iter_prefix` both work now.

As it's read-only I believe no change to `state_diff` is needed.
It's my first PR so please let me know if anything is inappropriate, thanks!