### PR TITLE
Skip spid/ra_api_key files if `--skip-ra` is active

### DIFF
--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -283,11 +283,16 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	InitializationHandler: TrackInitialization + IsInitialized + Sync + Send + 'static,
 	WorkerModeProvider: ProvideWorkerMode,
 {
+	let run_config = config.run_config.clone().expect("Run config missing");
+	let skip_ra = run_config.skip_ra;
+
 	println!("Integritee Worker v{}", VERSION);
 	info!("starting worker on shard {}", shard.encode().to_base58());
 	// ------------------------------------------------------------------------
 	// check for required files
-	check_files();
+	if !skip_ra {
+		check_files();
+	}
 	// ------------------------------------------------------------------------
 	// initialize the enclave
 	let mrenclave = enclave.get_mrenclave().unwrap();
@@ -297,8 +302,6 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	// ------------------------------------------------------------------------
 	// let new workers call us for key provisioning
 	println!("MU-RA server listening on {}", config.mu_ra_url());
-	let run_config = config.run_config.clone().expect("Run config missing");
-	let skip_ra = run_config.skip_ra;
 	let is_development_mode = run_config.dev;
 	let ra_url = config.mu_ra_url();
 	let enclave_api_key_prov = enclave.clone();

--- a/service/src/utils.rs
+++ b/service/src/utils.rs
@@ -44,7 +44,7 @@ pub fn extract_shard<E: EnclaveBase>(
 pub fn check_files() {
 	use itp_settings::files::{ENCLAVE_FILE, RA_API_KEY_FILE, RA_SPID_FILE};
 	debug!("*** Check files");
-	let files = vec![ENCLAVE_FILE, RA_SPID_FILE, RA_API_KEY_FILE];
+	let files = [ENCLAVE_FILE, RA_SPID_FILE, RA_API_KEY_FILE];
 	for f in files.iter() {
 		assert!(Path::new(f).exists(), "File doesn't exist: {}", f);
 	}


### PR DESCRIPTION
This PR gets rid of the need to create these two files when they won't be used.