### PR TITLE
Keep state in-memory, write snapshots to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3264,8 +3264,8 @@ dependencies = [
 name = "itp-stf-state-handler"
 version = "0.9.0"
 dependencies = [
- "ita-sgx-runtime",
  "ita-stf",
+ "itp-hashing",
  "itp-settings",
  "itp-sgx-crypto",
  "itp-sgx-externalities",
@@ -3279,7 +3279,6 @@ dependencies = [
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
- "sgx_crypto_helper",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -17,7 +17,7 @@ sgx_tstd = { branch = "master", features = ["untrusted_fs", "net", "backtrace"],
 
 # local crates
 ita-sgx-runtime = { default-features = false, path = "../sgx-runtime" }
-itp-hashing = { path = "../../core-primitives/hashing" }
+itp-hashing = { default-features = false, path = "../../core-primitives/hashing" }
 itp-sgx-externalities = { default-features = false, path = "../../core-primitives/substrate-sgx/externalities" }
 itp-stf-interface = { default-features = false, path = "../../core-primitives/stf-interface" }
 itp-storage = { default-features = false, path = "../../core-primitives/storage" }
@@ -62,6 +62,7 @@ std = [
     "rlp/std",
     # local
     "ita-sgx-runtime/std",
+    "itp-hashing/std",
     "itp-sgx-externalities/std",
     "itp-stf-interface/std",
     "itp-storage/std",

--- a/core-primitives/hashing/Cargo.toml
+++ b/core-primitives/hashing/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.9.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 
-
 [dependencies]
 # substrate
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
+
+[features]
+default = ["std"]
+std = []

--- a/core-primitives/hashing/src/lib.rs
+++ b/core-primitives/hashing/src/lib.rs
@@ -18,13 +18,29 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use sp_core::H256;
+
+#[cfg(feature = "std")]
+pub mod std_hash;
+
 /// Trait to compute a hash of self.
 pub trait Hash<Output> {
 	fn hash(&self) -> Output;
 }
 
-pub fn hash_from_slice(hash_slize: &[u8]) -> sp_core::H256 {
+// Cannot use the implementation below unfortunately, because our externalities
+// have their own hash implementation which ignores the state diff.
+// /// Implement Hash<H256> for any types that implement encode.
+// ///
+// ///
+// impl<T: Encode> Hash<H256> for T {
+// 	fn hash(&self) -> H256 {
+// 		blake2_256(&self.encode()).into()
+// 	}
+// }
+
+pub fn hash_from_slice(hash_slize: &[u8]) -> H256 {
 	let mut g = [0; 32];
 	g.copy_from_slice(hash_slize);
-	sp_core::H256::from(&mut g)
+	H256::from(&mut g)
 }

--- a/core-primitives/hashing/src/std_hash.rs
+++ b/core-primitives/hashing/src/std_hash.rs
@@ -15,6 +15,17 @@
 
 */
 
-pub mod initialize_state_mock;
-pub mod state_key_repository_mock;
-pub mod versioned_state_access_mock;
+use crate::Hash;
+use std::{
+	collections::hash_map::DefaultHasher,
+	hash::{Hash as StdHash, Hasher},
+};
+
+/// Implement Hash<u64> for all types implementing core::hash::Hash.
+impl<T: StdHash> Hash<u64> for T {
+	fn hash(&self) -> u64 {
+		let mut hasher = DefaultHasher::new();
+		self.hash(&mut hasher);
+		hasher.finish()
+	}
+}

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -65,7 +65,7 @@ pub mod files {
 	pub static RA_API_KEY_FILE: &str = "key.txt";
 
 	pub const SPID_MIN_LENGTH: usize = 32;
-	pub const STATE_SNAPSHOTS_CACHE_SIZE: usize = 120;
+	pub const STATE_SNAPSHOTS_CACHE_SIZE: usize = 4;
 }
 
 /// Settings concerning the worker

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -6,14 +6,13 @@ edition = "2021"
 
 [dependencies]
 # sgx dependencies
-sgx_crypto_helper = { default-features = false, optional = true, features = ["mesalock_sgx"], version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "v1.1.6-testing" }
 sgx_tcrypto = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local dependencies
-ita-sgx-runtime = { path = "../../app-libs/sgx-runtime", default-features = false }
 ita-stf = { path = "../../app-libs/stf", default-features = false }
+itp-hashing = { path = "../../core-primitives/hashing", default-features = false }
 itp-settings = { path = "../../core-primitives/settings" }
 itp-sgx-crypto = { path = "../../core-primitives/sgx/crypto", default-features = false }
 itp-sgx-externalities = { default-features = false, path = "../../core-primitives/substrate-sgx/externalities" }
@@ -40,12 +39,12 @@ sp-core = { default-features = false, features = ["full_crypto"], git = "https:/
 [dev-dependencies]
 itp-sgx-crypto = { path = "../../core-primitives/sgx/crypto", features = ["mocks"] }
 itp-stf-state-observer = { path = "../stf-state-observer", features = ["mocks"] }
+itp-hashing = { path = "../../core-primitives/hashing", features = ["std"] }
 
 [features]
 default = ["std"]
 std = [
     "rust-base58",
-    "ita-sgx-runtime/std",
     "ita-stf/std",
     "itp-sgx-crypto/std",
     "itp-sgx-externalities/std",
@@ -72,5 +71,4 @@ sgx = [
 test = [
     "itp-sgx-crypto/mocks",
     "itp-stf-interface/mocks",
-    "sgx_crypto_helper/mesalock_sgx",
 ]

--- a/core-primitives/stf-state-handler/src/lib.rs
+++ b/core-primitives/stf-state-handler/src/lib.rs
@@ -37,6 +37,7 @@ pub mod handle_state;
 pub mod in_memory_state_file_io;
 pub mod query_shard_state;
 pub mod state_handler;
+pub mod state_initializer;
 mod state_snapshot_primitives;
 pub mod state_snapshot_repository;
 pub mod state_snapshot_repository_loader;

--- a/core-primitives/stf-state-handler/src/state_handler.rs
+++ b/core-primitives/stf-state-handler/src/state_handler.rs
@@ -25,144 +25,261 @@ use crate::{
 	error::{Error, Result},
 	handle_state::HandleState,
 	query_shard_state::QueryShardState,
+	state_initializer::InitializeState,
 	state_snapshot_repository::VersionedStateAccess,
 };
+use itp_hashing::Hash;
+use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_stf_state_observer::traits::UpdateState;
 use itp_types::ShardIdentifier;
-use std::{sync::Arc, vec::Vec};
+use std::{collections::HashMap, sync::Arc, vec::Vec};
+
+type StatesMap<State, Hash> = HashMap<ShardIdentifier, (State, Hash)>;
 
 /// Implementation of the `HandleState` trait.
 ///
-/// It's a concurrency wrapper around a state snapshot repository, which handles
-/// access to any shards and state files. The state handler ensures we have thread-safe
-/// concurrent access to that repository.
-pub struct StateHandler<Repository, StateObserver> {
+/// Responsible for handling any state instances. Holds a map with all the latest states for each shard.
+/// In addition, uses the snapshot repository to save file snapshots of a state.
+pub struct StateHandler<Repository, StateObserver, StateInitializer>
+where
+	Repository: VersionedStateAccess,
+{
 	state_snapshot_repository: RwLock<Repository>,
+	states_map_lock: RwLock<StatesMap<Repository::StateType, Repository::HashType>>,
 	state_observer: Arc<StateObserver>,
+	state_initializer: Arc<StateInitializer>,
 }
 
-impl<Repository, StateObserver> StateHandler<Repository, StateObserver> {
-	pub fn new(state_snapshot_repository: Repository, state_observer: Arc<StateObserver>) -> Self {
+impl<Repository, StateObserver, StateInitializer>
+	StateHandler<Repository, StateObserver, StateInitializer>
+where
+	Repository: VersionedStateAccess,
+	Repository::StateType: Hash<Repository::HashType>,
+	StateObserver: UpdateState<Repository::StateType>,
+	StateInitializer: InitializeState<StateType = Repository::StateType>,
+{
+	/// Creates a new instance WITHOUT loading any state from the repository.
+	/// Results in an empty states map.
+	pub fn new(
+		state_snapshot_repository: Repository,
+		state_observer: Arc<StateObserver>,
+		state_initializer: Arc<StateInitializer>,
+	) -> Self {
+		Self::new_with_states_map(
+			state_snapshot_repository,
+			state_observer,
+			state_initializer,
+			Default::default(),
+		)
+	}
+
+	/// Create a new state handler and initialize its state map with the
+	/// states that are available in the snapshot repository.
+	pub fn load_from_repository(
+		state_snapshot_repository: Repository,
+		state_observer: Arc<StateObserver>,
+		state_initializer: Arc<StateInitializer>,
+	) -> Result<Self> {
+		let states_map = Self::load_all_latest_snapshots(&state_snapshot_repository)?;
+		Ok(Self::new_with_states_map(
+			state_snapshot_repository,
+			state_observer,
+			state_initializer,
+			states_map,
+		))
+	}
+
+	fn new_with_states_map(
+		state_snapshot_repository: Repository,
+		state_observer: Arc<StateObserver>,
+		state_initializer: Arc<StateInitializer>,
+		states_map: StatesMap<Repository::StateType, Repository::HashType>,
+	) -> Self {
 		StateHandler {
 			state_snapshot_repository: RwLock::new(state_snapshot_repository),
+			states_map_lock: RwLock::new(states_map),
 			state_observer,
+			state_initializer,
 		}
+	}
+
+	fn load_all_latest_snapshots(
+		state_snapshot_repository: &Repository,
+	) -> Result<StatesMap<Repository::StateType, Repository::HashType>> {
+		let shards = state_snapshot_repository.list_shards()?;
+
+		let r = shards
+			.into_iter()
+			.map(|shard| state_snapshot_repository.load_latest(&shard).map(|state| (state, shard)))
+			// Fill the pairs for state and shard into a map.
+			// Log an error for cases where state could not be loaded.
+			.fold(StatesMap::default(), |mut map, x| {
+				match x {
+					Ok((state, shard)) => {
+						let state_hash = state.hash();
+						map.insert(shard, (state, state_hash));
+					},
+					Err(e) => {
+						log::error!("Failed to load state from snapshot repository {:?}", e);
+					},
+				};
+				map
+			});
+
+		Ok(r)
+	}
+
+	fn update_state_snapshot(
+		&self,
+		shard: &ShardIdentifier,
+		state: &Repository::StateType,
+		state_hash: Repository::HashType,
+	) -> Result<()> {
+		let mut state_snapshots_lock =
+			self.state_snapshot_repository.write().map_err(|_| Error::LockPoisoning)?;
+
+		state_snapshots_lock.update(shard, state, state_hash)
 	}
 }
 
-impl<Repository, StateObserver> HandleState for StateHandler<Repository, StateObserver>
+impl<Repository, StateObserver, StateInitializer> HandleState
+	for StateHandler<Repository, StateObserver, StateInitializer>
 where
 	Repository: VersionedStateAccess,
+	Repository::StateType: SgxExternalitiesTrait + Hash<Repository::HashType>,
+	Repository::HashType: Copy,
 	StateObserver: UpdateState<Repository::StateType>,
+	StateInitializer: InitializeState<StateType = Repository::StateType>,
 {
-	type WriteLockPayload = Repository;
+	type WriteLockPayload = StatesMap<Repository::StateType, Repository::HashType>;
 	type StateT = Repository::StateType;
 	type HashType = Repository::HashType;
 
 	fn initialize_shard(&self, shard: ShardIdentifier) -> Result<Self::HashType> {
-		let mut state_write_lock =
-			self.state_snapshot_repository.write().map_err(|_| Error::LockPoisoning)?;
-		state_write_lock.initialize_new_shard(shard)
+		let initialized_state = self.state_initializer.initialize()?;
+		self.reset(initialized_state, &shard)
 	}
 
 	fn load(&self, shard: &ShardIdentifier) -> Result<Self::StateT> {
-		self.state_snapshot_repository
+		let state = self
+			.states_map_lock
 			.read()
 			.map_err(|_| Error::LockPoisoning)?
-			.load_latest(shard)
+			.get(shard)
+			.ok_or(Error::InvalidShard(*shard))?
+			.0
+			.clone();
+
+		Ok(state)
 	}
 
 	fn load_for_mutation(
 		&self,
 		shard: &ShardIdentifier,
 	) -> Result<(RwLockWriteGuard<'_, Self::WriteLockPayload>, Self::StateT)> {
-		let state_write_lock =
-			self.state_snapshot_repository.write().map_err(|_| Error::LockPoisoning)?;
-		let loaded_state = state_write_lock.load_latest(shard)?;
-		Ok((state_write_lock, loaded_state))
+		let state_write_lock = self.states_map_lock.write().map_err(|_| Error::LockPoisoning)?;
+		let state_clone = state_write_lock.get(shard).ok_or(Error::InvalidShard(*shard))?.0.clone();
+
+		Ok((state_write_lock, state_clone))
 	}
 
 	fn write_after_mutation(
 		&self,
-		state: Self::StateT,
+		mut state: Self::StateT,
 		mut state_lock: RwLockWriteGuard<'_, Self::WriteLockPayload>,
 		shard: &ShardIdentifier,
 	) -> Result<Self::HashType> {
+		state.prune_state_diff(); // Remove state diff before storing.
+		let state_hash = state.hash();
 		// We create a state copy here, in order to serve the state observer. This does not scale
 		// well and we will want a better solution in the future, maybe with #459.
-		let state_hash = state_lock.update(shard, state.clone())?;
+		state_lock.insert(*shard, (state.clone(), state_hash));
 		drop(state_lock); // Drop the write lock as early as possible.
+
+		self.update_state_snapshot(shard, &state, state_hash)?;
 
 		self.state_observer.queue_state_update(*shard, state)?;
 		Ok(state_hash)
 	}
 
 	fn reset(&self, state: Self::StateT, shard: &ShardIdentifier) -> Result<Self::HashType> {
-		let mut state_write_lock =
-			self.state_snapshot_repository.write().map_err(|_| Error::LockPoisoning)?;
-
-		// We create a state copy here, in order to serve the state observer. This does not scale
-		// well and we will want a better solution in the future, maybe with #459.
-		let state_hash = state_write_lock.update(shard, state.clone())?;
-		drop(state_write_lock); // Drop the write lock as early as possible.
-
-		self.state_observer.queue_state_update(*shard, state)?;
-		Ok(state_hash)
+		let state_write_lock = self.states_map_lock.write().map_err(|_| Error::LockPoisoning)?;
+		self.write_after_mutation(state, state_write_lock, shard)
 	}
 }
 
-impl<Repository, StateObserver> QueryShardState for StateHandler<Repository, StateObserver>
+impl<Repository, StateObserver, StateInitializer> QueryShardState
+	for StateHandler<Repository, StateObserver, StateInitializer>
 where
 	Repository: VersionedStateAccess,
+	Repository::StateType: Hash<Repository::HashType>,
+	StateObserver: UpdateState<Repository::StateType>,
+	StateInitializer: InitializeState<StateType = Repository::StateType>,
 {
 	fn shard_exists(&self, shard: &ShardIdentifier) -> Result<bool> {
-		let registry_lock =
-			self.state_snapshot_repository.read().map_err(|_| Error::LockPoisoning)?;
-
-		Ok(registry_lock.shard_exists(shard))
+		let states_map_lock = self.states_map_lock.read().map_err(|_| Error::LockPoisoning)?;
+		Ok(states_map_lock.contains_key(shard))
 	}
 
 	fn list_shards(&self) -> Result<Vec<ShardIdentifier>> {
-		self.state_snapshot_repository
-			.read()
-			.map_err(|_| Error::LockPoisoning)?
-			.list_shards()
+		let states_map_lock = self.states_map_lock.read().map_err(|_| Error::LockPoisoning)?;
+		Ok(states_map_lock.keys().cloned().collect())
 	}
 }
 
 #[cfg(test)]
 mod tests {
-
 	use super::*;
-	use crate::test::mocks::versioned_state_access_mock::VersionedStateAccessMock;
-	use itp_stf_state_observer::mock::UpdateStateMock;
-	use std::{
-		collections::{HashMap, VecDeque},
-		sync::Arc,
-		thread,
+	use crate::test::mocks::{
+		initialize_state_mock::InitializeStateMock,
+		versioned_state_access_mock::VersionedStateAccessMock,
 	};
+	use codec::Encode;
+	use itp_sgx_externalities::{SgxExternalities, SgxExternalitiesType};
+	use itp_stf_state_observer::mock::UpdateStateMock;
+	use itp_types::H256;
+	use std::{collections::VecDeque, sync::Arc, thread};
 
-	type TestState = u64;
-	type TestHash = u64;
+	type TestState = SgxExternalities;
+	type TestHash = H256;
 	type TestStateRepository = VersionedStateAccessMock<TestState, TestHash>;
 	type TestStateObserver = UpdateStateMock<TestState>;
-	type TestStateHandler = StateHandler<TestStateRepository, TestStateObserver>;
+	type TestStateInitializer = InitializeStateMock<TestState>;
+	type TestStateHandler =
+		StateHandler<TestStateRepository, TestStateObserver, TestStateInitializer>;
+
+	fn create_state(content: u64) -> TestState {
+		let mut state = TestState::new(SgxExternalitiesType::default());
+		state.insert("key_1".encode(), content.encode());
+		state
+	}
+
+	fn create_state_without_diff(content: u64) -> TestState {
+		let state = create_state(content);
+		prune_diff(state)
+	}
+
+	fn prune_diff(mut state: TestState) -> TestState {
+		state.prune_state_diff();
+		state
+	}
 
 	#[test]
 	fn load_for_mutation_blocks_any_concurrent_access() {
 		let shard_id = ShardIdentifier::random();
-		let state_handler = default_state_handler(&shard_id);
+		let state_handler = default_state_handler();
+		state_handler.initialize_shard(shard_id).unwrap();
 
 		let (lock, _s) = state_handler.load_for_mutation(&shard_id).unwrap();
-		let new_state = 4u64;
 
 		let state_handler_clone = state_handler.clone();
 		let join_handle = thread::spawn(move || {
 			let latest_state = state_handler_clone.load(&shard_id).unwrap();
-			assert_eq!(new_state, latest_state);
+			assert_eq!(create_state_without_diff(4u64), latest_state);
 		});
 
-		let _hash = state_handler.write_after_mutation(new_state, lock, &shard_id).unwrap();
+		let _hash =
+			state_handler.write_after_mutation(create_state(4u64), lock, &shard_id).unwrap();
 
 		join_handle.join().unwrap();
 	}
@@ -171,26 +288,32 @@ mod tests {
 	fn write_and_reset_queue_observer_update() {
 		let shard_id = ShardIdentifier::default();
 		let state_observer = Arc::new(TestStateObserver::default());
-		let state_handler =
-			Arc::new(TestStateHandler::new(default_repository(&shard_id), state_observer.clone()));
+		let state_initializer = Arc::new(TestStateInitializer::new(Default::default()));
+		let state_handler = Arc::new(TestStateHandler::new(
+			default_repository(),
+			state_observer.clone(),
+			state_initializer,
+		));
+		state_handler.initialize_shard(shard_id).unwrap();
 
 		let (lock, _s) = state_handler.load_for_mutation(&shard_id).unwrap();
-		let new_state = 4u64;
-		state_handler.write_after_mutation(new_state, lock, &shard_id).unwrap();
+		let new_state = create_state(4u64);
+		state_handler.write_after_mutation(new_state.clone(), lock, &shard_id).unwrap();
 
-		let reset_state = 5u64;
-		state_handler.reset(reset_state, &shard_id).unwrap();
+		let reset_state = create_state(5u64);
+		state_handler.reset(reset_state.clone(), &shard_id).unwrap();
 
 		let observer_updates = state_observer.queued_updates.read().unwrap().clone();
-		assert_eq!(2, observer_updates.len());
-		assert_eq!((shard_id, new_state), observer_updates[0]);
-		assert_eq!((shard_id, reset_state), observer_updates[1]);
+		assert_eq!(3, observer_updates.len());
+		assert_eq!((shard_id, prune_diff(new_state)), observer_updates[1]);
+		assert_eq!((shard_id, prune_diff(reset_state)), observer_updates[2]);
 	}
 
 	#[test]
 	fn load_initialized_works() {
 		let shard_id = ShardIdentifier::random();
-		let state_handler = default_state_handler(&shard_id);
+		let state_handler = default_state_handler();
+		state_handler.initialize_shard(shard_id).unwrap();
 		assert!(state_handler.load(&shard_id).is_ok());
 		assert!(state_handler.load(&ShardIdentifier::random()).is_err());
 	}
@@ -198,24 +321,73 @@ mod tests {
 	#[test]
 	fn list_shards_works() {
 		let shard_id = ShardIdentifier::random();
-		let state_handler = default_state_handler(&shard_id);
-		assert!(state_handler.list_shards().is_ok());
+		let state_handler = default_state_handler();
+		state_handler.initialize_shard(shard_id).unwrap();
+		assert_eq!(1, state_handler.list_shards().unwrap().len());
 	}
 
 	#[test]
 	fn shard_exists_works() {
 		let shard_id = ShardIdentifier::random();
-		let state_handler = default_state_handler(&shard_id);
+		let state_handler = default_state_handler();
+		state_handler.initialize_shard(shard_id).unwrap();
 		assert!(state_handler.shard_exists(&shard_id).unwrap());
 		assert!(!state_handler.shard_exists(&ShardIdentifier::random()).unwrap());
 	}
 
-	fn default_state_handler(shard: &ShardIdentifier) -> Arc<TestStateHandler> {
+	#[test]
+	fn load_from_repository_works() {
 		let state_observer = Arc::new(TestStateObserver::default());
-		Arc::new(TestStateHandler::new(default_repository(shard), state_observer))
+		let state_initializer = Arc::new(TestStateInitializer::new(Default::default()));
+
+		let repository = TestStateRepository::new(HashMap::from([
+			(
+				ShardIdentifier::from([1u8; 32]),
+				VecDeque::from([create_state(3), create_state(2), create_state(1)]),
+			),
+			(ShardIdentifier::from([2u8; 32]), VecDeque::from([create_state(5)])),
+			(ShardIdentifier::from([3u8; 32]), VecDeque::new()),
+		]));
+
+		assert_eq!(3, repository.list_shards().unwrap().len());
+		assert!(repository.load_latest(&ShardIdentifier::from([3u8; 32])).is_err());
+
+		let state_handler =
+			TestStateHandler::load_from_repository(repository, state_observer, state_initializer)
+				.unwrap();
+
+		assert_eq!(
+			2,
+			state_handler.list_shards().unwrap().len(),
+			"Only 2 shards, not 3, because 3rd was empty"
+		);
 	}
 
-	fn default_repository(shard: &ShardIdentifier) -> TestStateRepository {
-		TestStateRepository::new(HashMap::from([(*shard, VecDeque::from([1, 2, 3]))]))
+	#[test]
+	fn ensure_state_diff_is_discarded() {
+		let shard_id = ShardIdentifier::random();
+		let state_handler = default_state_handler();
+
+		let state = create_state(3u64);
+		let state_without_diff = {
+			let mut state_clone = state.clone();
+			state_clone.prune_state_diff();
+			state_clone
+		};
+
+		state_handler.reset(state, &shard_id).unwrap();
+		let loaded_state = state_handler.load(&shard_id).unwrap();
+
+		assert_eq!(state_without_diff, loaded_state);
+	}
+
+	fn default_state_handler() -> Arc<TestStateHandler> {
+		let state_observer = Arc::new(TestStateObserver::default());
+		let state_initializer = Arc::new(TestStateInitializer::new(Default::default()));
+		Arc::new(TestStateHandler::new(default_repository(), state_observer, state_initializer))
+	}
+
+	fn default_repository() -> TestStateRepository {
+		TestStateRepository::default()
 	}
 }

--- a/core-primitives/stf-state-handler/src/state_handler.rs
+++ b/core-primitives/stf-state-handler/src/state_handler.rs
@@ -166,7 +166,7 @@ where
 			.read()
 			.map_err(|_| Error::LockPoisoning)?
 			.get(shard)
-			.ok_or(Error::InvalidShard(*shard))?
+			.ok_or_else(|| Error::InvalidShard(*shard))?
 			.0
 			.clone();
 
@@ -178,7 +178,11 @@ where
 		shard: &ShardIdentifier,
 	) -> Result<(RwLockWriteGuard<'_, Self::WriteLockPayload>, Self::StateT)> {
 		let state_write_lock = self.states_map_lock.write().map_err(|_| Error::LockPoisoning)?;
-		let state_clone = state_write_lock.get(shard).ok_or(Error::InvalidShard(*shard))?.0.clone();
+		let state_clone = state_write_lock
+			.get(shard)
+			.ok_or_else(|| Error::InvalidShard(*shard))?
+			.0
+			.clone();
 
 		Ok((state_write_lock, state_clone))
 	}

--- a/core-primitives/stf-state-handler/src/state_initializer.rs
+++ b/core-primitives/stf-state-handler/src/state_initializer.rs
@@ -1,0 +1,64 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::error::Result;
+use core::marker::PhantomData;
+use itp_sgx_crypto::{ed25519_derivation::DeriveEd25519, key_repository::AccessKey};
+use itp_stf_interface::InitState;
+use itp_types::AccountId;
+use sp_core::Pair;
+use std::sync::Arc;
+
+/// Create and initialize a new state instance.
+pub trait InitializeState {
+	type StateType;
+
+	fn initialize(&self) -> Result<Self::StateType>;
+}
+
+pub struct StateInitializer<State, Stf, ShieldingKeyRepository> {
+	shielding_key_repository: Arc<ShieldingKeyRepository>,
+	_phantom: PhantomData<(State, Stf)>,
+}
+
+impl<State, Stf, ShieldingKeyRepository> StateInitializer<State, Stf, ShieldingKeyRepository>
+where
+	Stf: InitState<State, AccountId>,
+	ShieldingKeyRepository: AccessKey,
+	ShieldingKeyRepository::KeyType: DeriveEd25519,
+{
+	pub fn new(shielding_key_repository: Arc<ShieldingKeyRepository>) -> Self {
+		Self { shielding_key_repository, _phantom: Default::default() }
+	}
+}
+
+impl<State, Stf, ShieldingKeyRepository> InitializeState
+	for StateInitializer<State, Stf, ShieldingKeyRepository>
+where
+	Stf: InitState<State, AccountId>,
+	ShieldingKeyRepository: AccessKey,
+	ShieldingKeyRepository::KeyType: DeriveEd25519,
+{
+	type StateType = State;
+
+	fn initialize(&self) -> Result<Self::StateType> {
+		// This implementation basically exists because it is non-trivial to initialize the state with
+		// an enclave account that is derived from the shielding key.
+		let enclave_account = self.shielding_key_repository.retrieve_key()?.derive_ed25519()?;
+		Ok(Stf::init_state(enclave_account.public().into()))
+	}
+}

--- a/core-primitives/stf-state-handler/src/state_snapshot_primitives.rs
+++ b/core-primitives/stf-state-handler/src/state_snapshot_primitives.rs
@@ -41,12 +41,13 @@ impl<HashType> StateSnapshotMetaData<HashType> {
 pub(crate) fn initialize_shard_with_snapshot<HashType, FileIo>(
 	shard_identifier: &ShardIdentifier,
 	file_io: &FileIo,
+	state: &FileIo::StateType,
 ) -> Result<StateSnapshotMetaData<HashType>>
 where
 	FileIo: StateFileIo<HashType = HashType>,
 {
 	let state_id = generate_current_timestamp_state_id();
-	let state_hash = file_io.create_initialized(shard_identifier, state_id)?;
+	let state_hash = file_io.initialize_shard(shard_identifier, state_id, state)?;
 	Ok(StateSnapshotMetaData::new(state_hash, state_id))
 }
 

--- a/core-primitives/stf-state-handler/src/test/mocks/initialize_state_mock.rs
+++ b/core-primitives/stf-state-handler/src/test/mocks/initialize_state_mock.rs
@@ -15,6 +15,28 @@
 
 */
 
-pub mod initialize_state_mock;
-pub mod state_key_repository_mock;
-pub mod versioned_state_access_mock;
+use crate::{error::Result, state_initializer::InitializeState};
+use std::marker::PhantomData;
+
+/// Initialize state mock.
+pub struct InitializeStateMock<State> {
+	init_state: State,
+	_phantom: PhantomData<State>,
+}
+
+impl<State> InitializeStateMock<State> {
+	pub fn new(init_state: State) -> Self {
+		Self { init_state, _phantom: Default::default() }
+	}
+}
+
+impl<State> InitializeState for InitializeStateMock<State>
+where
+	State: Clone,
+{
+	type StateType = State;
+
+	fn initialize(&self) -> Result<Self::StateType> {
+		Ok(self.init_state.clone())
+	}
+}

--- a/core-primitives/stf-state-handler/src/test/mocks/versioned_state_access_mock.rs
+++ b/core-primitives/stf-state-handler/src/test/mocks/versioned_state_access_mock.rs
@@ -60,14 +60,15 @@ where
 	fn update(
 		&mut self,
 		shard_identifier: &ShardIdentifier,
-		state: Self::StateType,
-	) -> Result<Self::HashType> {
+		state: &Self::StateType,
+		_state_hash: Self::HashType,
+	) -> Result<()> {
 		let state_history = self
 			.state_history
 			.entry(*shard_identifier)
 			.or_insert_with(|| VecDeque::default());
-		state_history.push_front(state);
-		Ok(Hash::default())
+		state_history.push_front(state.clone());
+		Ok(())
 	}
 
 	fn revert_to(
@@ -85,8 +86,9 @@ where
 	fn initialize_new_shard(
 		&mut self,
 		shard_identifier: ShardIdentifier,
+		state: &Self::StateType,
 	) -> Result<Self::HashType> {
-		self.state_history.insert(shard_identifier, VecDeque::from([State::default()]));
+		self.state_history.insert(shard_identifier, VecDeque::from([state.clone()]));
 		Ok(Hash::default())
 	}
 

--- a/core-primitives/substrate-sgx/externalities/Cargo.toml
+++ b/core-primitives/substrate-sgx/externalities/Cargo.toml
@@ -19,14 +19,15 @@ sgx_tstd = { optional = true, features = ["untrusted_fs", "net", "backtrace"], g
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
 
 # local
-environmental = { path = "../environmental", default-features = false }
-itp-hashing = { path = "../../hashing" }
+environmental = { default-features = false, path = "../environmental" }
+itp-hashing = { default-features = false, path = "../../hashing" }
 
 [features]
 default = ["std"]
 std = [
     "codec/std",
     "environmental/std",
+    "itp-hashing/std",
     "log/std",
     "postcard/use-std",
     "serde/std",

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1954,8 +1954,8 @@ dependencies = [
 name = "itp-stf-state-handler"
 version = "0.9.0"
 dependencies = [
- "ita-sgx-runtime",
  "ita-stf",
+ "itp-hashing",
  "itp-settings",
  "itp-sgx-crypto",
  "itp-sgx-externalities",
@@ -1968,7 +1968,6 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "rust-base58",
- "sgx_crypto_helper",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -57,7 +57,8 @@ use itp_stf_executor::{
 	state_getter::StfStateGetter,
 };
 use itp_stf_state_handler::{
-	file_io::sgx::SgxStateFileIo, state_snapshot_repository::StateSnapshotRepository, StateHandler,
+	file_io::sgx::SgxStateFileIo, state_initializer::StateInitializer,
+	state_snapshot_repository::StateSnapshotRepository, StateHandler,
 };
 use itp_stf_state_observer::state_observer::StateObserver;
 use itp_top_pool::basic_pool::BasicPool;
@@ -84,11 +85,13 @@ pub type EnclaveTrustedCallSigned = TrustedCallSigned;
 pub type EnclaveStf = Stf<EnclaveTrustedCallSigned, EnclaveGetter, StfState, Runtime>;
 pub type EnclaveStateKeyRepository = KeyRepository<Aes, AesSeal>;
 pub type EnclaveShieldingKeyRepository = KeyRepository<Rsa3072KeyPair, Rsa3072Seal>;
-pub type EnclaveStateFileIo =
-	SgxStateFileIo<EnclaveStateKeyRepository, EnclaveShieldingKeyRepository, EnclaveStf, StfState>;
+pub type EnclaveStateFileIo = SgxStateFileIo<EnclaveStateKeyRepository, StfState>;
 pub type EnclaveStateSnapshotRepository = StateSnapshotRepository<EnclaveStateFileIo>;
 pub type EnclaveStateObserver = StateObserver<StfState>;
-pub type EnclaveStateHandler = StateHandler<EnclaveStateSnapshotRepository, EnclaveStateObserver>;
+pub type EnclaveStateInitializer =
+	StateInitializer<StfState, EnclaveStf, EnclaveShieldingKeyRepository>;
+pub type EnclaveStateHandler =
+	StateHandler<EnclaveStateSnapshotRepository, EnclaveStateObserver, EnclaveStateInitializer>;
 pub type EnclaveGetterExecutor = GetterExecutor<EnclaveStateObserver, StfStateGetter<EnclaveStf>>;
 pub type EnclaveOCallApi = OcallApi;
 pub type EnclaveNodeMetadataRepository = NodeMetadataRepository<NodeMetadata>;

--- a/enclave-runtime/src/ocall/sidechain_ocall.rs
+++ b/enclave-runtime/src/ocall/sidechain_ocall.rs
@@ -74,13 +74,15 @@ impl EnclaveSidechainOCallApi for OcallApi {
 		maybe_until_block_hash: Option<BlockHash>,
 		shard_identifier: ShardIdentifier,
 	) -> SgxResult<Vec<SignedSidechainBlock>> {
+		const BLOCK_BUFFER_SIZE: usize = 262144; // Buffer size for sidechain blocks in bytes (256KB).
+
 		let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
 		let last_imported_block_hash_encoded = last_imported_block_hash.encode();
 		let maybe_until_block_hash_encoded = maybe_until_block_hash.encode();
 		let shard_identifier_encoded = shard_identifier.encode();
 
-		// We have to pre-allocate the vector and hope it's large enough
-		let mut signed_blocks_encoded: Vec<u8> = vec![0; 4096 * 32];
+		// We have to pre-allocate the vector and hope it's large enough (see GitHub issue #621).
+		let mut signed_blocks_encoded: Vec<u8> = vec![0; BLOCK_BUFFER_SIZE];
 
 		let res = unsafe {
 			ffi::ocall_fetch_sidechain_blocks_from_peer(

--- a/service/src/ocall_bridge/ffi/store_sidechain_blocks.rs
+++ b/service/src/ocall_bridge/ffi/store_sidechain_blocks.rs
@@ -43,7 +43,7 @@ fn store_sidechain_blocks(
 	match sidechain_api.store_sidechain_blocks(signed_blocks_vec) {
 		Ok(_) => sgx_status_t::SGX_SUCCESS,
 		Err(e) => {
-			error!("send sidechain blocks failed: {:?}", e);
+			error!("store sidechain blocks failed: {:?}", e);
 			sgx_status_t::SGX_ERROR_UNEXPECTED
 		},
 	}


### PR DESCRIPTION
Part of #459 

Worker state is now kept in-memory, snapshots are written to file. 

* State handler interface remains the same, just the implementation behind it has changed
* The state handler now holds a map of states in-memory. The snapshot repository is only used to write snapshots to file (not read state from file for every read access)
* Reduce the amount of snapshots kept to 4
* Removes the `ita-sgx-runtime` dependency in the state handler
* Increase the peer block fetching buffer size from 128 KB to 256 KB

### Notes
* We still have file i/o on every state write - this will be improved in a next PR, when we introduce the concept of a finalized state (as a result we will only write finalized state snapshots to file)
* In contrast to what #459 suggests, we don't write snapshots asynchronously. Instead, each state handler write, is also a file write

- [x] Merge #1083 first and then rebase this onto master

Closes #459