### PR TITLE
State handling refactoring: Reduce state cloning

### DIFF
--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -180,6 +180,8 @@ where
 			.map(into_map)?;
 
 		// Update parentchain block on all states.
+		// TODO: Investigate if this is still necessary. We load and clone the entire state here,
+		// which scales badly for increasing state size.
 		let shards = self.state_handler.list_shards()?;
 		for shard_id in shards {
 			let (state_lock, mut state) = self.state_handler.load_for_mutation(&shard_id)?;

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	error::{Error, Result},
-	traits::{StatePostProcessing, StateUpdateProposer, StfExecuteGenericUpdate, StfUpdateState},
+	traits::{StatePostProcessing, StateUpdateProposer, StfUpdateState},
 	BatchExecutionResult, ExecutedOperation,
 };
 use codec::{Decode, Encode};
@@ -38,8 +38,7 @@ use itp_types::{storage::StorageEntryVerified, OpaqueCall, H256};
 use log::*;
 use sp_runtime::traits::Header as HeaderTrait;
 use std::{
-	collections::BTreeMap, fmt::Debug, format, marker::PhantomData, result::Result as StdResult,
-	sync::Arc, time::Duration, vec::Vec,
+	collections::BTreeMap, fmt::Debug, marker::PhantomData, sync::Arc, time::Duration, vec::Vec,
 };
 
 pub struct StfExecutor<OCallApi, StateHandler, NodeMetadataRepository, Stf> {
@@ -297,44 +296,6 @@ where
 			state_hash_before_execution,
 			state_after_execution: state,
 		})
