### PR TITLE
Investigate and fix sidechain integration test failures

### DIFF
--- a/cli/demo_direct_call.sh
+++ b/cli/demo_direct_call.sh
@@ -89,6 +89,7 @@ echo "* Send ${AMOUNTTRANSFER} funds from Alice's incognito account to Bob's inc
 $CLIENT trusted --mrenclave ${MRENCLAVE} --direct transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER}
 echo ""
 
+# Prevent getter being executed too early and returning an outdated result, before the transfer was made.
 echo "* Waiting 2 seconds"
 sleep 2
 echo ""

--- a/cli/demo_direct_call.sh
+++ b/cli/demo_direct_call.sh
@@ -89,6 +89,10 @@ echo "* Send ${AMOUNTTRANSFER} funds from Alice's incognito account to Bob's inc
 $CLIENT trusted --mrenclave ${MRENCLAVE} --direct transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER}
 echo ""
 
+echo "* Waiting 2 seconds"
+sleep 2
+echo ""
+
 echo "* Get balance of Alice's incognito account"
 RESULT=$(${CLIENT} trusted --mrenclave ${MRENCLAVE} balance ${ICGACCOUNTALICE} | xargs)
 echo $RESULT

--- a/cli/demo_sidechain.sh
+++ b/cli/demo_sidechain.sh
@@ -110,6 +110,7 @@ echo "* First transfer: Send ${AMOUNTTRANSFER} funds from Alice's incognito acco
 $CLIENTWORKER1 trusted --mrenclave ${MRENCLAVE} --direct transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER}
 echo ""
 
+# Prevent nonce clash when sending direct trusted calls to different workers.
 echo "* Waiting 2 seconds"
 sleep 2
 echo ""
@@ -119,6 +120,7 @@ echo "* Second transfer: Send ${AMOUNTTRANSFER} funds from Alice's incognito acc
 $CLIENTWORKER2 trusted --mrenclave ${MRENCLAVE} --direct transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER}
 echo ""
 
+# Prevent getter being executed too early and returning an outdated result, before the transfer was made.
 echo "* Waiting 2 seconds"
 sleep 2
 echo ""

--- a/cli/demo_sidechain.sh
+++ b/cli/demo_sidechain.sh
@@ -110,9 +110,17 @@ echo "* First transfer: Send ${AMOUNTTRANSFER} funds from Alice's incognito acco
 $CLIENTWORKER1 trusted --mrenclave ${MRENCLAVE} --direct transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER}
 echo ""
 
+echo "* Waiting 2 seconds"
+sleep 2
+echo ""
+
 # Send funds from Alice to Bobs account, on worker 2.
 echo "* Second transfer: Send ${AMOUNTTRANSFER} funds from Alice's incognito account to Bob's incognito account (on worker 2)"
 $CLIENTWORKER2 trusted --mrenclave ${MRENCLAVE} --direct transfer ${ICGACCOUNTALICE} ${ICGACCOUNTBOB} ${AMOUNTTRANSFER}
+echo ""
+
+echo "* Waiting 2 seconds"
+sleep 2
 echo ""
 
 echo "* Get balance of Alice's incognito account (on worker 1)"

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -122,9 +122,10 @@ where
 			.get_multiple_storages_verified(storage_hashes, header)
 			.map(into_map)?;
 
+		debug!("Apply state diff with {} entries from parentchain block", update_map.len());
 		Stf::apply_state_diff(state, update_map.into());
 
