### PR TITLE
Fix state provisioning bug when reading large byte buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,6 +3307,7 @@ dependencies = [
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
+ "sgx_crypto_helper",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -72,5 +72,5 @@ sgx = [
 test = [
     "itp-sgx-crypto/mocks",
     "itp-stf-interface/mocks",
-    "sgx_crypto_helper/mesalock_sgx"
+    "sgx_crypto_helper/mesalock_sgx",
 ]

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 # sgx dependencies
+sgx_crypto_helper = { default-features = false, optional = true, features = ["mesalock_sgx"], version = "1.1.5", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", tag = "v1.1.5" }
 sgx_tcrypto = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
@@ -71,4 +72,5 @@ sgx = [
 test = [
     "itp-sgx-crypto/mocks",
     "itp-stf-interface/mocks",
+    "sgx_crypto_helper/mesalock_sgx"
 ]

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -72,5 +72,5 @@ sgx = [
 test = [
     "itp-sgx-crypto/mocks",
     "itp-stf-interface/mocks",
-    "sgx_crypto_helper/mesalock_sgx",
+    "sgx_crypto_helper",
 ]

--- a/core-primitives/stf-state-handler/src/state_snapshot_repository.rs
+++ b/core-primitives/stf-state-handler/src/state_snapshot_repository.rs
@@ -248,10 +248,10 @@ where
 		&mut self,
 		shard_identifier: ShardIdentifier,
 	) -> Result<Self::HashType> {
-		if let Some(state_snapshots) = self.snapshot_history.get(&shard_identifier) {
-			warn!("Shard ({:?}) already exists, will not initialize again", shard_identifier);
-			return state_snapshots.front().map(|s| s.state_hash).ok_or(Error::EmptyRepository)
-		}
+		// if let Some(state_snapshots) = self.snapshot_history.get(&shard_identifier) {
+		// 	warn!("Shard ({:?}) already exists, will not initialize again", shard_identifier);
+		// 	return state_snapshots.front().map(|s| s.state_hash).ok_or(Error::EmptyRepository)
+		// }
 
 		let snapshot_metadata =
 			initialize_shard_with_snapshot(&shard_identifier, self.file_io.as_ref())?;

--- a/core-primitives/stf-state-handler/src/state_snapshot_repository.rs
+++ b/core-primitives/stf-state-handler/src/state_snapshot_repository.rs
@@ -51,6 +51,8 @@ pub trait VersionedStateAccess {
 	) -> Result<Self::StateType>;
 
 	/// Initialize a new shard.
+	///
+	/// If the shard already exists, it will re-initialize it.
 	fn initialize_new_shard(&mut self, shard_identifier: ShardIdentifier)
 		-> Result<Self::HashType>;
 
@@ -248,11 +250,6 @@ where
 		&mut self,
 		shard_identifier: ShardIdentifier,
 	) -> Result<Self::HashType> {
-		// if let Some(state_snapshots) = self.snapshot_history.get(&shard_identifier) {
-		// 	warn!("Shard ({:?}) already exists, will not initialize again", shard_identifier);
-		// 	return state_snapshots.front().map(|s| s.state_hash).ok_or(Error::EmptyRepository)
-		// }
-
 		let snapshot_metadata =
 			initialize_shard_with_snapshot(&shard_identifier, self.file_io.as_ref())?;
 

--- a/core-primitives/test/src/mock/handle_state_mock.rs
+++ b/core-primitives/test/src/mock/handle_state_mock.rs
@@ -54,18 +54,7 @@ impl HandleState for HandleStateMock {
 	type HashType = H256;
 
 	fn initialize_shard(&self, shard: ShardIdentifier) -> Result<Self::HashType> {
-		let maybe_state = self.state_map.read().unwrap().get(&shard).cloned();
-
-		return match maybe_state {
-			// Initialize with default state, if it doesn't exist yet.
-			None => {
-				let state = StfState::default();
-				let state_hash = state.using_encoded(blake2_256).into();
-				self.state_map.write().unwrap().insert(shard, state);
-				Ok(state_hash)
-			},
-			Some(s) => Ok(s.using_encoded(blake2_256).into()),
-		}
+		self.reset(StfState::default(), &shard)
 	}
 
 	fn load(&self, shard: &ShardIdentifier) -> Result<StfState> {

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1998,6 +1998,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "rust-base58",
+ "sgx_crypto_helper",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -84,7 +84,8 @@ pub type EnclaveTrustedCallSigned = TrustedCallSigned;
 pub type EnclaveStf = Stf<EnclaveTrustedCallSigned, EnclaveGetter, StfState, Runtime>;
 pub type EnclaveStateKeyRepository = KeyRepository<Aes, AesSeal>;
 pub type EnclaveShieldingKeyRepository = KeyRepository<Rsa3072KeyPair, Rsa3072Seal>;
-pub type EnclaveStateFileIo = SgxStateFileIo<EnclaveStateKeyRepository, EnclaveStf, StfState>;
+pub type EnclaveStateFileIo =
+	SgxStateFileIo<EnclaveStateKeyRepository, EnclaveShieldingKeyRepository, EnclaveStf, StfState>;
 pub type EnclaveStateSnapshotRepository = StateSnapshotRepository<EnclaveStateFileIo>;
 pub type EnclaveStateObserver = StateObserver<StfState>;
 pub type EnclaveStateHandler = StateHandler<EnclaveStateSnapshotRepository, EnclaveStateObserver>;

--- a/enclave-runtime/src/global_components.rs
+++ b/enclave-runtime/src/global_components.rs
@@ -179,12 +179,8 @@ pub type EnclaveSidechainBlockImportQueueWorker = BlockImportQueueWorker<
 	EnclaveSidechainBlockImportQueue,
 	EnclaveSidechainBlockSyncer,
 >;
-pub type EnclaveSealHandler = SealHandler<
-	EnclaveShieldingKeyRepository,
-	EnclaveStateKeyRepository,
-	EnclaveStateHandler,
-	EnclaveStf,
->;
+pub type EnclaveSealHandler =
+	SealHandler<EnclaveShieldingKeyRepository, EnclaveStateKeyRepository, EnclaveStateHandler>;
 pub type EnclaveOffchainWorkerExecutor = itc_offchain_worker_executor::executor::Executor<
 	ParentchainBlock,
 	EnclaveTopPoolAuthor,

--- a/enclave-runtime/src/initialization.rs
+++ b/enclave-runtime/src/initialization.rs
@@ -73,9 +73,7 @@ use itp_settings::{
 	files::STATE_SNAPSHOTS_CACHE_SIZE,
 	worker_mode::{ProvideWorkerMode, WorkerMode},
 };
-use itp_sgx_crypto::{
-	aes, ed25519, ed25519_derivation::DeriveEd25519, rsa3072, AesSeal, Ed25519Seal, Rsa3072Seal,
-};
+use itp_sgx_crypto::{aes, ed25519, rsa3072, AesSeal, Ed25519Seal, Rsa3072Seal};
 use itp_sgx_io::StaticSealedIO;
 use itp_stf_state_handler::{
 	handle_state::HandleState, query_shard_state::QueryShardState,
@@ -115,11 +113,8 @@ pub(crate) fn init_enclave(mu_ra_url: String, untrusted_worker_url: String) -> E
 		Arc::new(EnclaveStateKeyRepository::new(state_key, Arc::new(AesSeal)));
 	GLOBAL_STATE_KEY_REPOSITORY_COMPONENT.initialize(state_key_repository.clone());
 
-	let enclave_call_signer_key = shielding_key.derive_ed25519()?;
-	let state_file_io = Arc::new(EnclaveStateFileIo::new(
-		state_key_repository,
-		enclave_call_signer_key.public().into(),
-	));
+	let state_file_io =
+		Arc::new(EnclaveStateFileIo::new(state_key_repository, shielding_key_repository.clone()));
 	let state_snapshot_repository_loader =
 		StateSnapshotRepositoryLoader::<EnclaveStateFileIo>::new(state_file_io);
 	let state_snapshot_repository =

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -146,6 +146,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		tls_ra::seal_handler::test::seal_state_fails_for_invalid_state,
 		tls_ra::seal_handler::test::unseal_seal_state_works,
 		tls_ra::tests::test_tls_ra_server_client_networking,
+		tls_ra::tests::test_state_and_key_provisioning,
 		// RPC tests
 		direct_rpc_tests::get_state_request_works,
 

--- a/enclave-runtime/src/tls_ra/mod.rs
+++ b/enclave-runtime/src/tls_ra/mod.rs
@@ -57,7 +57,7 @@ impl From<u8> for Opcode {
 			0 => Opcode::ShieldingKey,
 			1 => Opcode::StateKey,
 			2 => Opcode::State,
-			_ => unimplemented!(),
+			_ => unimplemented!("Unsupported/unknown Opcode for MU-RA exchange"),
 		}
 	}
 }

--- a/enclave-runtime/src/tls_ra/seal_handler.rs
+++ b/enclave-runtime/src/tls_ra/seal_handler.rs
@@ -20,58 +20,46 @@
 
 use crate::error::{Error as EnclaveError, Result as EnclaveResult};
 use codec::{Decode, Encode};
-use core::marker::PhantomData;
 use ita_stf::{State as StfState, StateType as StfStateType};
 use itp_sgx_crypto::{
-	ed25519_derivation::DeriveEd25519,
 	key_repository::{AccessKey, MutateKey},
 	Aes,
 };
 use itp_sgx_externalities::SgxExternalitiesTrait;
-use itp_stf_interface::InitState;
 use itp_stf_state_handler::handle_state::HandleState;
-use itp_types::{AccountId, ShardIdentifier};
+use itp_types::ShardIdentifier;
 use log::*;
 use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
-use sp_core::Pair;
 use std::{sync::Arc, vec::Vec};
 
 /// Handles the sealing and unsealing of the shielding key, state key and the state.
 #[derive(Default)]
-pub struct SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler, Stf>
+pub struct SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
 	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	// Constraint StateT = StfState currently necessary because SgxExternalities Encode/Decode does not work.
 	// See https://github.com/integritee-network/sgx-runtime/issues/46.
 	StateHandler: HandleState<StateT = StfState>,
-	Stf: InitState<StfState, AccountId>,
 {
 	state_handler: Arc<StateHandler>,
 	state_key_repository: Arc<StateKeyRepository>,
 	shielding_key_repository: Arc<ShieldingKeyRepository>,
-	_phantom: PhantomData<Stf>,
 }
 
-impl<ShieldingKeyRepository, StateKeyRepository, StateHandler, Stf>
-	SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler, Stf>
+impl<ShieldingKeyRepository, StateKeyRepository, StateHandler>
+	SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
 	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	StateHandler: HandleState<StateT = StfState>,
-	Stf: InitState<StfState, AccountId>,
 {
 	pub fn new(
 		state_handler: Arc<StateHandler>,
 		state_key_repository: Arc<StateKeyRepository>,
 		shielding_key_repository: Arc<ShieldingKeyRepository>,
 	) -> Self {
-		Self {
-			state_handler,
-			state_key_repository,
-			shielding_key_repository,
-			_phantom: PhantomData,
-		}
+		Self { state_handler, state_key_repository, shielding_key_repository }
 	}
 }
 
@@ -88,13 +76,12 @@ pub trait UnsealStateAndKeys {
 	fn unseal_state(&self, shard: &ShardIdentifier) -> EnclaveResult<Vec<u8>>;
 }
 
-impl<ShieldingKeyRepository, StateKeyRepository, StateHandler, Stf> SealStateAndKeys
-	for SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler, Stf>
+impl<ShieldingKeyRepository, StateKeyRepository, StateHandler> SealStateAndKeys
+	for SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
 	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	StateHandler: HandleState<StateT = StfState>,
-	Stf: InitState<StfState, AccountId>,
 {
 	fn seal_shielding_key(&self, bytes: &[u8]) -> EnclaveResult<()> {
 		let key: Rsa3072KeyPair = serde_json::from_slice(bytes).map_err(|e| {
@@ -130,22 +117,18 @@ where
 	/// Since the enclave signing account is derived from the shielding key, we need to
 	/// newly initialize the state with the updated shielding key.
 	fn seal_new_empty_state(&self, shard: &ShardIdentifier) -> EnclaveResult<()> {
-		let enclave_account: AccountId =
-			self.shielding_key_repository.retrieve_key()?.derive_ed25519()?.public().into();
-		let state = Stf::init_state(enclave_account);
-		self.state_handler.reset(state, shard)?;
+		self.state_handler.initialize_shard(*shard)?;
 		info!("Successfully reset state with new enclave account, for shard {:?}", shard);
 		Ok(())
 	}
 }
 
-impl<ShieldingKeyRepository, StateKeyRepository, StateHandler, Stf> UnsealStateAndKeys
-	for SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler, Stf>
+impl<ShieldingKeyRepository, StateKeyRepository, StateHandler> UnsealStateAndKeys
+	for SealHandler<ShieldingKeyRepository, StateKeyRepository, StateHandler>
 where
 	ShieldingKeyRepository: AccessKey<KeyType = Rsa3072KeyPair> + MutateKey<Rsa3072KeyPair>,
 	StateKeyRepository: AccessKey<KeyType = Aes> + MutateKey<Aes>,
 	StateHandler: HandleState<StateT = StfState>,
-	Stf: InitState<StfState, AccountId>,
 {
 	fn unseal_shielding_key(&self) -> EnclaveResult<Vec<u8>> {
 		let shielding_key = self
@@ -172,19 +155,13 @@ where
 pub mod test {
 	use super::*;
 	use itp_sgx_crypto::mocks::KeyRepositoryMock;
-	use itp_sgx_externalities::{SgxExternalities, SgxExternalitiesDiffType};
-	use itp_stf_interface::mocks::StateInterfaceMock;
 	use itp_test::mock::handle_state_mock::HandleStateMock;
 
 	type StateKeyRepositoryMock = KeyRepositoryMock<Aes>;
 	type ShieldingKeyRepositoryMock = KeyRepositoryMock<Rsa3072KeyPair>;
 
-	type SealHandlerMock = SealHandler<
-		ShieldingKeyRepositoryMock,
-		StateKeyRepositoryMock,
-		HandleStateMock,
-		StateInterfaceMock<SgxExternalities, SgxExternalitiesDiffType>,
-	>;
+	type SealHandlerMock =
+		SealHandler<ShieldingKeyRepositoryMock, StateKeyRepositoryMock, HandleStateMock>;
 
 	pub fn seal_shielding_key_works() {
 		let seal_handler = SealHandlerMock::default();

--- a/enclave-runtime/src/tls_ra/tests.rs
+++ b/enclave-runtime/src/tls_ra/tests.rs
@@ -21,45 +21,59 @@ use super::{
 	mocks::SealHandlerMock, tls_ra_client::request_state_provisioning_internal,
 	tls_ra_server::run_state_provisioning_server_internal,
 };
+use crate::{
+	global_components::EnclaveStf,
+	tls_ra::seal_handler::{SealHandler, SealStateAndKeys, UnsealStateAndKeys},
+};
+use ita_stf::{AccountId, State};
 use itp_settings::worker_mode::{ProvideWorkerMode, WorkerMode, WorkerModeProvider};
+use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes};
+use itp_stf_interface::InitState;
+use itp_stf_state_handler::handle_state::HandleState;
+use itp_test::mock::handle_state_mock::HandleStateMock;
 use itp_types::ShardIdentifier;
+use sgx_crypto_helper::{rsa3072::Rsa3072KeyPair, RsaKeyPair};
 use sgx_types::sgx_quote_sign_type_t;
 use std::{
 	net::{TcpListener, TcpStream},
 	os::unix::io::AsRawFd,
+	string::String,
 	sync::{Arc, SgxRwLock as RwLock},
 	thread,
 	time::Duration,
 	vec::Vec,
 };
 
-static SERVER_ADDR: &str = "127.0.0.1:3149";
 static SIGN_TYPE: sgx_quote_sign_type_t = sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE;
 static SKIP_RA: i32 = 1;
 
-fn run_state_provisioning_server(seal_handler: SealHandlerMock) {
-	let listener = TcpListener::bind(SERVER_ADDR).unwrap();
+fn run_state_provisioning_server(seal_handler: impl UnsealStateAndKeys, port: u16) {
+	let listener = TcpListener::bind(server_addr(port)).unwrap();
 
 	let (socket, _addr) = listener.accept().unwrap();
 	run_state_provisioning_server_internal::<_, WorkerModeProvider>(
 		socket.as_raw_fd(),
 		SIGN_TYPE,
 		SKIP_RA,
-		seal_handler.clone(),
+		seal_handler,
 	)
 	.unwrap();
 }
 
+fn server_addr(port: u16) -> String {
+	format!("127.0.0.1:{}", port)
+}
+
 pub fn test_tls_ra_server_client_networking() {
 	let shard = ShardIdentifier::default();
-	let shielding_key = vec![1, 2, 3];
-	let state_key = vec![5, 2, 3];
-	let state = vec![5, 2, 3, 10, 21, 0, 9, 1];
+	let shielding_key_encoded = vec![1, 2, 3];
+	let state_key_encoded = vec![5, 2, 3, 7];
+	let state_encoded = Vec::from([1u8; 26000]); // Have a decently sized state, so read() must be called multiple times.
 
 	let server_seal_handler = SealHandlerMock::new(
-		Arc::new(RwLock::new(shielding_key.clone())),
-		Arc::new(RwLock::new(state_key.clone())),
-		Arc::new(RwLock::new(state.clone())),
+		Arc::new(RwLock::new(shielding_key_encoded.clone())),
+		Arc::new(RwLock::new(state_key_encoded.clone())),
+		Arc::new(RwLock::new(state_encoded.clone())),
 	);
 	let initial_client_state = vec![0, 0, 1];
 	let initial_client_state_key = vec![0, 0, 2];
@@ -73,14 +87,16 @@ pub fn test_tls_ra_server_client_networking() {
 		client_state.clone(),
 	);
 
+	let port: u16 = 3149;
+
 	// Start server.
 	let server_thread_handle = thread::spawn(move || {
-		run_state_provisioning_server(server_seal_handler);
+		run_state_provisioning_server(server_seal_handler, port);
 	});
 	thread::sleep(Duration::from_secs(1));
 
 	// Start client.
-	let socket = TcpStream::connect(SERVER_ADDR).unwrap();
+	let socket = TcpStream::connect(server_addr(port)).unwrap();
 	let result = request_state_provisioning_internal(
 		socket.as_raw_fd(),
 		SIGN_TYPE,
@@ -93,14 +109,64 @@ pub fn test_tls_ra_server_client_networking() {
 	server_thread_handle.join().unwrap();
 
 	assert!(result.is_ok());
-	assert_eq!(*client_shielding_key.read().unwrap(), shielding_key);
+	assert_eq!(*client_shielding_key.read().unwrap(), shielding_key_encoded);
 
 	// State and state-key are provisioned only in sidechain mode
 	if WorkerModeProvider::worker_mode() == WorkerMode::Sidechain {
-		assert_eq!(*client_state.read().unwrap(), state);
-		assert_eq!(*client_state_key.read().unwrap(), state_key);
+		assert_eq!(*client_state.read().unwrap(), state_encoded);
+		assert_eq!(*client_state_key.read().unwrap(), state_key_encoded);
 	} else {
 		assert_eq!(*client_state.read().unwrap(), initial_client_state);
 		assert_eq!(*client_state_key.read().unwrap(), initial_client_state_key);
 	}
+}
+
+// Test state and key provisioning with 'real' data structures.
+pub fn test_state_and_key_provisioning() {
+	let state_key = Aes::new([3u8; 16], [0u8; 16]);
+	let shielding_key = Rsa3072KeyPair::new().unwrap();
+	let initialized_state = EnclaveStf::init_state(AccountId::new([1u8; 32]));
+	let shard = ShardIdentifier::from([1u8; 32]);
+
+	let server_seal_handler =
+		create_seal_handler(state_key, shielding_key, initialized_state, &shard);
+	let client_seal_handler =
+		create_seal_handler(Aes::default(), Rsa3072KeyPair::default(), State::default(), &shard);
+
+	let port: u16 = 3150;
+
+	// Start server.
+	let server_thread_handle = thread::spawn(move || {
+		run_state_provisioning_server(server_seal_handler, port);
+	});
+	thread::sleep(Duration::from_secs(1));
+
+	// Start client.
+	let socket = TcpStream::connect(server_addr(port)).unwrap();
+	let result = request_state_provisioning_internal(
+		socket.as_raw_fd(),
+		SIGN_TYPE,
+		shard,
+		SKIP_RA,
+		client_seal_handler,
+	);
+
+	// Ensure server thread has finished.
+	server_thread_handle.join().unwrap();
+
+	assert!(result.is_ok());
+}
+
+fn create_seal_handler(
+	state_key: Aes,
+	shielding_key: Rsa3072KeyPair,
+	state: State,
+	shard: &ShardIdentifier,
+) -> impl UnsealStateAndKeys + SealStateAndKeys {
+	let state_key_repository = Arc::new(KeyRepositoryMock::<Aes>::new(state_key));
+	let shielding_key_repository =
+		Arc::new(KeyRepositoryMock::<Rsa3072KeyPair>::new(shielding_key));
+	let state_handler = Arc::new(HandleStateMock::default());
+	state_handler.reset(state, shard).unwrap();
+	SealHandler::new(state_handler, state_key_repository, shielding_key_repository)
 }

--- a/enclave-runtime/src/tls_ra/tls_ra_client.rs
+++ b/enclave-runtime/src/tls_ra/tls_ra_client.rs
@@ -130,14 +130,12 @@ where
 
 	/// Reads the payload header, indicating the sent payload length and type.
 	fn read_header(&mut self, start_byte: u8) -> EnclaveResult<TcpHeader> {
-		const PAYLOAD_SIZE_LENGTH: usize = 8; // u64 indicating the payload size is 8 bytes
-
 		debug!("Read first byte: {:?}", start_byte);
 		// The first sent byte indicates the payload type.
 		let opcode: Opcode = start_byte.into();
 		debug!("Read header opcode: {:?}", opcode);
-		// The 8 bytes following afterwards indicate the payload length.
-		let mut payload_length_buffer = [0u8; PAYLOAD_SIZE_LENGTH];
+		// The following bytes contain the payload length, which is a u64.
+		let mut payload_length_buffer = [0u8; std::mem::size_of::<u64>()];
 		self.tls_stream.read_exact(&mut payload_length_buffer)?;
 		let payload_length = u64::from_be_bytes(payload_length_buffer);
 		debug!("Payload length of {:?}: {}", opcode, payload_length);

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -308,7 +308,8 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 			sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
 			&ra_url,
 			skip_ra,
-		)
+		);
+		info!("State provisioning server stopped.");
 	});
 
 	let tokio_handle = tokio_handle_getter.get_handle();


### PR DESCRIPTION
Discovered while working on #459 and PR #1077: 

- State and key provisioning failed consistently with state sizes ~25 KB
- Stream reading in provisioning showed weird effects

The issue was, that we read bytes from the TLS stream, but did not check how many bytes we actually read. We provided a buffer with a given size and assumed that `read()` would always fill the buffer. But that is not the case (as the API documentation clearly states). `read()` reads `n` bytes, where `0 <= n <= buffer_size` bytes. So e.g. when we expect to read `1000` bytes (and pre-allocate our buffer accordingly), we must always check how many bytes `read()` actually read, and then call it again, until our buffer is full.

#### Minor changes
- `initialize_shard` of the `StateSnapshotRepository` will now re-initialize a shard state, even if that shard state already exists. This was necessary due to the on-boarding process, where the enclave account changes when provisioning from a peer.

Closes #1082