### PR TITLE
Avoid hardcoded call index when executing trusted calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,6 +2787,9 @@ dependencies = [
  "integritee-node-runtime",
  "ita-sgx-runtime",
  "itp-hashing",
+ "itp-node-api",
+ "itp-node-api-metadata",
+ "itp-node-api-metadata-provider",
  "itp-sgx-externalities",
  "itp-stf-interface",
  "itp-stf-primitives",
@@ -3425,6 +3428,8 @@ dependencies = [
 name = "itp-stf-interface"
 version = "0.8.0"
 dependencies = [
+ "itp-node-api-metadata",
+ "itp-node-api-metadata-provider",
  "itp-types",
 ]
 

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -18,9 +18,9 @@ sgx_tstd = { branch = "master", features = ["untrusted_fs", "net", "backtrace"],
 # local crates
 ita-sgx-runtime = { default-features = false, path = "../sgx-runtime" }
 itp-hashing = { default-features = false, path = "../../core-primitives/hashing" }
-itp-node-api = { path = "../../core-primitives/node-api", default-features = false }
-itp-node-api-metadata = { path = "../../core-primitives/node-api/metadata", default-features = false }
-itp-node-api-metadata-provider = { path = "../../core-primitives/node-api/metadata-provider", default-features = false }
+itp-node-api = { default-features = false, path = "../../core-primitives/node-api" }
+itp-node-api-metadata = { default-features = false, path = "../../core-primitives/node-api/metadata" }
+itp-node-api-metadata-provider = { default-features = false, path = "../../core-primitives/node-api/metadata-provider" }
 itp-sgx-externalities = { default-features = false, path = "../../core-primitives/substrate-sgx/externalities" }
 itp-stf-interface = { default-features = false, path = "../../core-primitives/stf-interface" }
 itp-stf-primitives = { default-features = false, path = "../../core-primitives/stf-primitives" }

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -18,6 +18,9 @@ sgx_tstd = { branch = "master", features = ["untrusted_fs", "net", "backtrace"],
 # local crates
 ita-sgx-runtime = { default-features = false, path = "../sgx-runtime" }
 itp-hashing = { default-features = false, path = "../../core-primitives/hashing" }
+itp-node-api = { path = "../../core-primitives/node-api", default-features = false }
+itp-node-api-metadata = { path = "../../core-primitives/node-api/metadata", default-features = false }
+itp-node-api-metadata-provider = { path = "../../core-primitives/node-api/metadata-provider", default-features = false }
 itp-sgx-externalities = { default-features = false, path = "../../core-primitives/substrate-sgx/externalities" }
 itp-stf-interface = { default-features = false, path = "../../core-primitives/stf-interface" }
 itp-stf-primitives = { default-features = false, path = "../../core-primitives/stf-primitives" }
@@ -55,6 +58,7 @@ sgx = [
     "itp-sgx-externalities/sgx",
     "itp-utils/sgx",
     "sp-io/sgx",
+    "itp-node-api/sgx",
 ]
 std = [
     # crates.io
@@ -69,6 +73,7 @@ std = [
     "itp-storage/std",
     "itp-types/std",
     "itp-utils/std",
+    "itp-node-api/std",
     # substrate
     "sp-core/std",
     "pallet-balances/std",

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -59,6 +59,7 @@ sgx = [
     "itp-utils/sgx",
     "sp-io/sgx",
     "itp-node-api/sgx",
+    "itp-node-api-metadata-provider/sgx",
 ]
 std = [
     # crates.io
@@ -74,6 +75,8 @@ std = [
     "itp-types/std",
     "itp-utils/std",
     "itp-node-api/std",
+    "itp-node-api-metadata/std",
+    "itp-node-api-metadata-provider/std",
     # substrate
     "sp-core/std",
     "pallet-balances/std",

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -33,6 +33,8 @@ pub use my_node_runtime::{Balance, Index};
 
 use codec::{Decode, Encode};
 use derive_more::Display;
+use itp_node_api_metadata::Error as MetadataError;
+use itp_node_api_metadata_provider::Error as MetadataProviderError;
 use itp_stf_primitives::types::AccountId;
 use std::string::String;
 
@@ -71,6 +73,19 @@ pub enum StfError {
 	InvalidNonce(Index),
 	StorageHashMismatch,
 	InvalidStorageDiff,
+	InvalidMetadata,
+}
+
+impl From<MetadataError> for StfError {
+	fn from(_e: MetadataError) -> Self {
+		StfError::InvalidMetadata
+	}
+}
+
+impl From<MetadataProviderError> for StfError {
+	fn from(_e: MetadataProviderError) -> Self {
+		StfError::InvalidMetadata
+	}
 }
 
 #[derive(Encode, Decode, Clone, Debug, PartialEq, Eq)]

--- a/app-libs/stf/src/stf_sgx_tests.rs
+++ b/app-libs/stf/src/stf_sgx_tests.rs
@@ -17,6 +17,7 @@
 
 use crate::{Getter, State, Stf, TrustedCall, TrustedCallSigned};
 use ita_sgx_runtime::Runtime;
+use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_stf_interface::{
 	sudo_pallet::SudoPalletInterface, system_pallet::SystemPalletAccountInterface, InitState,
 	StateCallInterface,
@@ -26,7 +27,7 @@ use sp_core::{
 	ed25519::{Pair as Ed25519Pair, Signature as Ed25519Signature},
 	Pair,
 };
-use std::vec::Vec;
+use std::{sync::Arc, vec::Vec};
 
 pub type StfState = Stf<TrustedCallSigned, Getter, State, Runtime>;
 
@@ -56,7 +57,8 @@ pub fn shield_funds_increments_signer_account_nonce() {
 		Signature::Ed25519(Ed25519Signature([0u8; 64])),
 	);
 
-	StfState::execute_call(&mut state, shield_funds_call, &mut Vec::new(), [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	StfState::execute_call(&mut state, shield_funds_call, &mut Vec::new(), repo).unwrap();
 	assert_eq!(1, StfState::get_account_nonce(&mut state, &enclave_signer_account_id));
 }
 

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -25,6 +25,9 @@ use crate::{helpers::ensure_enclave_signer_account, StfError, TrustedOperation};
 use codec::{Decode, Encode};
 use frame_support::{ensure, traits::UnfilteredDispatchable};
 pub use ita_sgx_runtime::{Balance, Index};
+use itp_node_api::metadata::{
+	pallet_teerex::TeerexCallIndexes, provider::AccessNodeMetadata,
+};
 use ita_sgx_runtime::{Runtime, System};
 use itp_stf_interface::ExecuteCall;
 use itp_stf_primitives::types::{AccountId, KeyPair, ShardIdentifier, Signature};
@@ -33,7 +36,7 @@ use itp_utils::stringify::account_id_to_string;
 use log::*;
 use sp_io::hashing::blake2_256;
 use sp_runtime::{traits::Verify, MultiAddress};
-use std::{format, prelude::v1::*};
+use std::{format, prelude::v1::*, sync::Arc};
 
 #[cfg(feature = "evm")]
 use ita_sgx_runtime::{AddressMapping, HashedAddressMapping};
@@ -165,13 +168,17 @@ pub struct TrustedReturnValue<T> {
 impl TrustedReturnValue
 */
 
-impl ExecuteCall for TrustedCallSigned {
+impl<NodeMetadataRepository> ExecuteCall<NodeMetadataRepository> for TrustedCallSigned
+where
+	NodeMetadataRepository: AccessNodeMetadata,
+	NodeMetadataRepository::MetadataType: TeerexCallIndexes,
+{
 	type Error = StfError;
 
 	fn execute(
 		self,
 		calls: &mut Vec<OpaqueCall>,
-		unshield_funds_fn: [u8; 2],
+		node_metadata_repo: Arc<NodeMetadataRepository>,
 	) -> Result<(), Self::Error> {
 		let sender = self.call.sender_account().clone();
 		let call_hash = blake2_256(&self.call.encode());
@@ -197,7 +204,7 @@ impl ExecuteCall for TrustedCallSigned {
 				.map_err(|e| {
 					Self::Error::Dispatch(format!("Balance Set Balance error: {:?}", e.error))
 				})?;
-				Ok(())
+				Ok::<(), Self::Error>(())
 			},
 			TrustedCall::balance_transfer(from, to, value) => {
 				let origin = ita_sgx_runtime::RuntimeOrigin::signed(from.clone());
@@ -227,7 +234,7 @@ impl ExecuteCall for TrustedCallSigned {
 				);
 				unshield_funds(account_incognito, value)?;
 				calls.push(OpaqueCall::from_tuple(&(
-					unshield_funds_fn,
+					node_metadata_repo.get_from_metadata(|m| m.unshield_funds_call_indexes())??,
 					beneficiary,
 					value,
 					shard,

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -202,8 +202,8 @@ where
 				.map_err(|e| {
 					Self::Error::Dispatch(format!("Balance Set Balance error: {:?}", e.error))
 				})?;
-                // TODO: we need clearly define the types so that the compiler can infer types
-                //       see https://github.com/integritee-network/worker/issues/1145
+				// TODO: we need clearly define the types so that the compiler can infer types
+				//       see https://github.com/integritee-network/worker/issues/1145
 				Ok::<(), Self::Error>(())
 			},
 			TrustedCall::balance_transfer(from, to, value) => {

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -25,10 +25,8 @@ use crate::{helpers::ensure_enclave_signer_account, StfError, TrustedOperation};
 use codec::{Decode, Encode};
 use frame_support::{ensure, traits::UnfilteredDispatchable};
 pub use ita_sgx_runtime::{Balance, Index};
-use itp_node_api::metadata::{
-	pallet_teerex::TeerexCallIndexes, provider::AccessNodeMetadata,
-};
 use ita_sgx_runtime::{Runtime, System};
+use itp_node_api::metadata::{pallet_teerex::TeerexCallIndexes, provider::AccessNodeMetadata};
 use itp_stf_interface::ExecuteCall;
 use itp_stf_primitives::types::{AccountId, KeyPair, ShardIdentifier, Signature};
 use itp_types::OpaqueCall;

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -202,6 +202,8 @@ where
 				.map_err(|e| {
 					Self::Error::Dispatch(format!("Balance Set Balance error: {:?}", e.error))
 				})?;
+                // TODO: we need clearly define the types so that the compiler can infer types
+                //       see https://github.com/integritee-network/worker/issues/1145
 				Ok::<(), Self::Error>(())
 			},
 			TrustedCall::balance_transfer(from, to, value) => {

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -112,10 +112,6 @@ where
 		// see issue #208
 		debug!("Update STF storage!");
 
-		// TODO: otherwise I got compile error:
-		//       cannot infer type for type parameter `NodeMetadataRepository` declared on the trait `ExecuteCall`
-		// let trusted_call_executor: Box<dyn ExecuteCall<NodeMetadataRepository, Error = StfError>> = Box::new(trusted_call.clone());
-		// let storage_hashes = trusted_call.clone().get_storage_hashes_to_update();
 		let storage_hashes = <TrustedCallSigned as ExecuteCall<NodeMetadataRepository>>::get_storage_hashes_to_update(trusted_call.clone());
 		let update_map = self
 			.ocall_api

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -60,10 +60,10 @@ where
 	Stf: UpdateState<
 			StateHandler::StateT,
 			<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType,
-		> + StateCallInterface<TrustedCallSigned, StateHandler::StateT>,
+		> + StateCallInterface<TrustedCallSigned, StateHandler::StateT, NodeMetadataRepository>,
 	<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType:
 		IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)> + From<BTreeMap<Vec<u8>, Option<Vec<u8>>>>,
-	<Stf as StateCallInterface<TrustedCallSigned, StateHandler::StateT>>::Error: Debug,
+	<Stf as StateCallInterface<TrustedCallSigned, StateHandler::StateT, NodeMetadataRepository>>::Error: Debug,
 {
 	pub fn new(
 		ocall_api: Arc<OCallApi>,
@@ -108,15 +108,15 @@ where
 			return Ok(ExecutedOperation::failed(top_or_hash))
 		}
 
-		let unshield_funds_fn = self
-			.node_metadata_repo
-			.get_from_metadata(|m| m.unshield_funds_call_indexes())??;
-
 		// Necessary because light client sync may not be up to date
 		// see issue #208
 		debug!("Update STF storage!");
 
-		let storage_hashes = trusted_call.clone().get_storage_hashes_to_update();
+		// TODO: otherwise I got compile error:
+		//       cannot infer type for type parameter `NodeMetadataRepository` declared on the trait `ExecuteCall`
+		// let trusted_call_executor: Box<dyn ExecuteCall<NodeMetadataRepository, Error = StfError>> = Box::new(trusted_call.clone());
+		// let storage_hashes = trusted_call.clone().get_storage_hashes_to_update();
+		let storage_hashes = <TrustedCallSigned as ExecuteCall<NodeMetadataRepository>>::get_storage_hashes_to_update(trusted_call.clone());
 		let update_map = self
 			.ocall_api
 			.get_multiple_storages_verified(storage_hashes, header)
@@ -131,7 +131,7 @@ where
 			state,
 			trusted_call.clone(),
 			&mut extrinsic_call_backs,
-			unshield_funds_fn,
+			self.node_metadata_repo.clone(),
 		) {
 			error!("Stf execute failed: {:?}", e);
 			return Ok(ExecutedOperation::failed(top_or_hash))
@@ -239,12 +239,12 @@ where
 	Stf: UpdateState<
 			StateHandler::StateT,
 			<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType,
-		> + StateCallInterface<TrustedCallSigned, StateHandler::StateT>,
+		> + StateCallInterface<TrustedCallSigned, StateHandler::StateT, NodeMetadataRepository>,
 	<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType:
 		IntoIterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
 	<StateHandler::StateT as SgxExternalitiesTrait>::SgxExternalitiesDiffType:
 		From<BTreeMap<Vec<u8>, Option<Vec<u8>>>>,
-	<Stf as StateCallInterface<TrustedCallSigned, StateHandler::StateT>>::Error: Debug,
+	<Stf as StateCallInterface<TrustedCallSigned, StateHandler::StateT, NodeMetadataRepository>>::Error: Debug,
 {
 	type Externalities = StateHandler::StateT;
 

--- a/core-primitives/stf-interface/Cargo.toml
+++ b/core-primitives/stf-interface/Cargo.toml
@@ -5,11 +5,15 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 
 [dependencies]
+itp-node-api-metadata = { path = "../node-api/metadata", default-features = false }
+itp-node-api-metadata-provider = { path = "../node-api/metadata-provider", default-features = false }
 itp-types = { default-features = false, path = "../types" }
 
 [features]
 default = ["std"]
 std = [
+    "itp-node-api-metadata/std",
+    "itp-node-api-metadata-provider/std",
     "itp-types/std",
 ]
 mocks = []

--- a/core-primitives/stf-interface/src/mocks.rs
+++ b/core-primitives/stf-interface/src/mocks.rs
@@ -22,8 +22,10 @@ use crate::{
 	system_pallet::SystemPalletAccountInterface, ExecuteCall, ExecuteGetter, InitState,
 	StateCallInterface, StateGetterInterface, UpdateState,
 };
-use alloc::{string::String, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 use core::marker::PhantomData;
+use itp_node_api_metadata::metadata_mocks::NodeMetadataMock;
+use itp_node_api_metadata_provider::NodeMetadataRepository;
 use itp_types::{AccountId, Index, OpaqueCall};
 
 #[derive(Default)]
@@ -49,7 +51,8 @@ impl<State, StateDiff> UpdateState<State, StateDiff> for StateInterfaceMock<Stat
 	}
 }
 
-impl<Call, State, StateDiff> StateCallInterface<Call, State>
+impl<Call, State, StateDiff>
+	StateCallInterface<Call, State, NodeMetadataRepository<NodeMetadataMock>>
 	for StateInterfaceMock<State, StateDiff>
 {
 	type Error = String;
@@ -58,7 +61,7 @@ impl<Call, State, StateDiff> StateCallInterface<Call, State>
 		_state: &mut State,
 		_call: Call,
 		_calls: &mut Vec<OpaqueCall>,
-		_unshield_funds_fn: [u8; 2],
+		_node_metadata_repo: Arc<NodeMetadataRepository<NodeMetadataMock>>,
 	) -> Result<(), Self::Error> {
 		unimplemented!()
 	}
@@ -88,13 +91,13 @@ impl<State, StateDiff> SystemPalletAccountInterface<State, AccountId>
 
 pub struct CallExecutorMock;
 
-impl ExecuteCall for CallExecutorMock {
+impl ExecuteCall<NodeMetadataRepository<NodeMetadataMock>> for CallExecutorMock {
 	type Error = String;
 
 	fn execute(
 		self,
 		_calls: &mut Vec<OpaqueCall>,
-		_unshield_funds_fn: [u8; 2],
+		_node_metadata_repo: Arc<NodeMetadataRepository<NodeMetadataMock>>,
 	) -> Result<(), Self::Error> {
 		unimplemented!()
 	}

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1474,6 +1474,9 @@ dependencies = [
  "frame-system",
  "ita-sgx-runtime",
  "itp-hashing",
+ "itp-node-api",
+ "itp-node-api-metadata",
+ "itp-node-api-metadata-provider",
  "itp-sgx-externalities",
  "itp-stf-interface",
  "itp-stf-primitives",
@@ -1959,6 +1962,8 @@ dependencies = [
 name = "itp-stf-interface"
 version = "0.8.0"
 dependencies = [
+ "itp-node-api-metadata",
+ "itp-node-api-metadata-provider",
  "itp-types",
 ]
 

--- a/enclave-runtime/src/test/enclave_signer_tests.rs
+++ b/enclave-runtime/src/test/enclave_signer_tests.rs
@@ -18,6 +18,7 @@
 use codec::Encode;
 use ita_sgx_runtime::Runtime;
 use ita_stf::{Stf, TrustedCall, TrustedCallSigned, TrustedOperation};
+use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_crypto::{
 	ed25519_derivation::DeriveEd25519, key_repository::AccessKey, mocks::KeyRepositoryMock,
@@ -28,7 +29,6 @@ use itp_stf_interface::{
 	mocks::GetterExecutorMock, system_pallet::SystemPalletAccountInterface, InitState,
 	StateCallInterface,
 };
-use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_stf_primitives::types::{AccountId, ShardIdentifier};
 use itp_stf_state_observer::mock::ObserveStateMock;
 use itp_test::mock::onchain_mock::OnchainMock;
@@ -127,9 +127,13 @@ pub fn nonce_is_computed_correctly() {
 
 	assert_eq!(0, TestStf::get_account_nonce(&mut state, &enclave_account));
 	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
-	assert!(TestStf::execute_call(&mut state, trusted_call_1_signed, &mut Vec::new(), repo.clone())
-		.is_ok());
-	assert!(TestStf::execute_call(&mut state, trusted_call_2_signed, &mut Vec::new(), repo)
-		.is_ok());
+	assert!(TestStf::execute_call(
+		&mut state,
+		trusted_call_1_signed,
+		&mut Vec::new(),
+		repo.clone()
+	)
+	.is_ok());
+	assert!(TestStf::execute_call(&mut state, trusted_call_2_signed, &mut Vec::new(), repo).is_ok());
 	assert_eq!(2, TestStf::get_account_nonce(&mut state, &enclave_account));
 }

--- a/enclave-runtime/src/test/enclave_signer_tests.rs
+++ b/enclave-runtime/src/test/enclave_signer_tests.rs
@@ -28,6 +28,7 @@ use itp_stf_interface::{
 	mocks::GetterExecutorMock, system_pallet::SystemPalletAccountInterface, InitState,
 	StateCallInterface,
 };
+use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_stf_primitives::types::{AccountId, ShardIdentifier};
 use itp_stf_state_observer::mock::ObserveStateMock;
 use itp_test::mock::onchain_mock::OnchainMock;
@@ -125,9 +126,10 @@ pub fn nonce_is_computed_correctly() {
 	);
 
 	assert_eq!(0, TestStf::get_account_nonce(&mut state, &enclave_account));
-	assert!(TestStf::execute_call(&mut state, trusted_call_1_signed, &mut Vec::new(), [0u8, 1u8])
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	assert!(TestStf::execute_call(&mut state, trusted_call_1_signed, &mut Vec::new(), repo.clone())
 		.is_ok());
-	assert!(TestStf::execute_call(&mut state, trusted_call_2_signed, &mut Vec::new(), [0u8, 1u8])
+	assert!(TestStf::execute_call(&mut state, trusted_call_2_signed, &mut Vec::new(), repo)
 		.is_ok());
 	assert_eq!(2, TestStf::get_account_nonce(&mut state, &enclave_account));
 }

--- a/enclave-runtime/src/test/evm_pallet_tests.rs
+++ b/enclave-runtime/src/test/evm_pallet_tests.rs
@@ -32,7 +32,7 @@ use itp_stf_primitives::types::KeyPair;
 use itp_types::{AccountId, OpaqueCall, ShardIdentifier};
 use primitive_types::H256;
 use sp_core::{crypto::Pair, H160, U256};
-use std::{string::ToString, vec::Vec};
+use std::{string::ToString, sync::Arc, vec::Vec};
 use substrate_api_client::utils::FromHexString;
 
 pub fn test_evm_call() {

--- a/enclave-runtime/src/test/evm_pallet_tests.rs
+++ b/enclave-runtime/src/test/evm_pallet_tests.rs
@@ -25,6 +25,7 @@ use ita_stf::{
 	test_genesis::{endow, endowed_account as funded_pair},
 	State, TrustedCall,
 };
+use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_stf_interface::StateCallInterface;
 use itp_stf_primitives::types::KeyPair;
@@ -77,7 +78,8 @@ pub fn test_evm_call() {
 	.sign(&sender.clone().into(), 0, &mrenclave, &shard);
 
 	// when
-	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, repo).unwrap();
 
 	// then
 	assert_eq!(
@@ -121,7 +123,8 @@ pub fn test_evm_counter() {
 
 	// when
 	let execution_address = evm_create_address(sender_evm_acc, 0);
-	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, repo).unwrap();
 
 	// then
 	assert_eq!(
@@ -244,7 +247,8 @@ fn execute_and_verify_evm_call(
 		Vec::new(),
 	)
 	.sign(&pair, nonce, &mrenclave, &shard);
-	TestStf::execute_call(state, inc_call, calls, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(state, inc_call, calls, repo).unwrap();
 
 	let counter_value = state
 		.execute_with(|| get_evm_account_storages(&execution_address, &H256::zero()))
@@ -289,7 +293,8 @@ pub fn test_evm_create() {
 	let nonce = state.execute_with(|| System::account_nonce(&sender_evm_substrate_addr));
 	assert_eq!(nonce, 0);
 	let execution_address = evm_create_address(sender_evm_acc, nonce);
-	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, repo).unwrap();
 
 	assert_eq!(
 		execution_address,
@@ -343,7 +348,8 @@ pub fn test_evm_create2() {
 	// when
 	let code_hash = create_code_hash(&smart_contract);
 	let execution_address = evm_create2_address(sender_evm_acc, salt, code_hash);
-	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, repo).unwrap();
 
 	// then
 	assert_eq!(

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -40,6 +40,7 @@ use ita_stf::{
 	AccountInfo, Getter, State, StatePayload, TrustedCall, TrustedCallSigned, TrustedGetter,
 	TrustedOperation,
 };
+use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_sgx_crypto::{Aes, StateCrypto};
 use itp_sgx_externalities::{SgxExternalitiesDiffType, SgxExternalitiesTrait, StateHash};
 use itp_stf_executor::{
@@ -597,7 +598,8 @@ pub fn test_retrieve_events() {
 		transfer_value,
 	)
 	.sign(&sender.clone().into(), 0, &mrenclave, &shard);
-	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, repo).unwrap();
 
 	assert_eq!(TestStf::get_events(&mut state).len(), 3);
 }
@@ -620,7 +622,8 @@ pub fn test_retrieve_event_count() {
 	.sign(&sender.clone().into(), 0, &mrenclave, &shard);
 
 	// when
-	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, repo).unwrap();
 
 	let event_count = TestStf::get_event_count(&mut state);
 	assert_eq!(event_count, 3);
@@ -641,7 +644,8 @@ pub fn test_reset_events() {
 		transfer_value,
 	)
 	.sign(&sender.clone().into(), 0, &mrenclave, &shard);
-	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, [0u8, 1u8]).unwrap();
+	let repo = Arc::new(NodeMetadataRepository::<NodeMetadataMock>::default());
+	TestStf::execute_call(&mut state, trusted_call, &mut opaque_vec, repo).unwrap();
 	let receiver_acc_info = TestStf::get_account_data(&mut state, &receiver.public().into());
 	assert_eq!(receiver_acc_info.free, transfer_value);
 	// Ensure that there really have been events generated.


### PR DESCRIPTION
Currently the callback call-indexes in trusted call execution are always encoded as `unshield_funds_fn: [u8; 2]`: https://github.com/integritee-network/worker/blob/98e151adbb83d49c9f1204d23520fc71620d8c71/core-primitives/stf-interface/src/lib.rs#L53-L57

It makes it hard to extend when we want more calls to the parentchain and/or pallets other than teerex - we have such needs already.

This PR uses a more generic and extensible `node_metadata_repo` to replace the hardcoded one.