### PR TITLE
GHA: always run integration-tests even if unit tests failed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Test Enclave # cargo test is not supported in the enclave, see: https://github.com/apache/incubator-teaclave-sgx-sdk/issues/232
         run: docker run --name ${{ env.BUILD_CONTAINER_NAME }} integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }} test --all
+        continue-on-error: true
 
       - name: Export worker image(s)
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -153,6 +153,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-20.04
+    if: ${{ always() }}
     needs: build-test
     env:
       WORKER_IMAGE_TAG: integritee-worker:dev


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-not-requiring-successful-dependent-jobs for details.