-		debug!("execute STF, call with nonce {}", trusted_call.nonce);
+		debug!("execute on STF, call with nonce {}", trusted_call.nonce);
 		let mut extrinsic_call_backs: Vec<OpaqueCall> = Vec::new();
 		if let Err(e) = Stf::execute_call(
 			state,

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s
@@ -33,7 +33,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node', 'integritee-worker-1']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait http://integritee-worker-1:4645/is_initialized -timeout 150s 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-1 -T wss://integritee-worker-1 
       -u ws://integritee-node -U ws://integritee-worker-1 -P 2011 -w 2101 -p 9912 -h 4645
       run --dev --skip-ra"
-    restart: always
+    restart: "no"
   integritee-worker-2:
     image: integritee-worker:dev
     container_name: integritee-worker-2

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info,itp_stf_executor::executor=debug,its_consensus_aura::slot_proposer=info
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s
@@ -33,7 +33,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node', 'integritee-worker-1']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info,itp_stf_executor::executor=debug,its_consensus_aura::slot_proposer=info
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait http://integritee-worker-1:4645/is_initialized -timeout 150s 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info,itp_stf_executor::executor=debug,its_consensus_aura::slot_proposer=info
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s
@@ -33,7 +33,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node', 'integritee-worker-1']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info,its_rpc_handler::import_block_api=info,its_consensus_slots=info,itp_stf_executor::executor=debug,its_consensus_aura::slot_proposer=info
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait http://integritee-worker-1:4645/is_initialized -timeout 150s 

--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -137,7 +137,7 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 		&mut LastSlotSeal,
 	)? {
 		Some(slot) => {
-			if let None = slot.duration_remaining() {
+			if slot.duration_remaining().is_none() {
 				warn!("No time remaining in slot, skipping AURA execution");
 				return Ok(())
 			}

--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -137,18 +137,12 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 		&mut LastSlotSeal,
 	)? {
 		Some(slot) => {
-			let duration_now = duration_now();
-			if duration_now >= slot.ends_at {
+			if let None = slot.duration_remaining() {
 				warn!("No time remaining in slot, skipping AURA execution");
 				return Ok(())
 			}
 
-			let remaining_time = slot.ends_at - duration_now;
-			info!(
-				"Remaining slot time for aura: {} ms, {}% of slot time",
-				remaining_time.as_millis(),
-				(remaining_time.as_millis() as f64 / slot.duration.as_millis() as f64) * 100f64
-			);
+			log_remaining_slot_duration(&slot, "Before AURA");
 
 			let shards = state_handler.list_shards()?;
 			let env = ProposerFactory::<Block, _, _, _>::new(
@@ -158,7 +152,7 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 			);
 
 			let (blocks, opaque_calls) = exec_aura_on_slot::<_, _, SignedSidechainBlock, _, _, _>(
-				slot,
+				slot.clone(),
 				authority,
 				ocall_api.clone(),
 				parentchain_import_dispatcher,
@@ -171,13 +165,17 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 			// Drop lock as soon as we don't need it anymore.
 			drop(_enclave_write_lock);
 
+			log_remaining_slot_duration(&slot, "After AURA");
+
 			send_blocks_and_extrinsics::<Block, _, _, _, _>(
 				blocks,
 				opaque_calls,
 				ocall_api,
 				validator_access.as_ref(),
 				extrinsics_factory.as_ref(),
-			)?
+			)?;
+
+			log_remaining_slot_duration(&slot, "After broadcasting and sending extrinsic");
 		},
 		None => {
 			debug!("No slot yielded. Skipping block production.");
@@ -272,4 +270,24 @@ where
 	validator_access.execute_mut_on_validator(|v| v.send_extrinsics(xts))?;
 
 	Ok(())
+}
+
+fn log_remaining_slot_duration<B: BlockTrait<Hash = H256>>(
+	slot_info: &SlotInfo<B>,
+	stage_name: &str,
+) {
+	match slot_info.duration_remaining() {
+		None => {
+			info!("No time remaining in slot (id: {:?}, stage: {})", slot_info.slot, stage_name);
+		},
+		Some(remainder) => {
+			info!(
+				"Remaining time in slot (id: {:?}, stage {}): {} ms, {}% of slot time",
+				slot_info.slot,
+				stage_name,
+				remainder.as_millis(),
+				(remainder.as_millis() as f64 / slot_info.duration.as_millis() as f64) * 100f64
+			);
+		},
+	};
 }

--- a/sidechain/consensus/aura/src/lib.rs
+++ b/sidechain/consensus/aura/src/lib.rs
@@ -104,7 +104,7 @@ impl<AuthorityPair, ParentchainBlock, SidechainBlock, Environment, OcallApi, Imp
 
 /// The fraction of total block time we are allowed to be producing the block. So that we have
 /// enough time send create and send the block to fellow validateers.
-pub const BLOCK_PROPOSAL_SLOT_PORTION: f32 = 0.4;
+pub const BLOCK_PROPOSAL_SLOT_PORTION: f32 = 0.7;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum SlotClaimStrategy {

--- a/sidechain/consensus/aura/src/lib.rs
+++ b/sidechain/consensus/aura/src/lib.rs
@@ -104,7 +104,7 @@ impl<AuthorityPair, ParentchainBlock, SidechainBlock, Environment, OcallApi, Imp
 
 /// The fraction of total block time we are allowed to be producing the block. So that we have
 /// enough time send create and send the block to fellow validateers.
-pub const BLOCK_PROPOSAL_SLOT_PORTION: f32 = 0.8;
+pub const BLOCK_PROPOSAL_SLOT_PORTION: f32 = 0.6;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum SlotClaimStrategy {

--- a/sidechain/consensus/aura/src/lib.rs
+++ b/sidechain/consensus/aura/src/lib.rs
@@ -104,7 +104,7 @@ impl<AuthorityPair, ParentchainBlock, SidechainBlock, Environment, OcallApi, Imp
 
 /// The fraction of total block time we are allowed to be producing the block. So that we have
 /// enough time send create and send the block to fellow validateers.
-pub const BLOCK_PROPOSAL_SLOT_PORTION: f32 = 0.6;
+pub const BLOCK_PROPOSAL_SLOT_PORTION: f32 = 0.4;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum SlotClaimStrategy {

--- a/sidechain/consensus/aura/src/lib.rs
+++ b/sidechain/consensus/aura/src/lib.rs
@@ -535,9 +535,8 @@ mod tests {
 
 		// hard to compare actual numbers but we can at least ensure that the general concept works
 		assert!(
-			proposing_remaining_duration(&slot_info, duration_now()) > SLOT_DURATION / 2
-				&& proposing_remaining_duration(&slot_info, duration_now())
-					< SLOT_DURATION.mul_f32(BLOCK_PROPOSAL_SLOT_PORTION + 0.01)
+			proposing_remaining_duration(&slot_info, duration_now())
+				< SLOT_DURATION.mul_f32(BLOCK_PROPOSAL_SLOT_PORTION + 0.01)
 		);
 	}
 
@@ -546,9 +545,8 @@ mod tests {
 		let slot_info = now_slot_with_default_header(0.into());
 
 		assert!(
-			proposing_remaining_duration(&slot_info, Duration::from_millis(0)) > SLOT_DURATION / 2
-				&& proposing_remaining_duration(&slot_info, Duration::from_millis(0))
-					< SLOT_DURATION.mul_f32(BLOCK_PROPOSAL_SLOT_PORTION + 0.01)
+			proposing_remaining_duration(&slot_info, Duration::from_millis(0))
+				< SLOT_DURATION.mul_f32(BLOCK_PROPOSAL_SLOT_PORTION + 0.01)
 		);
 	}
 

--- a/sidechain/consensus/aura/src/slot_proposer.rs
+++ b/sidechain/consensus/aura/src/slot_proposer.rs
@@ -34,13 +34,7 @@ use sp_runtime::{
 	traits::{Block, NumberFor},
 	MultiSignature,
 };
-use std::{
-	marker::PhantomData,
-	string::ToString,
-	sync::Arc,
-	time::{Duration, Instant},
-	vec::Vec,
-};
+use std::{marker::PhantomData, string::ToString, sync::Arc, time::Duration, vec::Vec};
 
 pub type ExternalitiesFor<T> = <T as StateUpdateProposer>::Externalities;
 ///! `SlotProposer` instance that has access to everything needed to propose a sidechain block.
@@ -94,7 +88,6 @@ where
 		max_duration: Duration,
 	) -> Result<Proposal<SignedSidechainBlock>, ConsensusError> {
 		let latest_parentchain_header = &self.parentchain_header;
-		let mut timer = Instant::now();
 
 		// 1) Retrieve trusted calls from top pool.
 		let trusted_calls = self.top_pool_author.get_pending_trusted_calls(self.shard);
@@ -102,9 +95,6 @@ where
 		if !trusted_calls.is_empty() {
 			debug!("Got following trusted calls from pool: {:?}", trusted_calls);
 		}
-
-		info!("Retrieving calls from TOP pool took {} ms", timer.elapsed().as_millis());
-		timer = Instant::now();
 
 		// 2) Execute trusted calls.
 		let batch_execution_result = self
@@ -134,16 +124,8 @@ where
 			batch_execution_result.get_executed_operation_hashes().to_vec();
 		let number_executed_transactions = executed_operation_hashes.len();
 
-		info!(
-			"STF execution took {} ms for {} calls",
-			timer.elapsed().as_millis(),
-			trusted_calls.len()
-		);
-		timer = Instant::now();
-
 		// Remove all not successfully executed operations from the top pool.
 		let failed_operations = batch_execution_result.get_failed_operations();
-		info!("Removing {} failed operations from TOP pool", failed_operations.len());
 		self.top_pool_author.remove_calls_from_pool(
 			self.shard,
 			failed_operations
@@ -173,8 +155,6 @@ where
 			max_duration.as_millis(),
 			number_executed_transactions
 		);
-
-		info!("Proposing block took {} ms", timer.elapsed().as_millis());
 
 		Ok(Proposal { block: sidechain_block, parentchain_effects: parentchain_extrinsics })
 	}

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -37,7 +37,7 @@ its-consensus-common = { path = "../common", default-features = false }
 itc-parentchain-test = { path = "../../../core/parentchain/test" }
 its-test = { path = "../../test" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
-tokio = "*"
+tokio = { version = "1.6.1", features = ["full"] }
 
 
 [features]

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -271,7 +271,8 @@ pub trait SimpleSlotWorker<ParentchainBlock: ParentchainBlockTrait> {
 		if !timestamp_within_slot(&slot_info, &proposing.block) {
 			warn!(
 				target: logging_target,
-				"⌛️ Discarding proposal for slot {}, block number {}; block production took too long", proposing.block.block().header().block_number(), *slot,
+				"⌛️ Discarding proposal for slot {}, block number {}; block production took too long", 
+				*slot, proposing.block.block().header().block_number(),
 			);
 
 			return None

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -271,7 +271,7 @@ pub trait SimpleSlotWorker<ParentchainBlock: ParentchainBlockTrait> {
 		if !timestamp_within_slot(&slot_info, &proposing.block) {
 			warn!(
 				target: logging_target,
-				"⌛️ Discarding proposal for slot {}; block production took too long", *slot,
+				"⌛️ Discarding proposal for slot {}, block number {}; block production took too long", proposing.block.block().header().block_number(), *slot,
 			);
 
 			return None

--- a/sidechain/rpc-handler/src/import_block_api.rs
+++ b/sidechain/rpc-handler/src/import_block_api.rs
@@ -46,9 +46,10 @@ where
 			)
 		})?;
 
-		info!("{}. Blocks: {:?}", RPC_METHOD_NAME_IMPORT_BLOCKS, blocks);
+		debug!("{}. Blocks: {:?}", RPC_METHOD_NAME_IMPORT_BLOCKS, blocks);
 
 		for block in blocks {
+			info!("Add block {} to import queue", block.block.header.block_number);
 			let _ = import_fn(block).map_err(|e| {
 				let error = jsonrpc_core::error::Error::invalid_params_with_details(
 					"Failed to import Block.",

--- a/sidechain/test/Cargo.toml
+++ b/sidechain/test/Cargo.toml
@@ -18,7 +18,7 @@ sp-core = { default_features = false, git = "https://github.com/paritytech/subst
 
 # local
 itp-types = { path = "../../core-primitives/types", default_features = false }
-its-primitives = { path = "../primitives", default_features = false }
+its-primitives = { path = "../primitives", default_features = false, features = ["full_crypto"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This issue is to investigate the intermittent failures we see in our integration tests.
Related GH issue: #1023 

### Observations:
* Getters in the integration test scripts return wrong results
* We have nonce clashes on rare occasions
* Slot times in about 5% of the cases are exceeded, with 2 effects:
  * The proposed block is discarded before it's broadcasted, or
  * the block is broadcasted and reaches the import queue AFTER the next block is being produced. This will result in a 'block is already imported' warning.
  * Both of the above effects are NOT forks, and will maintain sidechain integrity. What we lose is efficiency and responsiveness.
* Calls from the integration test scripts are executed simultaneously

### Conclusions
* I found that we removed the `sleep`s in our integration tests scripts at some point. Those sleeps were placed between executing calls and getters.
  * When multiple distinct calls are sent to 2 workers simultaneously, it can happen that we have a nonce clash, because they both try to execute a call and increase the same account nonce at the same time (before that block can be imported)
* A couple of weeks ago, we changed the getter execution to be immediate and not part of the TOP pool anymore. 
  *  As a result, when we send a call and a getter almost simultaneously, the getter will return a result before the call was executed and included in a sidechain block.

### Solution
* Simply re-introduce the `sleep`s in our integration test scripts again, so that we wait for the calls to be executed and included in a sidechain block before calling a getter to verify that effect. 

Closes #1023 