### PR TITLE
Adjust nonce in StfEnclaveSigner based on pending tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,6 +3407,7 @@ dependencies = [
  "itp-storage",
  "itp-test",
  "itp-time-utils",
+ "itp-top-pool-author",
  "itp-types",
  "log 0.4.17",
  "parity-scale-codec",

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -113,4 +113,12 @@ impl TrustedOperation {
 			_ => None,
 		}
 	}
+
+	pub fn signed_caller_account(&self) -> Option<&AccountId> {
+		match self {
+			TrustedOperation::direct_call(c) => Some(c.call.sender_account()),
+			TrustedOperation::indirect_call(c) => Some(c.call.sender_account()),
+			_ => None,
+		}
+	}
 }

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -22,6 +22,7 @@ itp-stf-state-handler = { path = "../stf-state-handler", default-features = fals
 itp-stf-state-observer = { path = "../stf-state-observer", default-features = false }
 itp-storage = { path = "../storage", default-features = false }
 itp-time-utils = { path = "../time-utils", default-features = false }
+itp-top-pool-author = { path = "../top-pool-author", default-features = false }
 itp-types = { path = "../types", default-features = false }
 
 # scs
@@ -61,6 +62,7 @@ std = [
     "itp-stf-interface/std",
     "itp-stf-state-handler/std",
     "itp-stf-state-observer/std",
+    "itp-top-pool-author/std",
     "itp-storage/std",
     "itp-types/std",
     "itp-time-utils/std",
@@ -82,6 +84,7 @@ sgx = [
     "itp-sgx-externalities/sgx",
     "itp-stf-state-handler/sgx",
     "itp-stf-state-observer/sgx",
+    "itp-top-pool-author/sgx",
     "itp-storage/sgx",
     "itp-time-utils/sgx",
     "thiserror_sgx",

--- a/core-primitives/stf-executor/src/enclave_signer.rs
+++ b/core-primitives/stf-executor/src/enclave_signer.rs
@@ -15,28 +15,34 @@
 
 */
 
-use crate::{error::Result, traits::StfEnclaveSigning};
+use crate::{
+	error::{Error, Result},
+	traits::StfEnclaveSigning,
+	H256,
+};
 use core::marker::PhantomData;
-use ita_stf::{TrustedCall, TrustedCallSigned};
+use ita_stf::{TrustedCall, TrustedCallSigned, TrustedOperation};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_crypto::{ed25519_derivation::DeriveEd25519, key_repository::AccessKey};
 use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_stf_interface::system_pallet::SystemPalletAccountInterface;
 use itp_stf_primitives::types::{AccountId, KeyPair};
 use itp_stf_state_observer::traits::ObserveState;
+use itp_top_pool_author::traits::AuthorApi;
 use itp_types::{Index, ShardIdentifier};
 use sp_core::{ed25519::Pair as Ed25519Pair, Pair};
 use std::{boxed::Box, sync::Arc};
 
-pub struct StfEnclaveSigner<OCallApi, StateObserver, ShieldingKeyRepository, Stf> {
+pub struct StfEnclaveSigner<OCallApi, StateObserver, ShieldingKeyRepository, Stf, TopPoolAuthor> {
 	state_observer: Arc<StateObserver>,
 	ocall_api: Arc<OCallApi>,
 	shielding_key_repo: Arc<ShieldingKeyRepository>,
+	top_pool_author: Arc<TopPoolAuthor>,
 	_phantom: PhantomData<Stf>,
 }
 
-impl<OCallApi, StateObserver, ShieldingKeyRepository, Stf>
-	StfEnclaveSigner<OCallApi, StateObserver, ShieldingKeyRepository, Stf>
+impl<OCallApi, StateObserver, ShieldingKeyRepository, Stf, TopPoolAuthor>
+	StfEnclaveSigner<OCallApi, StateObserver, ShieldingKeyRepository, Stf, TopPoolAuthor>
 where
 	OCallApi: EnclaveAttestationOCallApi,
 	StateObserver: ObserveState,
@@ -45,13 +51,21 @@ where
 	<ShieldingKeyRepository as AccessKey>::KeyType: DeriveEd25519,
 	Stf: SystemPalletAccountInterface<StateObserver::StateType, AccountId>,
 	Stf::Index: Into<Index>,
+	TopPoolAuthor: AuthorApi<H256, H256> + Send + Sync + 'static,
 {
 	pub fn new(
 		state_observer: Arc<StateObserver>,
 		ocall_api: Arc<OCallApi>,
 		shielding_key_repo: Arc<ShieldingKeyRepository>,
+		top_pool_author: Arc<TopPoolAuthor>,
 	) -> Self {
-		Self { state_observer, ocall_api, shielding_key_repo, _phantom: Default::default() }
+		Self {
+			state_observer,
+			ocall_api,
+			shielding_key_repo,
+			top_pool_author,
+			_phantom: Default::default(),
+		}
 	}
 
 	fn get_enclave_account_nonce(&self, shard: &ShardIdentifier) -> Result<Stf::Index> {
@@ -69,8 +83,8 @@ where
 	}
 }
 
-impl<OCallApi, StateObserver, ShieldingKeyRepository, Stf> StfEnclaveSigning
-	for StfEnclaveSigner<OCallApi, StateObserver, ShieldingKeyRepository, Stf>
+impl<OCallApi, StateObserver, ShieldingKeyRepository, Stf, TopPoolAuthor> StfEnclaveSigning
+	for StfEnclaveSigner<OCallApi, StateObserver, ShieldingKeyRepository, Stf, TopPoolAuthor>
 where
 	OCallApi: EnclaveAttestationOCallApi,
 	StateObserver: ObserveState,
@@ -79,6 +93,7 @@ where
 	<ShieldingKeyRepository as AccessKey>::KeyType: DeriveEd25519,
 	Stf: SystemPalletAccountInterface<StateObserver::StateType, AccountId>,
 	Stf::Index: Into<Index>,
+	TopPoolAuthor: AuthorApi<H256, H256> + Send + Sync + 'static,
 {
 	fn get_enclave_account(&self) -> Result<AccountId> {
 		let enclave_call_signing_key = self.get_enclave_call_signing_key()?;
@@ -91,12 +106,28 @@ where
 		shard: &ShardIdentifier,
 	) -> Result<TrustedCallSigned> {
 		let mr_enclave = self.ocall_api.get_mrenclave_of_self()?;
-		let enclave_account_nonce = self.get_enclave_account_nonce(shard)?;
+		let enclave_account_id = self.get_enclave_account()?;
 		let enclave_call_signing_key = self.get_enclave_call_signing_key()?;
+
+		let current_nonce = self.get_enclave_account_nonce(shard)?;
+		let pending_tx = self
+			.top_pool_author
+			.get_pending_trusted_calls(shard.clone())
+			.iter()
+			.filter(|v| match v {
+				TrustedOperation::indirect_call(ref call) =>
+					call.call.sender_account().eq(&enclave_account_id),
+				TrustedOperation::direct_call(ref call) =>
+					call.call.sender_account().eq(&enclave_account_id),
+				_ => false,
+			})
+			.count();
+		let pending_tx = Index::try_from(pending_tx).map_err(|e| Error::Other(e.into()))?;
+		let adjusted_nonce: Index = current_nonce.into() + pending_tx;
 
 		Ok(trusted_call.sign(
 			&KeyPair::Ed25519(Box::new(enclave_call_signing_key)),
-			enclave_account_nonce.into(),
+			adjusted_nonce,
 			&mr_enclave.m,
 			shard,
 		))

--- a/core-primitives/stf-executor/src/enclave_signer.rs
+++ b/core-primitives/stf-executor/src/enclave_signer.rs
@@ -21,7 +21,7 @@ use crate::{
 	H256,
 };
 use core::marker::PhantomData;
-use ita_stf::{TrustedCall, TrustedCallSigned, TrustedOperation};
+use ita_stf::{TrustedCall, TrustedCallSigned};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_crypto::{ed25519_derivation::DeriveEd25519, key_repository::AccessKey};
 use itp_sgx_externalities::SgxExternalitiesTrait;
@@ -106,24 +106,17 @@ where
 		shard: &ShardIdentifier,
 	) -> Result<TrustedCallSigned> {
 		let mr_enclave = self.ocall_api.get_mrenclave_of_self()?;
-		let enclave_account_id = self.get_enclave_account()?;
+		let enclave_account = self.get_enclave_account()?;
 		let enclave_call_signing_key = self.get_enclave_call_signing_key()?;
 
 		let current_nonce = self.get_enclave_account_nonce(shard)?;
-		let pending_tx = self
+		let pending_tx_count = self
 			.top_pool_author
-			.get_pending_trusted_calls(shard.clone())
-			.iter()
-			.filter(|v| match v {
-				TrustedOperation::indirect_call(ref call) =>
-					call.call.sender_account().eq(&enclave_account_id),
-				TrustedOperation::direct_call(ref call) =>
-					call.call.sender_account().eq(&enclave_account_id),
-				_ => false,
-			})
-			.count();
-		let pending_tx = Index::try_from(pending_tx).map_err(|e| Error::Other(e.into()))?;
-		let adjusted_nonce: Index = current_nonce.into() + pending_tx;
+			.get_pending_trusted_calls_for(*shard, &enclave_account)
+			.len();
+		let pending_tx_count =
+			Index::try_from(pending_tx_count).map_err(|e| Error::Other(e.into()))?;
+		let adjusted_nonce: Index = current_nonce.into() + pending_tx_count;
 
 		Ok(trusted_call.sign(
 			&KeyPair::Ed25519(Box::new(enclave_call_signing_key)),

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -29,6 +29,7 @@ use ita_stf::{hash, Getter, TrustedOperation};
 use itp_enclave_metrics::EnclaveMetric;
 use itp_ocall_api::EnclaveMetricsOCallApi;
 use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCryptoDecrypt};
+use itp_stf_primitives::types::AccountId;
 use itp_stf_state_handler::query_shard_state::QueryShardState;
 use itp_top_pool::{
 	error::{Error as PoolError, IntoPoolError},
@@ -300,6 +301,17 @@ where
 				matches!(o, TrustedOperation::direct_call(_))
 					|| matches!(o, TrustedOperation::indirect_call(_))
 			})
+			.collect()
+	}
+
+	fn get_pending_trusted_calls_for(
+		&self,
+		shard: ShardIdentifier,
+		account: &AccountId,
+	) -> Vec<TrustedOperation> {
+		self.get_pending_trusted_calls(shard)
+			.into_iter()
+			.filter(|o| o.signed_caller_account() == Some(account))
 			.collect()
 	}
 

--- a/core-primitives/top-pool-author/src/mocks.rs
+++ b/core-primitives/top-pool-author/src/mocks.rs
@@ -33,6 +33,7 @@ use ita_stf::{
 	hash::{Hash, TrustedOperationOrHash},
 	Getter, TrustedGetterSigned, TrustedOperation,
 };
+use itp_stf_primitives::types::AccountId;
 use itp_top_pool::primitives::PoolFuture;
 use itp_types::ShardIdentifier;
 use jsonrpc_core::{futures::future::ready, Error as RpcError};
@@ -133,6 +134,29 @@ impl AuthorApi<H256, H256> for AuthorApiMock<H256, H256> {
 				for encoded_operation in encoded_operations {
 					if let Some(o) = Self::decode_trusted_operation(encoded_operation) {
 						trusted_operations.push(o);
+					}
+				}
+				trusted_operations
+			})
+			.unwrap_or_default()
+	}
+
+	fn get_pending_trusted_calls_for(
+		&self,
+		shard: ShardIdentifier,
+		account: &AccountId,
+	) -> Vec<TrustedOperation> {
+		self.tops
+			.read()
+			.unwrap()
+			.get(&shard)
+			.map(|encoded_operations| {
+				let mut trusted_operations: Vec<TrustedOperation> = Vec::new();
+				for encoded_operation in encoded_operations {
+					if let Some(o) = Self::decode_trusted_operation(encoded_operation) {
+						if o.signed_caller_account() == Some(account) {
+							trusted_operations.push(o);
+						}
 					}
 				}
 				trusted_operations

--- a/core-primitives/top-pool-author/src/traits.rs
+++ b/core-primitives/top-pool-author/src/traits.rs
@@ -20,6 +20,7 @@ use crate::sgx_reexport_prelude::*;
 
 use crate::error::Result;
 use ita_stf::{hash, TrustedOperation};
+use itp_stf_primitives::types::AccountId;
 use itp_top_pool::primitives::PoolFuture;
 use itp_types::{BlockHash as SidechainBlockHash, ShardIdentifier, H256};
 use jsonrpc_core::Error as RpcError;
@@ -44,6 +45,13 @@ pub trait AuthorApi<Hash, BlockHash> {
 
 	/// Returns all pending trusted calls.
 	fn get_pending_trusted_calls(&self, shard: ShardIdentifier) -> Vec<TrustedOperation>;
+
+	/// Returns all pending trusted calls for a given `account`
+	fn get_pending_trusted_calls_for(
+		&self,
+		shard: ShardIdentifier,
+		account: &AccountId,
+	) -> Vec<TrustedOperation>;
 
 	fn get_shards(&self) -> Vec<ShardIdentifier>;
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1942,6 +1942,7 @@ dependencies = [
  "itp-storage",
  "itp-test",
  "itp-time-utils",
+ "itp-top-pool-author",
  "itp-types",
  "log",
  "parity-scale-codec",

--- a/enclave-runtime/src/initialization/global_components.rs
+++ b/enclave-runtime/src/initialization/global_components.rs
@@ -106,6 +106,7 @@ pub type EnclaveStfEnclaveSigner = StfEnclaveSigner<
 	EnclaveStateObserver,
 	EnclaveShieldingKeyRepository,
 	EnclaveStf,
+	EnclaveTopPoolAuthor,
 >;
 pub type EnclaveAttestationHandler = IntelAttestationHandler<EnclaveOCallApi>;
 

--- a/enclave-runtime/src/initialization/parentchain/common.rs
+++ b/enclave-runtime/src/initialization/parentchain/common.rs
@@ -54,6 +54,7 @@ pub(crate) fn create_parentchain_block_importer(
 		state_observer,
 		ocall_api,
 		shielding_key_repository.clone(),
+		top_pool_author.clone(),
 	));
 	let indirect_calls_executor = Arc::new(EnclaveIndirectCallsExecutor::new(
 		shielding_key_repository,

--- a/enclave-runtime/src/test/enclave_signer_tests.rs
+++ b/enclave-runtime/src/test/enclave_signer_tests.rs
@@ -15,8 +15,9 @@
 
 */
 
+use codec::Encode;
 use ita_sgx_runtime::Runtime;
-use ita_stf::{Stf, TrustedCall};
+use ita_stf::{Stf, TrustedCall, TrustedCallSigned, TrustedOperation};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_crypto::{
 	ed25519_derivation::DeriveEd25519, key_repository::AccessKey, mocks::KeyRepositoryMock,
@@ -24,19 +25,19 @@ use itp_sgx_crypto::{
 use itp_sgx_externalities::SgxExternalities;
 use itp_stf_executor::{enclave_signer::StfEnclaveSigner, traits::StfEnclaveSigning};
 use itp_stf_interface::{
-	mocks::{CallExecutorMock, GetterExecutorMock},
-	InitState,
+	mocks::GetterExecutorMock, system_pallet::SystemPalletAccountInterface, InitState,
+	StateCallInterface,
 };
 use itp_stf_primitives::types::{AccountId, ShardIdentifier};
 use itp_stf_state_observer::mock::ObserveStateMock;
 use itp_test::mock::onchain_mock::OnchainMock;
-use itp_top_pool_author::mocks::AuthorApiMock;
+use itp_top_pool_author::{mocks::AuthorApiMock, traits::AuthorApi};
 use sgx_crypto_helper::{rsa3072::Rsa3072KeyPair, RsaKeyPair};
 use sp_core::Pair;
-use std::sync::Arc;
+use std::{sync::Arc, vec::Vec};
 
 type ShieldingKeyRepositoryMock = KeyRepositoryMock<Rsa3072KeyPair>;
-type TestStf = Stf<CallExecutorMock, GetterExecutorMock, SgxExternalities, Runtime>;
+type TestStf = Stf<TrustedCallSigned, GetterExecutorMock, SgxExternalities, Runtime>;
 
 pub fn derive_key_is_deterministic() {
 	let rsa_key = Rsa3072KeyPair::new().unwrap();
@@ -73,4 +74,60 @@ pub fn enclave_signer_signatures_are_valid() {
 
 	let trusted_call_signed = enclave_signer.sign_call_with_self(&trusted_call, &shard).unwrap();
 	assert!(trusted_call_signed.verify_signature(&mr_enclave.m, &shard));
+}
+
+pub fn nonce_is_computed_correctly() {
+	let top_pool_author = Arc::new(AuthorApiMock::default());
+	let ocall_api = Arc::new(OnchainMock::default());
+	let shielding_key_repo = Arc::new(ShieldingKeyRepositoryMock::default());
+	let enclave_account: AccountId = shielding_key_repo
+		.retrieve_key()
+		.unwrap()
+		.derive_ed25519()
+		.unwrap()
+		.public()
+		.into();
+	let mut state = TestStf::init_state(enclave_account.clone());
+	// only used to create the enclave signer, the state is **not** synchronised
+	let state_observer: Arc<ObserveStateMock<SgxExternalities>> =
+		Arc::new(ObserveStateMock::new(state.clone()));
+	let shard = ShardIdentifier::default();
+	let enclave_signer = StfEnclaveSigner::<_, _, _, TestStf, _>::new(
+		state_observer,
+		ocall_api,
+		shielding_key_repo,
+		top_pool_author.clone(),
+	);
+
+	// create the first trusted_call and submit it
+	let trusted_call_1 =
+		TrustedCall::balance_shield(enclave_account.clone(), AccountId::new([1u8; 32]), 100u128);
+	let trusted_call_1_signed =
+		enclave_signer.sign_call_with_self(&trusted_call_1, &shard).unwrap();
+	top_pool_author
+		.submit_top(TrustedOperation::indirect_call(trusted_call_1_signed.clone()).encode(), shard);
+	assert_eq!(1, top_pool_author.get_pending_trusted_calls_for(shard, &enclave_account).len());
+
+	// create the second trusted_call and submit it
+	let trusted_call_2 =
+		TrustedCall::balance_shield(enclave_account.clone(), AccountId::new([2u8; 32]), 200u128);
+	let trusted_call_2_signed =
+		enclave_signer.sign_call_with_self(&trusted_call_2, &shard).unwrap();
+	top_pool_author
+		.submit_top(TrustedOperation::indirect_call(trusted_call_2_signed.clone()).encode(), shard);
+	assert_eq!(2, top_pool_author.get_pending_trusted_calls_for(shard, &enclave_account).len());
+	// there should be no pending trusted calls for non-enclave-account
+	assert_eq!(
+		0,
+		top_pool_author
+			.get_pending_trusted_calls_for(shard, &AccountId::new([1u8; 32]))
+			.len()
+	);
+
+	assert_eq!(0, TestStf::get_account_nonce(&mut state, &enclave_account));
+	assert!(TestStf::execute_call(&mut state, trusted_call_1_signed, &mut Vec::new(), [0u8, 1u8])
+		.is_ok());
+	assert!(TestStf::execute_call(&mut state, trusted_call_2_signed, &mut Vec::new(), [0u8, 1u8])
+		.is_ok());
+	assert_eq!(2, TestStf::get_account_nonce(&mut state, &enclave_account));
 }

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -129,6 +129,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		stf_executor_tests::propose_state_update_executes_all_calls_given_enough_time,
 		enclave_signer_tests::enclave_signer_signatures_are_valid,
 		enclave_signer_tests::derive_key_is_deterministic,
+		enclave_signer_tests::nonce_is_computed_correctly,
 		state_getter_tests::state_getter_works,
 		// sidechain integration tests
 		sidechain_aura_tests::produce_sidechain_block_and_import_it,

--- a/enclave-runtime/src/test/top_pool_tests.rs
+++ b/enclave-runtime/src/test/top_pool_tests.rs
@@ -120,10 +120,11 @@ pub fn submit_shielding_call_to_top_pool() {
 		Arc::new(MetricsOCallMock::default()),
 	));
 
-	let enclave_signer = Arc::new(StfEnclaveSigner::<_, _, _, TestStf>::new(
+	let enclave_signer = Arc::new(StfEnclaveSigner::<_, _, _, TestStf, _>::new(
 		state_observer,
 		ocall_api.clone(),
 		shielding_key_repo.clone(),
+		top_pool_author.clone(),
 	));
 	let node_meta_data_repository = Arc::new(NodeMetadataRepository::default());
 	node_meta_data_repository.set_metadata(NodeMetadataMock::new());


### PR DESCRIPTION
resolves #1084 

This PR tries to take the pending tx into consideration when computing the nonce in `StfEnclaveSigner::sign_call_with_self`, it's based on https://github.com/litentry/tee-worker/pull/123/files#diff-b45d7f9d388a23fd97f42304612c00c9ea1205f05fc1e8bcc41439effa02406b

We do have a testcase [here](https://github.com/litentry/tee-worker/commit/887a6252e9e05e863f1e9e34e611b5df84fc1046) but I'm not sure if it's worth integrating it here (as it introduces additional CI steps/ymls).