-	}
-}
-
-impl<OCallApi, StateHandler, NodeMetadataRepository, Stf> StfExecuteGenericUpdate
-	for StfExecutor<OCallApi, StateHandler, NodeMetadataRepository, Stf>
-where
-	StateHandler: HandleState<HashType = H256>,
-	StateHandler::StateT: SgxExternalitiesTrait + Encode,
-	NodeMetadataRepository: AccessNodeMetadata,
-	Stf: UpdateState<
-		StateHandler::StateT,
-		<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType,
-	>,
-	<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType:
-		IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
-{
-	type Externalities = StateHandler::StateT;
-
-	fn execute_update<F, ResultT, ErrorT>(
-		&self,
-		shard: &ShardIdentifier,
-		update_function: F,
-	) -> Result<(ResultT, H256)>
-	where
-		F: FnOnce(Self::Externalities) -> StdResult<(Self::Externalities, ResultT), ErrorT>,
-		ErrorT: Debug,
-	{
-		let (state_lock, state) = self.state_handler.load_for_mutation(&shard)?;
-
-		let (new_state, result) = update_function(state).map_err(|e| {
-			Error::Other(format!("Failed to run update function on STF state: {:?}", e).into())
-		})?;
-
-		let new_state_hash = self
-			.state_handler
-			.write_after_mutation(new_state, state_lock, shard)
-			.map_err(|e| Error::StateHandler(e))?;
-		Ok((result, new_state_hash))
 	}
 }
 

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -261,7 +261,7 @@ where
 	{
 		let ends_at = duration_now() + max_exec_duration;
 
-		let (state, state_hash_before_execution) = self.state_handler.load_clone(shard)?;
+		let (state, state_hash_before_execution) = self.state_handler.load_cloned(shard)?;
 
 		// Execute any pre-processing steps.
 		let mut state = prepare_state_function(state);

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -260,8 +260,7 @@ where
 	{
 		let ends_at = duration_now() + max_exec_duration;
 
-		let state = self.state_handler.load(shard)?;
-		let state_hash_before_execution = state.hash();
+		let (state, state_hash_before_execution) = self.state_handler.load_clone(shard)?;
 
 		// Execute any pre-processing steps.
 		let mut state = prepare_state_function(state);
@@ -271,6 +270,7 @@ where
 		for trusted_call_signed in trusted_calls.into_iter() {
 			// Break if allowed time window is over.
 			if ends_at < duration_now() {
+				info!("Aborting execution of trusted calls because slot time is up");
 				break
 			}
 

--- a/core-primitives/stf-executor/src/executor_tests.rs
+++ b/core-primitives/stf-executor/src/executor_tests.rs
@@ -15,11 +15,7 @@
 
 */
 
-use crate::{
-	error::Error,
-	executor::*,
-	traits::{StateUpdateProposer, StfExecuteGenericUpdate},
-};
+use crate::{executor::StfExecutor, traits::StateUpdateProposer};
 use codec::Encode;
 use ita_stf::{
 	stf_sgx_tests::StfState,
@@ -208,33 +204,6 @@ pub fn propose_state_update_always_executes_preprocessing_step() {
 	assert_eq!(*retrieved_value, value);
 	// Ensure that state has not been actually written.
 	assert_ne!(old_state, batch_execution_result.state_after_execution);
-}
-
-pub fn execute_update_works() {
-	// given
-	let shard = ShardIdentifier::default();
-	let (stf_executor, _ocall_api, state_handler) = stf_executor();
-	let _init_hash = state_handler.initialize_shard(shard).unwrap();
-	let key = "my_key".encode();
-	let value = "my_value".encode();
-	let (_, old_state_hash) = state_handler.load_clone(&shard).unwrap();
-
-	// when
-	let (result, updated_state_hash) = stf_executor
-		.execute_update::<_, _, Error>(&shard, |mut state| {
-			state.insert(key.clone(), value.clone());
-			Ok((state, 0))
-		})
-		.unwrap();
-
-	// then
-	assert_eq!(result, 0);
-	assert_ne!(updated_state_hash, old_state_hash);
-
-	// Ensure that state has been written.
-	let (updated_state, _) = state_handler.load_clone(&shard).unwrap();
-	let retrieved_value = updated_state.get(key.as_slice()).unwrap();
-	assert_eq!(*retrieved_value, value);
 }
 
 // Helper Functions

--- a/core-primitives/stf-executor/src/executor_tests.rs
+++ b/core-primitives/stf-executor/src/executor_tests.rs
@@ -58,7 +58,7 @@ pub fn propose_state_update_executes_all_calls_given_enough_time() {
 	let trusted_operation_2 = signed_call_2.into_trusted_operation(true);
 	let call_operation_hash_2: H256 = blake2_256(&trusted_operation_2.encode()).into();
 
-	let (_, old_state_hash) = state_handler.load_clone(&shard).unwrap();
+	let (_, old_state_hash) = state_handler.load_cloned(&shard).unwrap();
 
 	// when
 	let batch_execution_result = stf_executor
@@ -80,7 +80,7 @@ pub fn propose_state_update_executes_all_calls_given_enough_time() {
 	);
 	// Ensure that state has been updated and not actually written.
 	assert_ne!(
-		state_handler.load_clone(&shard).unwrap().0,
+		state_handler.load_cloned(&shard).unwrap().0,
 		batch_execution_result.state_after_execution
 	);
 }
@@ -108,7 +108,7 @@ pub fn propose_state_update_executes_only_one_trusted_call_given_not_enough_time
 	.sign(&sender.clone().into(), 0, &mrenclave, &shard);
 	let trusted_operation_2 = signed_call_2.into_trusted_operation(true);
 
-	let (_, old_state_hash) = state_handler.load_clone(&shard).unwrap();
+	let (_, old_state_hash) = state_handler.load_cloned(&shard).unwrap();
 
 	// when
 	let batch_execution_result = stf_executor
@@ -127,7 +127,7 @@ pub fn propose_state_update_executes_only_one_trusted_call_given_not_enough_time
 	assert_eq!(batch_execution_result.get_executed_operation_hashes(), vec![call_operation_hash_1]);
 	// Ensure that state has been updated and not actually written.
 	assert_ne!(
-		state_handler.load_clone(&shard).unwrap().0,
+		state_handler.load_cloned(&shard).unwrap().0,
 		batch_execution_result.state_after_execution
 	);
 }
@@ -154,7 +154,7 @@ pub fn propose_state_update_executes_no_trusted_calls_given_no_time() {
 	.sign(&sender.clone().into(), 0, &mrenclave, &shard);
 	let trusted_operation_2 = signed_call_2.into_trusted_operation(true);
 
-	let (_, old_state_hash) = state_handler.load_clone(&shard).unwrap();
+	let (_, old_state_hash) = state_handler.load_cloned(&shard).unwrap();
 
 	// when
 	let batch_execution_result = stf_executor
@@ -180,7 +180,7 @@ pub fn propose_state_update_always_executes_preprocessing_step() {
 	let _init_hash = state_handler.initialize_shard(shard).unwrap();
 	let key = "my_key".encode();
 	let value = "my_value".encode();
-	let (old_state, old_state_hash) = state_handler.load_clone(&shard).unwrap();
+	let (old_state, old_state_hash) = state_handler.load_cloned(&shard).unwrap();
 
 	// when
 	let batch_execution_result = stf_executor

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -23,7 +23,7 @@ use ita_stf::{
 use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_types::H256;
 use sp_runtime::traits::Header as HeaderTrait;
-use std::{fmt::Debug, result::Result as StdResult, time::Duration};
+use std::time::Duration;
 
 /// Post-processing steps after executing STF
 pub enum StatePostProcessing {
@@ -63,20 +63,6 @@ pub trait StateUpdateProposer {
 	where
 		PH: HeaderTrait<Hash = H256>,
 		F: FnOnce(Self::Externalities) -> Self::Externalities;
-}
-
-/// Execute a generic function on the STF state
-pub trait StfExecuteGenericUpdate {
-	type Externalities: SgxExternalitiesTrait + Encode;
-
-	fn execute_update<F, ResultT, ErrorT>(
-		&self,
-		shard: &ShardIdentifier,
-		update_function: F,
-	) -> Result<(ResultT, H256)>
-	where
-		F: FnOnce(Self::Externalities) -> StdResult<(Self::Externalities, ResultT), ErrorT>,
-		ErrorT: Debug;
 }
 
 /// Updates the STF state for a specific header.

--- a/core-primitives/stf-state-handler/src/handle_state.rs
+++ b/core-primitives/stf-state-handler/src/handle_state.rs
@@ -46,7 +46,7 @@ pub trait HandleState {
 	///
 	/// Requires the shard to exist and be initialized, otherwise returns an error.
 	/// Because it results in a clone, prefer using `execute_on_current` whenever possible.
-	fn load_clone(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)>;
+	fn load_cloned(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)>;
 
 	/// Load the state in order to mutate it.
 	///

--- a/core-primitives/stf-state-handler/src/handle_state.rs
+++ b/core-primitives/stf-state-handler/src/handle_state.rs
@@ -35,10 +35,18 @@ pub trait HandleState {
 	/// Initializes a default state for the shard and returns its hash.
 	fn initialize_shard(&self, shard: ShardIdentifier) -> Result<Self::HashType>;
 
-	/// Load the state for a given shard.
+	/// Execute a function that acts (immutably) on the current state.
+	///
+	/// This allows access to the state, without any cloning.
+	fn execute_on_current<E, R>(&self, shard: &ShardIdentifier, executing_function: E) -> Result<R>
+	where
+		E: FnOnce(&Self::StateT, Self::HashType) -> R;
+
+	/// Load a clone of the current state for a given shard.
 	///
 	/// Requires the shard to exist and be initialized, otherwise returns an error.
-	fn load(&self, shard: &ShardIdentifier) -> Result<Self::StateT>;
+	/// Because it results in a clone, prefer using `execute_on_current` whenever possible.
+	fn load_clone(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)>;
 
 	/// Load the state in order to mutate it.
 	///

--- a/core-primitives/stf-state-handler/src/state_handler.rs
+++ b/core-primitives/stf-state-handler/src/state_handler.rs
@@ -169,7 +169,7 @@ where
 			.map_err(|_| Error::LockPoisoning)?
 			.get(shard)
 			.map(|(state, state_hash)| executing_function(state, *state_hash))
-			.ok_or(Error::InvalidShard(*shard))
+			.ok_or_else(|| Error::InvalidShard(*shard))
 	}
 
 	fn load_clone(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)> {

--- a/core-primitives/stf-state-handler/src/state_handler.rs
+++ b/core-primitives/stf-state-handler/src/state_handler.rs
@@ -160,14 +160,25 @@ where
 		self.reset(initialized_state, &shard)
 	}
 
-	fn load(&self, shard: &ShardIdentifier) -> Result<Self::StateT> {
+	fn execute_on_current<E, R>(&self, shard: &ShardIdentifier, executing_function: E) -> Result<R>
+	where
+		E: FnOnce(&Self::StateT, Self::HashType) -> R,
+	{
+		self.states_map_lock
+			.read()
+			.map_err(|_| Error::LockPoisoning)?
+			.get(shard)
+			.map(|(state, state_hash)| executing_function(state, *state_hash))
+			.ok_or(Error::InvalidShard(*shard))
+	}
+
+	fn load_clone(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)> {
 		let state = self
 			.states_map_lock
 			.read()
 			.map_err(|_| Error::LockPoisoning)?
 			.get(shard)
 			.ok_or_else(|| Error::InvalidShard(*shard))?
-			.0
 			.clone();
 
 		Ok(state)
@@ -278,7 +289,7 @@ mod tests {
 
 		let state_handler_clone = state_handler.clone();
 		let join_handle = thread::spawn(move || {
-			let latest_state = state_handler_clone.load(&shard_id).unwrap();
+			let (latest_state, _) = state_handler_clone.load_clone(&shard_id).unwrap();
 			assert_eq!(create_state_without_diff(4u64), latest_state);
 		});
 
@@ -318,8 +329,8 @@ mod tests {
 		let shard_id = ShardIdentifier::random();
 		let state_handler = default_state_handler();
 		state_handler.initialize_shard(shard_id).unwrap();
-		assert!(state_handler.load(&shard_id).is_ok());
-		assert!(state_handler.load(&ShardIdentifier::random()).is_err());
+		assert!(state_handler.load_clone(&shard_id).is_ok());
+		assert!(state_handler.load_clone(&ShardIdentifier::random()).is_err());
 	}
 
 	#[test]
@@ -380,7 +391,7 @@ mod tests {
 		};
 
 		state_handler.reset(state, &shard_id).unwrap();
-		let loaded_state = state_handler.load(&shard_id).unwrap();
+		let (loaded_state, _) = state_handler.load_clone(&shard_id).unwrap();
 
 		assert_eq!(state_without_diff, loaded_state);
 	}

--- a/core-primitives/stf-state-handler/src/state_handler.rs
+++ b/core-primitives/stf-state-handler/src/state_handler.rs
@@ -172,7 +172,7 @@ where
 			.ok_or_else(|| Error::InvalidShard(*shard))
 	}
 
-	fn load_clone(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)> {
+	fn load_cloned(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)> {
 		let state = self
 			.states_map_lock
 			.read()
@@ -289,7 +289,7 @@ mod tests {
 
 		let state_handler_clone = state_handler.clone();
 		let join_handle = thread::spawn(move || {
-			let (latest_state, _) = state_handler_clone.load_clone(&shard_id).unwrap();
+			let (latest_state, _) = state_handler_clone.load_cloned(&shard_id).unwrap();
 			assert_eq!(create_state_without_diff(4u64), latest_state);
 		});
 
@@ -329,8 +329,8 @@ mod tests {
 		let shard_id = ShardIdentifier::random();
 		let state_handler = default_state_handler();
 		state_handler.initialize_shard(shard_id).unwrap();
-		assert!(state_handler.load_clone(&shard_id).is_ok());
-		assert!(state_handler.load_clone(&ShardIdentifier::random()).is_err());
+		assert!(state_handler.load_cloned(&shard_id).is_ok());
+		assert!(state_handler.load_cloned(&ShardIdentifier::random()).is_err());
 	}
 
 	#[test]
@@ -391,7 +391,7 @@ mod tests {
 		};
 
 		state_handler.reset(state, &shard_id).unwrap();
-		let (loaded_state, _) = state_handler.load_clone(&shard_id).unwrap();
+		let (loaded_state, _) = state_handler.load_cloned(&shard_id).unwrap();
 
 		assert_eq!(state_without_diff, loaded_state);
 	}

--- a/core-primitives/stf-state-handler/src/test/sgx_tests.rs
+++ b/core-primitives/stf-state-handler/src/test/sgx_tests.rs
@@ -112,7 +112,7 @@ pub fn test_write_and_load_state_works() {
 	let (lock, _s) = state_handler.load_for_mutation(&shard).unwrap();
 	let _hash = state_handler.write_after_mutation(state.clone(), lock, &shard).unwrap();
 
-	let (result_state, _) = state_handler.load_clone(&shard).unwrap();
+	let (result_state, _) = state_handler.load_cloned(&shard).unwrap();
 
 	// then
 	assert_eq!(state.state, result_state.state);
@@ -129,7 +129,7 @@ pub fn test_ensure_subsequent_state_loads_have_same_hash() {
 	let (lock, initial_state) = state_handler.load_for_mutation(&shard).unwrap();
 	state_handler.write_after_mutation(initial_state.clone(), lock, &shard).unwrap();
 
-	let (_state_loaded, loaded_state_hash) = state_handler.load_clone(&shard).unwrap();
+	let (_, loaded_state_hash) = state_handler.load_cloned(&shard).unwrap();
 
 	assert_eq!(initial_state.hash(), loaded_state_hash);
 
@@ -156,7 +156,7 @@ pub fn test_write_access_locks_read_until_finished() {
 	let state_handler_clone = state_handler.clone();
 	let shard_for_read = shard.clone();
 	let join_handle = thread::spawn(move || {
-		let (state_to_read, _) = state_handler_clone.load_clone(&shard_for_read).unwrap();
+		let (state_to_read, _) = state_handler_clone.load_cloned(&shard_for_read).unwrap();
 		assert!(state_to_read.get(new_state_key_for_read.as_slice()).is_some());
 	});
 
@@ -179,7 +179,7 @@ pub fn test_state_handler_file_backend_is_initialized() {
 	assert!(1 <= state_handler.list_shards().unwrap().len()); // only greater equal, because there might be other (non-test) shards present
 	assert_eq!(1, number_of_files_in_shard_dir(&shard).unwrap()); // creates a first initialized file
 
-	let _state = state_handler.load_clone(&shard).unwrap();
+	let _state = state_handler.load_cloned(&shard).unwrap();
 
 	assert_eq!(1, number_of_files_in_shard_dir(&shard).unwrap());
 
@@ -269,7 +269,7 @@ pub fn test_state_files_from_handler_can_be_loaded_again() {
 	assert_eq!(
 		&"value3".encode(),
 		updated_state_handler
-			.load_clone(&shard)
+			.load_cloned(&shard)
 			.unwrap()
 			.0
 			.state()

--- a/core-primitives/stf-state-handler/src/test/sgx_tests.rs
+++ b/core-primitives/stf-state-handler/src/test/sgx_tests.rs
@@ -32,12 +32,12 @@ use crate::{
 };
 use codec::{Decode, Encode};
 use ita_stf::{State as StfState, StateType as StfStateType};
+use itp_hashing::Hash;
 use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes, AesSeal, StateCrypto};
 use itp_sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 use itp_sgx_io::{write, StaticSealedIO};
 use itp_stf_state_observer::state_observer::StateObserver;
 use itp_types::{ShardIdentifier, H256};
-use sp_core::hashing::blake2_256;
 use std::{sync::Arc, thread, vec::Vec};
 
 const STATE_SNAPSHOTS_CACHE_SIZE: usize = 3;
@@ -112,10 +112,10 @@ pub fn test_write_and_load_state_works() {
 	let (lock, _s) = state_handler.load_for_mutation(&shard).unwrap();
 	let _hash = state_handler.write_after_mutation(state.clone(), lock, &shard).unwrap();
 
-	let result = state_handler.load(&shard).unwrap();
+	let (result_state, _) = state_handler.load_clone(&shard).unwrap();
 
 	// then
-	assert_eq!(state.state, result.state);
+	assert_eq!(state.state, result_state.state);
 
 	// clean up
 	std::mem::drop(shard_dir_handle);
@@ -129,16 +129,12 @@ pub fn test_ensure_subsequent_state_loads_have_same_hash() {
 	let (lock, initial_state) = state_handler.load_for_mutation(&shard).unwrap();
 	state_handler.write_after_mutation(initial_state.clone(), lock, &shard).unwrap();
 
-	let state_loaded = state_handler.load(&shard).unwrap();
+	let (_state_loaded, loaded_state_hash) = state_handler.load_clone(&shard).unwrap();
 
-	assert_eq!(hash_of(&initial_state.state), hash_of(&state_loaded.state));
+	assert_eq!(initial_state.hash(), loaded_state_hash);
 
 	// clean up
 	std::mem::drop(shard_dir_handle);
-}
-
-fn hash_of<T: Encode>(encodable: &T) -> H256 {
-	encodable.using_encoded(blake2_256).into()
 }
 
 pub fn test_write_access_locks_read_until_finished() {
@@ -160,7 +156,7 @@ pub fn test_write_access_locks_read_until_finished() {
 	let state_handler_clone = state_handler.clone();
 	let shard_for_read = shard.clone();
 	let join_handle = thread::spawn(move || {
-		let state_to_read = state_handler_clone.load(&shard_for_read).unwrap();
+		let (state_to_read, _) = state_handler_clone.load_clone(&shard_for_read).unwrap();
 		assert!(state_to_read.get(new_state_key_for_read.as_slice()).is_some());
 	});
 
@@ -183,7 +179,7 @@ pub fn test_state_handler_file_backend_is_initialized() {
 	assert!(1 <= state_handler.list_shards().unwrap().len()); // only greater equal, because there might be other (non-test) shards present
 	assert_eq!(1, number_of_files_in_shard_dir(&shard).unwrap()); // creates a first initialized file
 
-	let _state = state_handler.load(&shard).unwrap();
+	let _state = state_handler.load_clone(&shard).unwrap();
 
 	assert_eq!(1, number_of_files_in_shard_dir(&shard).unwrap());
 
@@ -273,8 +269,9 @@ pub fn test_state_files_from_handler_can_be_loaded_again() {
 	assert_eq!(
 		&"value3".encode(),
 		updated_state_handler
-			.load(&shard)
+			.load_clone(&shard)
 			.unwrap()
+			.0
 			.state()
 			.get("test_key_3".encode().as_slice())
 			.unwrap()

--- a/core-primitives/test/src/mock/handle_state_mock.rs
+++ b/core-primitives/test/src/mock/handle_state_mock.rs
@@ -21,15 +21,13 @@ use std::sync::{SgxRwLock as RwLock, SgxRwLockWriteGuard as RwLockWriteGuard};
 #[cfg(feature = "std")]
 use std::sync::{RwLock, RwLockWriteGuard};
 
-use codec::Encode;
-use ita_stf::State as StfState;
+use ita_stf::{hash::Hash, State as StfState};
 use itp_stf_state_handler::{
 	error::{Error, Result},
 	handle_state::HandleState,
 	query_shard_state::QueryShardState,
 };
 use itp_types::{ShardIdentifier, H256};
-use sp_core::blake2_256;
 use std::{collections::HashMap, format, vec::Vec};
 
 /// Mock implementation for the `HandleState` trait.
@@ -57,12 +55,28 @@ impl HandleState for HandleStateMock {
 		self.reset(StfState::default(), &shard)
 	}
 
-	fn load(&self, shard: &ShardIdentifier) -> Result<StfState> {
+	fn execute_on_current<E, R>(&self, shard: &ShardIdentifier, executing_function: E) -> Result<R>
+	where
+		E: FnOnce(&Self::StateT, Self::HashType) -> R,
+	{
+		self.state_map
+			.read()
+			.unwrap()
+			.get(shard)
+			.map(|state| executing_function(state, state.hash()))
+			.ok_or_else(|| Error::Other(format!("shard is not initialized {:?}", shard).into()))
+	}
+
+	fn load_clone(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)> {
 		self.state_map
 			.read()
 			.unwrap()
 			.get(shard)
 			.cloned()
+			.map(|s| {
+				let state_hash = s.hash();
+				(s, state_hash)
+			})
 			.ok_or_else(|| Error::Other(format!("shard is not initialized {:?}", shard).into()))
 	}
 
@@ -70,7 +84,7 @@ impl HandleState for HandleStateMock {
 		&self,
 		shard: &ShardIdentifier,
 	) -> Result<(RwLockWriteGuard<'_, Self::WriteLockPayload>, StfState)> {
-		let initialized_state = self.load(shard)?;
+		let (initialized_state, _) = self.load_clone(shard)?;
 		let write_lock = self.state_map.write().unwrap();
 		Ok((write_lock, initialized_state))
 	}
@@ -82,7 +96,7 @@ impl HandleState for HandleStateMock {
 		shard: &ShardIdentifier,
 	) -> Result<Self::HashType> {
 		state_lock.insert(*shard, state.clone());
-		Ok(state.using_encoded(blake2_256).into())
+		Ok(state.hash())
 	}
 
 	fn reset(&self, state: Self::StateT, shard: &ShardIdentifier) -> Result<Self::HashType> {
@@ -109,10 +123,10 @@ pub mod tests {
 	use super::*;
 	use codec::{Decode, Encode};
 	use ita_stf::stf_sgx_tests::StfState;
-	use itp_sgx_externalities::{SgxExternalitiesTrait, SgxExternalitiesType};
+	use itp_sgx_externalities::{SgxExternalities, SgxExternalitiesTrait, SgxExternalitiesType};
 	use itp_stf_interface::InitState;
 	use itp_types::ShardIdentifier;
-	use sp_core::{blake2_256, crypto::AccountId32};
+	use sp_core::crypto::AccountId32;
 
 	pub fn initialized_shards_list_is_empty() {
 		let state_handler = HandleStateMock::default();
@@ -124,7 +138,7 @@ pub mod tests {
 		let shard = ShardIdentifier::default();
 		state_handler.initialize_shard(shard).unwrap();
 
-		assert!(state_handler.load(&shard).is_ok());
+		assert!(state_handler.load_clone(&shard).is_ok());
 		assert!(state_handler.shard_exists(&shard).unwrap());
 	}
 
@@ -132,7 +146,7 @@ pub mod tests {
 		let shard = ShardIdentifier::default();
 		let state_handler = HandleStateMock::from_shard(shard).unwrap();
 
-		assert!(state_handler.load(&shard).is_ok());
+		assert!(state_handler.load_clone(&shard).is_ok());
 		assert!(state_handler.shard_exists(&shard).unwrap());
 	}
 
@@ -141,7 +155,7 @@ pub mod tests {
 		let shard = ShardIdentifier::default();
 		state_handler.initialize_shard(shard).unwrap();
 
-		let loaded_state_result = state_handler.load(&shard);
+		let loaded_state_result = state_handler.load_clone(&shard);
 
 		assert!(loaded_state_result.is_ok());
 	}
@@ -158,7 +172,7 @@ pub mod tests {
 
 		state_handler.write_after_mutation(state, lock, &shard).unwrap();
 
-		let updated_state = state_handler.load(&shard).unwrap();
+		let (updated_state, _) = state_handler.load_clone(&shard).unwrap();
 
 		let inserted_value =
 			updated_state.get(key.encode().as_slice()).expect("value for key should exist");
@@ -172,29 +186,23 @@ pub mod tests {
 
 		let (lock, _) = state_handler.load_for_mutation(&shard).unwrap();
 		let initial_state = StfState::init_state(AccountId32::new([0u8; 32]));
-		let state_hash_before_execution = hash_of(&initial_state.state);
+		let state_hash_before_execution = initial_state.hash();
 		state_handler.write_after_mutation(initial_state, lock, &shard).unwrap();
 
-		let state_loaded = state_handler.load(&shard).unwrap();
-		let loaded_state_hash = hash_of(&state_loaded.state);
+		let (_state_loaded, loaded_state_hash) = state_handler.load_clone(&shard).unwrap();
 
 		assert_eq!(state_hash_before_execution, loaded_state_hash);
 	}
 
 	pub fn ensure_encode_and_encrypt_does_not_affect_state_hash() {
 		let state = StfState::init_state(AccountId32::new([0u8; 32]));
-		let state_hash_before_execution = hash_of(&state.state);
+		let state_hash_before_execution = state.hash();
 
 		let encoded_state = state.state.encode();
 		let decoded_state: SgxExternalitiesType = decode(encoded_state);
-
-		let decoded_state_hash = hash_of(&decoded_state);
+		let decoded_state_hash = SgxExternalities::new(decoded_state).hash();
 
 		assert_eq!(state_hash_before_execution, decoded_state_hash);
-	}
-
-	fn hash_of<T: Encode>(encodable: &T) -> H256 {
-		encodable.using_encoded(blake2_256).into()
 	}
 
 	fn decode<T: Decode>(encoded: Vec<u8>) -> T {

--- a/core-primitives/test/src/mock/handle_state_mock.rs
+++ b/core-primitives/test/src/mock/handle_state_mock.rs
@@ -67,7 +67,7 @@ impl HandleState for HandleStateMock {
 			.ok_or_else(|| Error::Other(format!("shard is not initialized {:?}", shard).into()))
 	}
 
-	fn load_clone(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)> {
+	fn load_cloned(&self, shard: &ShardIdentifier) -> Result<(Self::StateT, Self::HashType)> {
 		self.state_map
 			.read()
 			.unwrap()
@@ -84,7 +84,7 @@ impl HandleState for HandleStateMock {
 		&self,
 		shard: &ShardIdentifier,
 	) -> Result<(RwLockWriteGuard<'_, Self::WriteLockPayload>, StfState)> {
-		let (initialized_state, _) = self.load_clone(shard)?;
+		let (initialized_state, _) = self.load_cloned(shard)?;
 		let write_lock = self.state_map.write().unwrap();
 		Ok((write_lock, initialized_state))
 	}
@@ -138,7 +138,7 @@ pub mod tests {
 		let shard = ShardIdentifier::default();
 		state_handler.initialize_shard(shard).unwrap();
 
-		assert!(state_handler.load_clone(&shard).is_ok());
+		assert!(state_handler.load_cloned(&shard).is_ok());
 		assert!(state_handler.shard_exists(&shard).unwrap());
 	}
 
@@ -146,7 +146,7 @@ pub mod tests {
 		let shard = ShardIdentifier::default();
 		let state_handler = HandleStateMock::from_shard(shard).unwrap();
 
-		assert!(state_handler.load_clone(&shard).is_ok());
+		assert!(state_handler.load_cloned(&shard).is_ok());
 		assert!(state_handler.shard_exists(&shard).unwrap());
 	}
 
@@ -155,7 +155,7 @@ pub mod tests {
 		let shard = ShardIdentifier::default();
 		state_handler.initialize_shard(shard).unwrap();
 
-		let loaded_state_result = state_handler.load_clone(&shard);
+		let loaded_state_result = state_handler.load_cloned(&shard);
 
 		assert!(loaded_state_result.is_ok());
 	}
@@ -172,7 +172,7 @@ pub mod tests {
 
 		state_handler.write_after_mutation(state, lock, &shard).unwrap();
 
-		let (updated_state, _) = state_handler.load_clone(&shard).unwrap();
+		let (updated_state, _) = state_handler.load_cloned(&shard).unwrap();
 
 		let inserted_value =
 			updated_state.get(key.encode().as_slice()).expect("value for key should exist");
@@ -189,7 +189,7 @@ pub mod tests {
 		let state_hash_before_execution = initial_state.hash();
 		state_handler.write_after_mutation(initial_state, lock, &shard).unwrap();
 
-		let (_state_loaded, loaded_state_hash) = state_handler.load_clone(&shard).unwrap();
+		let (_, loaded_state_hash) = state_handler.load_cloned(&shard).unwrap();
 
 		assert_eq!(state_hash_before_execution, loaded_state_hash);
 	}

--- a/core-primitives/top-pool-author/src/author_tests.rs
+++ b/core-primitives/top-pool-author/src/author_tests.rs
@@ -130,7 +130,7 @@ fn create_author_with_filter<F: Filter<Value = TrustedOperation>>(
 
 	let shard_id = shard_id();
 	let state_facade = HandleStateMock::from_shard(shard_id).unwrap();
-	let _ = state_facade.load(&shard_id).unwrap();
+	let _ = state_facade.load_clone(&shard_id).unwrap();
 
 	let encryption_key = ShieldingCryptoMock::default();
 	let shielding_key_repo =

--- a/core-primitives/top-pool-author/src/author_tests.rs
+++ b/core-primitives/top-pool-author/src/author_tests.rs
@@ -130,7 +130,7 @@ fn create_author_with_filter<F: Filter<Value = TrustedOperation>>(
 
 	let shard_id = shard_id();
 	let state_facade = HandleStateMock::from_shard(shard_id).unwrap();
-	let _ = state_facade.load_clone(&shard_id).unwrap();
+	state_facade.load_cloned(&shard_id).unwrap();
 
 	let encryption_key = ShieldingCryptoMock::default();
 	let shielding_key_repo =

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       target: deployed-worker
     depends_on: ['integritee-node']
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,enclave_runtime::top_pool_execution=info
+      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
     networks:
       - integritee-test-network
     entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s

--- a/enclave-runtime/src/initialization/global_components.rs
+++ b/enclave-runtime/src/initialization/global_components.rs
@@ -56,7 +56,6 @@ use itp_extrinsics_factory::ExtrinsicsFactory;
 use itp_node_api::metadata::{provider::NodeMetadataRepository, NodeMetadata};
 use itp_nonce_cache::NonceCache;
 use itp_sgx_crypto::{key_repository::KeyRepository, Aes, AesSeal, Rsa3072Seal};
-use itp_sgx_externalities::SgxExternalities;
 use itp_stf_executor::{
 	enclave_signer::StfEnclaveSigner, executor::StfExecutor, getter_executor::GetterExecutor,
 	state_getter::StfStateGetter,
@@ -80,7 +79,6 @@ use its_sidechain::{
 	aura::block_importer::BlockImporter as SidechainBlockImporter,
 	block_composer::BlockComposer,
 	consensus_common::{BlockImportConfirmationHandler, BlockImportQueueWorker, PeerBlockSync},
-	state::SidechainDB,
 };
 use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
 use sp_core::ed25519::Pair;
@@ -151,8 +149,6 @@ pub type EnclaveParentchainBlockImportDispatcher = BlockImportDispatcher<
 >;
 
 /// Sidechain types
-pub type EnclaveSidechainState =
-	SidechainDB<<SignedSidechainBlock as SignedSidechainBlockTrait>::Block, SgxExternalities>;
 pub type EnclaveTopPool = BasicPool<EnclaveSidechainApi, ParentchainBlock, EnclaveRpcResponder>;
 
 pub type EnclaveTopPoolAuthor = Author<
@@ -169,7 +165,6 @@ pub type EnclaveSidechainBlockImporter = SidechainBlockImporter<
 	ParentchainBlock,
 	SignedSidechainBlock,
 	EnclaveOCallApi,
-	EnclaveSidechainState,
 	EnclaveStateHandler,
 	EnclaveStateKeyRepository,
 	EnclaveTopPoolAuthor,

--- a/enclave-runtime/src/test/mocks/types.rs
+++ b/enclave-runtime/src/test/mocks/types.rs
@@ -88,7 +88,6 @@ pub type TestBlockImporter = BlockImporter<
 	ParentchainBlock,
 	SignedSidechainBlock,
 	TestOCallApi,
-	TestSidechainDb,
 	HandleStateMock,
 	TestStateKeyRepo,
 	TestTopPoolAuthor,

--- a/enclave-runtime/src/test/mocks/types.rs
+++ b/enclave-runtime/src/test/mocks/types.rs
@@ -33,10 +33,8 @@ use itp_test::mock::{
 use itp_top_pool::basic_pool::BasicPool;
 use itp_top_pool_author::{api::SidechainApi, author::Author, top_filter::AllowAllTopsFilter};
 use itp_types::{Block as ParentchainBlock, SignedBlock as SignedParentchainBlock};
-use its_primitives::types::{Block as SidechainBlock, SignedBlock as SignedSidechainBlock};
-use its_sidechain::{
-	aura::block_importer::BlockImporter, block_composer::BlockComposer, state::SidechainDB,
-};
+use its_primitives::types::SignedBlock as SignedSidechainBlock;
+use its_sidechain::{aura::block_importer::BlockImporter, block_composer::BlockComposer};
 use primitive_types::H256;
 use sgx_crypto_helper::rsa3072::Rsa3072KeyPair;
 use sp_core::ed25519 as spEd25519;
@@ -54,8 +52,6 @@ pub type TestShieldingKeyRepo = KeyRepositoryMock<TestShieldingKey>;
 pub type TestStateKeyRepo = KeyRepositoryMock<TestStateKey>;
 
 pub type TestStateHandler = HandleStateMock;
-
-pub type TestSidechainDb = SidechainDB<SidechainBlock, SgxExternalities>;
 
 pub type TestOCallApi = OnchainMock;
 

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -37,6 +37,7 @@ use ita_stf::{
 use itc_parentchain::light_client::mocks::validator_access_mock::ValidatorAccessMock;
 use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
 use itp_extrinsics_factory::mock::ExtrinsicsFactoryMock;
+use itp_hashing::Hash;
 use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_settings::{
@@ -53,9 +54,7 @@ use itp_top_pool_author::{top_filter::AllowAllTopsFilter, traits::AuthorApi};
 use itp_types::{AccountId, Block as ParentchainBlock, ShardIdentifier};
 use its_block_verification::slot::slot_from_timestamp_and_duration;
 use its_primitives::{traits::Block, types::SignedBlock as SignedSidechainBlock};
-use its_sidechain::{
-	aura::proposer_factory::ProposerFactory, slots::SlotInfo, state::SidechainState,
-};
+use its_sidechain::{aura::proposer_factory::ProposerFactory, slots::SlotInfo};
 use jsonrpc_core::futures::executor;
 use log::*;
 use primitive_types::H256;
@@ -254,6 +253,5 @@ fn get_state_hashes_from_block(
 
 fn get_state_hash(state_handler: &HandleStateMock, shard_id: &ShardIdentifier) -> H256 {
 	let state = state_handler.load(shard_id).unwrap();
-	let sidechain_state = TestSidechainDb::new(state);
-	sidechain_state.state_hash()
+	state.hash()
 }

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -37,7 +37,6 @@ use ita_stf::{
 use itc_parentchain::light_client::mocks::validator_access_mock::ValidatorAccessMock;
 use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
 use itp_extrinsics_factory::mock::ExtrinsicsFactoryMock;
-use itp_hashing::Hash;
 use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_settings::{
@@ -215,7 +214,7 @@ pub fn produce_sidechain_block_and_import_it() {
 		get_state_hash(state_handler.as_ref(), &shard_id)
 	);
 
-	let mut state = state_handler.load(&shard_id).unwrap();
+	let (mut state, _) = state_handler.load_clone(&shard_id).unwrap();
 	let free_balance = TestStf::get_account_data(&mut state, &receiver.public().into()).free;
 	assert_eq!(free_balance, transfered_amount);
 	assert!(TestStf::get_event_count(&mut state) > 0);
@@ -252,6 +251,6 @@ fn get_state_hashes_from_block(
 }
 
 fn get_state_hash(state_handler: &HandleStateMock, shard_id: &ShardIdentifier) -> H256 {
-	let state = state_handler.load(shard_id).unwrap();
-	state.hash()
+	let (_, state_hash) = state_handler.load_clone(shard_id).unwrap();
+	state_hash
 }

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -214,7 +214,7 @@ pub fn produce_sidechain_block_and_import_it() {
 		get_state_hash(state_handler.as_ref(), &shard_id)
 	);
 
-	let (mut state, _) = state_handler.load_clone(&shard_id).unwrap();
+	let (mut state, _) = state_handler.load_cloned(&shard_id).unwrap();
 	let free_balance = TestStf::get_account_data(&mut state, &receiver.public().into()).free;
 	assert_eq!(free_balance, transfered_amount);
 	assert!(TestStf::get_event_count(&mut state) > 0);
@@ -251,6 +251,6 @@ fn get_state_hashes_from_block(
 }
 
 fn get_state_hash(state_handler: &HandleStateMock, shard_id: &ShardIdentifier) -> H256 {
-	let (_, state_hash) = state_handler.load_clone(shard_id).unwrap();
+	let (_, state_hash) = state_handler.load_cloned(shard_id).unwrap();
 	state_hash
 }

--- a/enclave-runtime/src/test/sidechain_event_tests.rs
+++ b/enclave-runtime/src/test/sidechain_event_tests.rs
@@ -124,7 +124,7 @@ pub fn ensure_events_get_reset_upon_block_proposal() {
 	state_handler.write_after_mutation(state.clone(), lock, &shard_id).unwrap();
 
 	// Check if state now really contains events and topics.
-	let (mut state, _) = state_handler.load_clone(&shard_id).unwrap();
+	let (mut state, _) = state_handler.load_cloned(&shard_id).unwrap();
 	assert_eq!(TestStf::get_event_count(&mut state), 1);
 	assert_eq!(TestStf::get_events(&mut state).len(), 1);
 	assert_eq!(TestStf::get_event_topics(&mut state, &topic_hash).len(), 1);
@@ -162,7 +162,7 @@ pub fn ensure_events_get_reset_upon_block_proposal() {
 	.unwrap();
 
 	// Ensure events have been reset.
-	let (mut state, _) = state_handler.load_clone(&shard_id).unwrap();
+	let (mut state, _) = state_handler.load_cloned(&shard_id).unwrap();
 	assert_eq!(TestStf::get_event_count(&mut state), 0);
 	assert_eq!(TestStf::get_event_topics(&mut state, &topic_hash).len(), 0);
 	assert_eq!(TestStf::get_events(&mut state).len(), 0);

--- a/enclave-runtime/src/test/sidechain_event_tests.rs
+++ b/enclave-runtime/src/test/sidechain_event_tests.rs
@@ -124,7 +124,7 @@ pub fn ensure_events_get_reset_upon_block_proposal() {
 	state_handler.write_after_mutation(state.clone(), lock, &shard_id).unwrap();
 
 	// Check if state now really contains events and topics.
-	let mut state = state_handler.load(&shard_id).unwrap();
+	let (mut state, _) = state_handler.load_clone(&shard_id).unwrap();
 	assert_eq!(TestStf::get_event_count(&mut state), 1);
 	assert_eq!(TestStf::get_events(&mut state).len(), 1);
 	assert_eq!(TestStf::get_event_topics(&mut state, &topic_hash).len(), 1);
@@ -162,7 +162,7 @@ pub fn ensure_events_get_reset_upon_block_proposal() {
 	.unwrap();
 
 	// Ensure events have been reset.
-	let mut state = state_handler.load(&shard_id).unwrap();
+	let (mut state, _) = state_handler.load_clone(&shard_id).unwrap();
 	assert_eq!(TestStf::get_event_count(&mut state), 0);
 	assert_eq!(TestStf::get_event_topics(&mut state, &topic_hash).len(), 0);
 	assert_eq!(TestStf::get_events(&mut state).len(), 0);

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -195,7 +195,7 @@ fn test_compose_block() {
 
 	let signed_top_hashes: Vec<H256> = vec![[94; 32].into(), [1; 32].into()].to_vec();
 
-	let mut state = state_handler.load(&shard).unwrap();
+	let (mut state, _) = state_handler.load_clone(&shard).unwrap();
 	state.set_block_number(&1);
 	let state_hash_before_execution = state.hash();
 
@@ -446,7 +446,7 @@ fn test_executing_call_updates_account_nonce() {
 
 fn test_call_set_update_parentchain_block() {
 	let (_, _, shard, _, _, state_handler, _) = test_setup();
-	let mut state = state_handler.load(&shard).unwrap();
+	let (mut state, _) = state_handler.load_clone(&shard).unwrap();
 
 	let block_number = 3;
 	let parent_hash = H256::from([1; 32]);

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -194,7 +194,7 @@ fn test_compose_block() {
 
 	let signed_top_hashes: Vec<H256> = vec![[94; 32].into(), [1; 32].into()].to_vec();
 
-	let (mut state, _) = state_handler.load_clone(&shard).unwrap();
+	let (mut state, _) = state_handler.load_cloned(&shard).unwrap();
 	state.set_block_number(&1);
 	let state_hash_before_execution = state.hash();
 
@@ -445,7 +445,7 @@ fn test_executing_call_updates_account_nonce() {
 
 fn test_call_set_update_parentchain_block() {
 	let (_, _, shard, _, _, state_handler, _) = test_setup();
-	let (mut state, _) = state_handler.load_clone(&shard).unwrap();
+	let (mut state, _) = state_handler.load_cloned(&shard).unwrap();
 
 	let block_number = 3;
 	let parent_hash = H256::from([1; 32]);

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -122,7 +122,6 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		sidechain_rw_lock_works,
 		enclave_rw_lock_works,
 		// unit tests of stf_executor
-		stf_executor_tests::execute_update_works,
 		stf_executor_tests::propose_state_update_always_executes_preprocessing_step,
         stf_executor_tests::propose_state_update_executes_no_trusted_calls_given_no_time,
 		stf_executor_tests::propose_state_update_executes_only_one_trusted_call_given_not_enough_time,

--- a/enclave-runtime/src/tls_ra/seal_handler.rs
+++ b/enclave-runtime/src/tls_ra/seal_handler.rs
@@ -146,8 +146,7 @@ where
 	}
 
 	fn unseal_state(&self, shard: &ShardIdentifier) -> EnclaveResult<Vec<u8>> {
-		let state = self.state_handler.load(shard)?;
-		Ok(state.state.encode())
+		Ok(self.state_handler.execute_on_current(shard, |state, _| state.state.encode())?)
 	}
 }
 

--- a/sidechain/block-composer/src/block_composer.rs
+++ b/sidechain/block-composer/src/block_composer.rs
@@ -138,12 +138,9 @@ where
 		}
 
 		// create encrypted payload
-		let mut payload: Vec<u8> = StatePayload::new(
-			state_hash_apriori,
-			state_hash_new,
-			aposteriori_state.state_diff().clone(),
-		)
-		.encode();
+		let mut payload: Vec<u8> =
+			StatePayload::new(state_hash_apriori, state_hash_new, aposteriori_state.state_diff())
+				.encode();
 
 		let state_key = self
 			.state_key_repository

--- a/sidechain/consensus/aura/src/block_importer.rs
+++ b/sidechain/consensus/aura/src/block_importer.rs
@@ -217,6 +217,8 @@ impl<
 			.load_for_mutation(shard)
 			.map_err(|e| ConsensusError::Other(format!("{:?}", e).into()))?;
 
+		// We load a copy of the state and apply the update. In case the update fails, we don't write
+		// the state back to the state handler, and thus guaranteeing state integrity.
 		let updated_state = mutating_function(state)?;
 
 		self.state_handler
@@ -237,12 +239,6 @@ impl<
 		self.state_handler
 			.execute_on_current(shard, |state, _| verifying_function(&state))
 			.map_err(|e| ConsensusError::Other(format!("{:?}", e).into()))?
-
-		// let (state, _) = self
-		// 	.state_handler
-		// 	.load_clone(shard)
-		// 	.map_err(|e| ConsensusError::Other(format!("{:?}", e).into()))?;
-		// verifying_function(&state)
 	}
 
 	fn state_key(&self) -> Result<Self::StateCrypto, ConsensusError> {

--- a/sidechain/consensus/aura/src/block_importer.rs
+++ b/sidechain/consensus/aura/src/block_importer.rs
@@ -52,7 +52,6 @@ pub struct BlockImporter<
 	ParentchainBlock,
 	SignedSidechainBlock,
 	OCallApi,
-	SidechainState,
 	StateHandler,
 	StateKeyRepository,
 	TopPoolAuthor,
@@ -63,7 +62,7 @@ pub struct BlockImporter<
 	top_pool_author: Arc<TopPoolAuthor>,
 	parentchain_block_importer: Arc<ParentchainBlockImporter>,
 	ocall_api: Arc<OCallApi>,
-	_phantom: PhantomData<(Authority, ParentchainBlock, SignedSidechainBlock, SidechainState)>,
+	_phantom: PhantomData<(Authority, ParentchainBlock, SignedSidechainBlock)>,
 }
 
 impl<
@@ -71,7 +70,6 @@ impl<
 		ParentchainBlock,
 		SignedSidechainBlock,
 		OCallApi,
-		SidechainState,
 		StateHandler,
 		StateKeyRepository,
 		TopPoolAuthor,
@@ -82,7 +80,6 @@ impl<
 		ParentchainBlock,
 		SignedSidechainBlock,
 		OCallApi,
-		SidechainState,
 		StateHandler,
 		StateKeyRepository,
 		TopPoolAuthor,
@@ -168,7 +165,6 @@ impl<
 		ParentchainBlock,
 		SignedSidechainBlock,
 		OCallApi,
-		SidechainDB<SignedSidechainBlock::Block, SgxExternalities>,
 		StateHandler,
 		StateKeyRepository,
 		TopPoolAuthor,

--- a/sidechain/consensus/aura/src/block_importer.rs
+++ b/sidechain/consensus/aura/src/block_importer.rs
@@ -237,7 +237,7 @@ impl<
 		F: FnOnce(&Self::SidechainState) -> Result<SignedSidechainBlock, ConsensusError>,
 	{
 		self.state_handler
-			.execute_on_current(shard, |state, _| verifying_function(&state))
+			.execute_on_current(shard, |state, _| verifying_function(state))
 			.map_err(|e| ConsensusError::Other(format!("{:?}", e).into()))?
 	}
 

--- a/sidechain/consensus/aura/src/block_importer.rs
+++ b/sidechain/consensus/aura/src/block_importer.rs
@@ -234,11 +234,15 @@ impl<
 	where
 		F: FnOnce(&Self::SidechainState) -> Result<SignedSidechainBlock, ConsensusError>,
 	{
-		let state = self
-			.state_handler
-			.load(shard)
-			.map_err(|e| ConsensusError::Other(format!("{:?}", e).into()))?;
-		verifying_function(&state)
+		self.state_handler
+			.execute_on_current(shard, |state, _| verifying_function(&state))
+			.map_err(|e| ConsensusError::Other(format!("{:?}", e).into()))?
+
+		// let (state, _) = self
+		// 	.state_handler
+		// 	.load_clone(shard)
+		// 	.map_err(|e| ConsensusError::Other(format!("{:?}", e).into()))?;
+		// verifying_function(&state)
 	}
 
 	fn state_key(&self) -> Result<Self::StateCrypto, ConsensusError> {

--- a/sidechain/consensus/aura/src/slot_proposer.rs
+++ b/sidechain/consensus/aura/src/slot_proposer.rs
@@ -28,7 +28,7 @@ use its_primitives::traits::{
 	Block as SidechainBlockTrait, Header as HeaderTrait, ShardIdentifierFor,
 	SignedBlock as SignedSidechainBlockTrait,
 };
-use its_state::{SidechainDB, SidechainState, SidechainSystemExt};
+use its_state::{SidechainState, SidechainSystemExt};
 use log::*;
 use sp_runtime::{
 	traits::{Block, NumberFor},
@@ -104,16 +104,12 @@ where
 				latest_parentchain_header,
 				&self.shard,
 				max_duration,
-				|s| {
-					let mut sidechain_db = SidechainDB::<
-						SignedSidechainBlock::Block,
-						ExternalitiesFor<StfExecutor>,
-					>::new(s);
+				|mut sidechain_db| {
 					sidechain_db.reset_events();
 					sidechain_db
 						.set_block_number(&sidechain_db.get_block_number().map_or(1, |n| n + 1));
 					sidechain_db.set_timestamp(&now_as_u64());
-					sidechain_db.ext
+					sidechain_db
 				},
 			)
 			.map_err(|e| ConsensusError::Other(e.to_string().into()))?;
@@ -145,7 +141,7 @@ where
 				executed_operation_hashes,
 				self.shard,
 				batch_execution_result.state_hash_before_execution,
-				batch_execution_result.state_after_execution,
+				&batch_execution_result.state_after_execution,
 			)
 			.map_err(|e| ConsensusError::Other(e.to_string().into()))?;
 

--- a/sidechain/consensus/aura/src/test/block_importer_tests.rs
+++ b/sidechain/consensus/aura/src/test/block_importer_tests.rs
@@ -18,7 +18,6 @@
 use crate::{block_importer::BlockImporter, test::fixtures::validateer, ShardIdentifierFor};
 use codec::Encode;
 use core::assert_matches::assert_matches;
-use ita_stf::hash::Hash;
 use itc_parentchain_block_import_dispatcher::trigger_parentchain_block_import_mock::TriggerParentchainBlockImportMock;
 use itc_parentchain_test::{
 	parentchain_block_builder::ParentchainBlockBuilder,
@@ -104,7 +103,7 @@ fn test_fixtures_with_default_import_trigger(
 }
 
 fn empty_encrypted_state_update(state_handler: &HandleStateMock) -> Vec<u8> {
-	let apriori_state_hash = state_handler.load(&shard()).unwrap().hash();
+	let (_, apriori_state_hash) = state_handler.load_clone(&shard()).unwrap();
 	let empty_state_diff = SgxExternalitiesDiffType::default();
 	let mut state_update =
 		StateUpdate::new(apriori_state_hash, apriori_state_hash, empty_state_diff).encode();

--- a/sidechain/consensus/aura/src/test/block_importer_tests.rs
+++ b/sidechain/consensus/aura/src/test/block_importer_tests.rs
@@ -103,7 +103,7 @@ fn test_fixtures_with_default_import_trigger(
 }
 
 fn empty_encrypted_state_update(state_handler: &HandleStateMock) -> Vec<u8> {
-	let (_, apriori_state_hash) = state_handler.load_clone(&shard()).unwrap();
+	let (_, apriori_state_hash) = state_handler.load_cloned(&shard()).unwrap();
 	let empty_state_diff = SgxExternalitiesDiffType::default();
 	let mut state_update =
 		StateUpdate::new(apriori_state_hash, apriori_state_hash, empty_state_diff).encode();

--- a/sidechain/consensus/aura/src/test/block_importer_tests.rs
+++ b/sidechain/consensus/aura/src/test/block_importer_tests.rs
@@ -56,7 +56,6 @@ type TestBlockImporter = BlockImporter<
 	ParentchainBlock,
 	SignedSidechainBlock,
 	OnchainMock,
-	TestSidechainState,
 	HandleStateMock,
 	TestStateKeyRepo,
 	TestTopPoolAuthor,

--- a/sidechain/consensus/common/src/block_import.rs
+++ b/sidechain/consensus/common/src/block_import.rs
@@ -53,7 +53,10 @@ where
 	type Context: EnclaveSidechainOCallApi;
 
 	/// Get a verifier instance.
-	fn verifier(&self, state: Self::SidechainState) -> Self::Verifier;
+	fn verifier(
+		&self,
+		maybe_last_sidechain_block: Option<SignedSidechainBlock::Block>,
+	) -> Self::Verifier;
 
 	/// Apply a state update by providing a mutating function.
 	fn apply_state_update<F>(
@@ -71,7 +74,7 @@ where
 		verifying_function: F,
 	) -> Result<SignedSidechainBlock, Error>
 	where
-		F: FnOnce(Self::SidechainState) -> Result<SignedSidechainBlock, Error>;
+		F: FnOnce(&Self::SidechainState) -> Result<SignedSidechainBlock, Error>;
 
 	/// Key that is used for state encryption.
 	fn state_key(&self) -> Result<Self::StateCrypto, Error>;
@@ -129,7 +132,7 @@ where
 				});
 
 		let block_import_params = self.verify_import(&shard, |state| {
-			let verifier = self.verifier(state);
+			let verifier = self.verifier(state.get_last_block());
 			verifier.verify(
 				signed_sidechain_block.clone(),
 				&peeked_parentchain_header,

--- a/sidechain/consensus/common/src/test/mocks/block_importer_mock.rs
+++ b/sidechain/consensus/common/src/test/mocks/block_importer_mock.rs
@@ -22,7 +22,6 @@ use itp_sgx_externalities::SgxExternalities;
 use itp_test::mock::onchain_mock::OnchainMock;
 use itp_types::H256;
 use its_primitives::traits::{ShardIdentifierFor, SignedBlock as SignedSidechainBlockTrait};
-use its_state::SidechainDB;
 use sp_core::Pair;
 use sp_runtime::traits::Block as ParentchainBlockTrait;
 use std::{collections::VecDeque, sync::RwLock};
@@ -93,11 +92,14 @@ where
 {
 	type Verifier =
 		VerifierMock<ParentchainBlock, SignedSidechainBlock, SignedSidechainBlock, OnchainMock>;
-	type SidechainState = SidechainDB<SignedSidechainBlock::Block, SgxExternalities>;
+	type SidechainState = SgxExternalities;
 	type StateCrypto = Aes;
 	type Context = OnchainMock;
 
-	fn verifier(&self, _state: Self::SidechainState) -> Self::Verifier {
+	fn verifier(
+		&self,
+		_maybe_last_sidechain_block: Option<SignedSidechainBlock::Block>,
+	) -> Self::Verifier {
 		todo!()
 	}
 
@@ -118,7 +120,7 @@ where
 		_verifying_function: F,
 	) -> core::result::Result<SignedSidechainBlock, Error>
 	where
-		F: FnOnce(Self::SidechainState) -> core::result::Result<SignedSidechainBlock, Error>,
+		F: FnOnce(&Self::SidechainState) -> core::result::Result<SignedSidechainBlock, Error>,
 	{
 		todo!()
 	}

--- a/sidechain/state/src/impls.rs
+++ b/sidechain/state/src/impls.rs
@@ -17,7 +17,7 @@
 
 //! Implement the sidechain state traits.
 
-use crate::{Error, SidechainDB, SidechainState, StateUpdate};
+use crate::{Error, SidechainState, StateUpdate};
 use codec::{Decode, Encode};
 use frame_support::ensure;
 use itp_sgx_externalities::{SgxExternalitiesTrait, StateHash};
@@ -25,70 +25,6 @@ use itp_storage::keys::storage_value_key;
 use log::{error, info};
 use sp_core::H256;
 use sp_io::{storage, KillStorageResult};
-use std::vec::Vec;
-
-impl<SidechainBlock, T> SidechainState for SidechainDB<SidechainBlock, T>
-where
-	T: SgxExternalitiesTrait + StateHash + Clone,
-	<T as SgxExternalitiesTrait>::SgxExternalitiesType: Encode,
-	SidechainBlock: Clone,
-{
-	type Externalities = T;
-	type StateUpdate = StateUpdate;
-	type Hash = H256;
-
-	fn state_hash(&self) -> Self::Hash {
-		self.ext.hash()
-	}
-
-	fn ext(&self) -> &Self::Externalities {
-		&self.ext
-	}
-
-	fn ext_mut(&mut self) -> &mut Self::Externalities {
-		&mut self.ext
-	}
-
-	fn apply_state_update(&mut self, state_payload: &Self::StateUpdate) -> Result<(), Error> {
-		self.ext_mut().apply_state_update(state_payload)
-	}
-
-	fn get_with_name<V: Decode>(&self, module_prefix: &str, storage_prefix: &str) -> Option<V> {
-		self.ext().get_with_name(module_prefix, storage_prefix)
-	}
-
-	fn set_with_name<V: Encode>(&mut self, module_prefix: &str, storage_prefix: &str, value: V) {
-		self.ext_mut().set_with_name(module_prefix, storage_prefix, value)
-	}
-
-	fn clear_with_name(&mut self, module_prefix: &str, storage_prefix: &str) {
-		self.ext_mut().clear_with_name(module_prefix, storage_prefix)
-	}
-
-	fn clear_prefix_with_name(
-		&mut self,
-		module_prefix: &str,
-		storage_prefix: &str,
-	) -> KillStorageResult {
-		self.ext_mut().clear_prefix_with_name(module_prefix, storage_prefix)
-	}
-
-	fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-		self.ext().get(key).cloned()
-	}
-
-	fn set(&mut self, key: &[u8], value: &[u8]) {
-		self.ext_mut().set(key, value)
-	}
-
-	fn clear(&mut self, key: &[u8]) {
-		self.ext_mut().clear(key)
-	}
-
-	fn clear_sidechain_prefix(&mut self, prefix: &[u8]) -> KillStorageResult {
-		self.ext_mut().clear_sidechain_prefix(prefix)
-	}
-}
 
 impl<T: SgxExternalitiesTrait + Clone + StateHash> SidechainState for T
 where
@@ -164,10 +100,6 @@ where
 		self.clear_sidechain_prefix(&storage_value_key(module_prefix, storage_prefix))
 	}
 
-	fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-		self.get(key).cloned()
-	}
-
 	fn set(&mut self, key: &[u8], value: &[u8]) {
 		self.execute_with(|| sp_io::storage::set(key, value))
 	}
@@ -184,13 +116,13 @@ where
 #[cfg(test)]
 pub mod tests {
 	use super::*;
-	use crate::{SidechainDB, StateUpdate};
+	use crate::StateUpdate;
 	use frame_support::{assert_err, assert_ok};
 	use itp_sgx_externalities::{SgxExternalities, SgxExternalitiesTrait};
 	use sp_core::H256;
 
-	pub fn default_db() -> SidechainDB<(), SgxExternalities> {
-		SidechainDB::<(), SgxExternalities>::default()
+	pub fn default_db() -> SgxExternalities {
+		SgxExternalities::default()
 	}
 
 	#[test]
@@ -202,13 +134,12 @@ pub mod tests {
 		state1.set(b"Hello", b"World");
 		let aposteriori = state1.state_hash();
 
-		let mut state_update =
-			StateUpdate::new(apriori, aposteriori, state1.ext.state_diff.clone());
+		let mut state_update = StateUpdate::new(apriori, aposteriori, state1.state_diff().clone());
 
 		assert_ok!(state2.apply_state_update(&mut state_update));
 		assert_eq!(state2.state_hash(), aposteriori);
 		assert_eq!(state2.get(b"Hello").unwrap(), b"World");
-		assert!(state2.ext.state_diff.is_empty());
+		assert!(state2.state_diff().is_empty());
 	}
 
 	#[test]
@@ -220,8 +151,7 @@ pub mod tests {
 		state1.set(b"Hello", b"World");
 		let aposteriori = state1.state_hash();
 
-		let mut state_update =
-			StateUpdate::new(apriori, aposteriori, state1.ext.state_diff.clone());
+		let mut state_update = StateUpdate::new(apriori, aposteriori, state1.state_diff().clone());
 
 		assert_err!(state2.apply_state_update(&mut state_update), Error::InvalidAprioriHash);
 		assert_eq!(state2, default_db());
@@ -236,8 +166,7 @@ pub mod tests {
 		state1.set(b"Hello", b"World");
 		let aposteriori = H256::from([1; 32]);
 
-		let mut state_update =
-			StateUpdate::new(apriori, aposteriori, state1.ext.state_diff.clone());
+		let mut state_update = StateUpdate::new(apriori, aposteriori, state1.state_diff().clone());
 
 		assert_err!(state2.apply_state_update(&mut state_update), Error::InvalidStorageDiff);
 		assert_eq!(state2, default_db());
@@ -247,11 +176,11 @@ pub mod tests {
 	pub fn sp_io_storage_set_creates_storage_diff() {
 		let mut state1 = default_db();
 
-		state1.ext.execute_with(|| {
+		state1.execute_with(|| {
 			storage::set(b"hello", b"world");
 		});
 
-		assert_eq!(state1.ext.state_diff.get(&b"hello"[..]).unwrap(), &Some(b"world".encode()));
+		assert_eq!(state1.state_diff().get(&b"hello"[..]).unwrap(), &Some(b"world".encode()));
 	}
 
 	#[test]
@@ -260,6 +189,6 @@ pub mod tests {
 
 		state1.set(b"hello", b"world");
 
-		assert_eq!(state1.ext.state_diff.get(&b"hello"[..]).unwrap(), &Some(b"world".encode()));
+		assert_eq!(state1.state_diff().get(&b"hello"[..]).unwrap(), &Some(b"world".encode()));
 	}
 }

--- a/sidechain/state/src/lib.rs
+++ b/sidechain/state/src/lib.rs
@@ -42,25 +42,6 @@ use its_primitives::{
 };
 use sp_core::H256;
 use sp_io::KillStorageResult;
-use sp_std::prelude::Vec;
-use std::marker::PhantomData;
-
-/// Sidechain wrapper and interface of the STF state.
-///
-/// TODO: In the course of refactoring the STF (#269), verify if this struct is even needed.
-/// It might be that we could implement everything directly on `[SgxExternalities]`.
-#[derive(Clone, Debug, Default, Encode, Decode, PartialEq, Eq)]
-pub struct SidechainDB<Block, E> {
-	/// Externalities
-	pub ext: E,
-	_phantom: PhantomData<Block>,
-}
-
-impl<Block, E> SidechainDB<Block, E> {
-	pub fn new(externalities: E) -> Self {
-		Self { ext: externalities, _phantom: Default::default() }
-	}
-}
 
 /// Contains the necessary data to update the `SidechainDB` when importing a `SidechainBlock`.
 #[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
@@ -133,9 +114,6 @@ pub trait SidechainState: Clone {
 		storage_prefix: &str,
 	) -> KillStorageResult;
 
-	/// get a storage value by its storage hash
-	fn get(&self, key: &[u8]) -> Option<Vec<u8>>;
-
 	/// set a storage value by its storage hash
 	fn set(&mut self, key: &[u8], value: &[u8]);
 
@@ -155,10 +133,8 @@ pub trait LastBlockExt<SidechainBlock: SidechainBlockTrait> {
 	fn set_last_block(&mut self, block: &SidechainBlock);
 }
 
-impl<SidechainBlock: SidechainBlockTrait, E> LastBlockExt<SidechainBlock>
-	for SidechainDB<SidechainBlock, E>
-where
-	SidechainDB<SidechainBlock, E>: SidechainState + SidechainSystemExt,
+impl<SidechainBlock: SidechainBlockTrait, E: SidechainState + SidechainSystemExt>
+	LastBlockExt<SidechainBlock> for E
 {
 	fn get_last_block(&self) -> Option<SidechainBlock> {
 		self.get_with_name("System", "LastBlock")

--- a/sidechain/state/src/lib.rs
+++ b/sidechain/state/src/lib.rs
@@ -84,27 +84,19 @@ pub trait SidechainState: Clone {
 
 	type StateUpdate: Encode + Decode;
 
-	type Hash;
-
-	/// get the hash of the state
-	fn state_hash(&self) -> Self::Hash;
-
-	/// get a reference to the underlying externalities of the state
-	fn ext(&self) -> &Self::Externalities;
-
-	/// get a mutable reference to the underlying externalities of the state
-	fn ext_mut(&mut self) -> &mut Self::Externalities;
-
-	/// apply the state update to the state
+	/// Apply the state update to the state.
+	///
+	/// Does not guarantee state consistency in case of a failure.
+	/// Caller is responsible for discarding corrupt/inconsistent state.
 	fn apply_state_update(&mut self, state_payload: &Self::StateUpdate) -> Result<(), Error>;
 
-	/// get a storage value by its full name
+	/// Get a storage value by its full name.
 	fn get_with_name<V: Decode>(&self, module_prefix: &str, storage_prefix: &str) -> Option<V>;
 
-	/// set a storage value by its full name
+	/// Set a storage value by its full name.
 	fn set_with_name<V: Encode>(&mut self, module_prefix: &str, storage_prefix: &str, value: V);
 
-	/// Clear a storage value by its full name
+	/// Clear a storage value by its full name.
 	fn clear_with_name(&mut self, module_prefix: &str, storage_prefix: &str);
 
 	/// Clear all storage values for the given prefix.
@@ -114,7 +106,7 @@ pub trait SidechainState: Clone {
 		storage_prefix: &str,
 	) -> KillStorageResult;
 
-	/// set a storage value by its storage hash
+	/// Set a storage value by its storage hash.
 	fn set(&mut self, key: &[u8], value: &[u8]);
 
 	/// Clear a storage value by its storage hash.


### PR DESCRIPTION
This is a follow-up refactoring for #459 

In our current design, we copy our state many times over during the regular workflow of producing sidechain blocks. Copying state is one of the performance bottlenecks, as our benchmarks have shown (once the state gets to MB size). This refactoring is a step towards reducing the amount of copying necessary.

* The sidechain state traits like `SidechainState` are now directly implemented by `SgxExternalities` instead of having a separate `SidechainDB` struct that requires moving in a state (which in turn required copying state).
  * Removed `SidechainDB` as a result 
* Added a `execute_on_current` method to the state handler trait, which executes a function on a state reference without having to copy the state.
* Removed obsolete `StfExecuteGenericUpdate` trait and its implementation and tests.
* Re-named the `load` method of the state handler to `load_clone`, to better express the fact that we're copying/cloning state for this method call.
