### PR TITLE
Rename label `E3-dependencies` to `E3-hardmerge`

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -21,4 +21,4 @@ jobs:
   E-label-check:
     uses: ./.github/workflows/label-checker.yml
     with:
-        predefined_labels: "E0-breaksnothing,E3-dependencies,E5-publicapi,E6-parentchain,E8-breakseverything"
+        predefined_labels: "E0-breaksnothing,E3-hardmerge,E5-publicapi,E6-parentchain,E8-breakseverything"


### PR DESCRIPTION
Label E3 now marks hard to merge PRs instead of a general breaking dependencies. 

General idea:
E5+ labels are breaking changes, everything below marks something that does not break an interface.

Linked issue: #961  

