### PR TITLE
Replace dockerize with built-in healthcheck

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,7 +94,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    container: "integritee/integritee-dev:0.1.11"
+    container: "integritee/integritee-dev:0.1.12"
     steps:
       - uses: actions/checkout@v3
       - name: init rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.2",
  "once_cell 1.17.0",
  "strsim 0.10.0",
  "termcolor",
@@ -2065,7 +2065,7 @@ dependencies = [
  "futures-sink 0.3.25",
  "futures-util 0.3.25",
  "http 0.2.8",
- "indexmap",
+ "indexmap 1.9.2",
  "slab 0.4.7",
  "tokio",
  "tokio-util 0.7.4",
@@ -2092,6 +2092,12 @@ name = "hashbrown"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fba9abe4742d586dfd0c06ae4f7e73a1c2d86b856933509b269d82cdf06e18"
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hashbrown"
@@ -2471,6 +2477,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.1"
+source = "git+https://github.com/mesalock-linux/indexmap-sgx#19f52458ba64dd7349a5d3a62227619a17e4db85"
+dependencies = [
+ "autocfg 1.1.0",
+ "hashbrown 0.9.1",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -4923,7 +4939,7 @@ checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "crc32fast",
  "hashbrown 0.12.3",
- "indexmap",
+ "indexmap 1.9.2",
  "memchr 2.5.0",
 ]
 
@@ -6682,6 +6698,7 @@ name = "serde_json"
 version = "1.0.60"
 source = "git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3#380893814ad2a057758d825bab798aa117f7362a"
 dependencies = [
+ "indexmap 1.6.1",
  "itoa 0.4.5",
  "ryu",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
@@ -6705,6 +6722,7 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
+ "indexmap 1.9.2",
  "itoa 1.0.5",
  "ryu",
  "serde 1.0.152",
@@ -8844,7 +8862,7 @@ version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5d3e08b13876f96dd55608d03cd4883a0545884932d5adf11925876c96daef"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.2",
 ]
 
 [[package]]
@@ -8856,7 +8874,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "cfg-if 1.0.0",
- "indexmap",
+ "indexmap 1.9.2",
  "libc",
  "log 0.4.17",
  "object 0.29.0",
@@ -8890,7 +8908,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.26.2",
- "indexmap",
+ "indexmap 1.9.2",
  "log 0.4.17",
  "object 0.29.0",
  "serde 1.0.152",
@@ -8942,7 +8960,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap",
+ "indexmap 1.9.2",
  "libc",
  "log 0.4.17",
  "mach",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM integritee/integritee-dev:0.1.11
+FROM integritee/integritee-dev:0.1.12
 LABEL maintainer="zoltan@integritee.network"
 
 # By default we warp the service

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -83,9 +83,7 @@ RUN --mount=type=cache,id=cargo,target=/root/work/.cache/sccache cargo test --re
 ##################################################
 FROM ubuntu:20.04 AS runner
 
-RUN apt update && apt install -y libssl-dev iproute2
-
-COPY --from=powerman/dockerize /usr/local/bin/dockerize /usr/local/bin/dockerize
+RUN apt update && apt install -y libssl-dev iproute2 curl
 
 
 ### Deployed CLI client

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -17,7 +17,7 @@
 
 ### Builder Stage
 ##################################################
-FROM integritee/integritee-dev:0.1.11 AS builder
+FROM integritee/integritee-dev:0.1.12 AS builder
 LABEL maintainer="zoltan@integritee.network"
 
 # set environment variables
@@ -49,7 +49,7 @@ RUN cargo test --release
 # A builder stage that uses sccache to speed up local builds with docker
 # Installation and setup of sccache should be moved to the integritee-dev image, so we don't
 # always need to compile and install sccache on CI (where we have no caching so far).
-FROM integritee/integritee-dev:0.1.11 AS cached-builder
+FROM integritee/integritee-dev:0.1.12 AS cached-builder
 LABEL maintainer="zoltan@integritee.network"
 
 # set environment variables

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@
 
 * Make sure you have installed Docker (version >= `2.0.0`) with [Docker Compose](https://docs.docker.com/compose/install/). On Windows, this can be Docker Desktop with WSL 2 integration.
 * In case you also build the worker directly, without docker (e.g. on a dev machine, running `make`), you should run `make clean` before running the docker build. Otherwise, it can occasionally lead to build errors.
-* The node image version that is loaded in the `docker-compose.yml`, (e.g. `image: "integritee/integritee-node-dev:1.0.11"`) needs to be compatible with the worker you're trying to build.
+* The node image version that is loaded in the `docker-compose.yml`, (e.g. `image: "integritee/integritee-node-dev:1.0.32"`) needs to be compatible with the worker you're trying to build.
 
 ## Building the Docker containers
 

--- a/docker/demo-direct-call.yml
+++ b/docker/demo-direct-call.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s    
-      /usr/local/worker-cli/demo_direct_call_2_workers.sh -p 9912 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/demo_direct_call_2_workers.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -W wss://integritee-worker-2 -B 2012 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/docker/demo-indirect-invocation.yml
+++ b/docker/demo-indirect-invocation.yml
@@ -6,14 +6,20 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,itc_rpc_client=warn
       - FLAVOR_ID
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s    
-      /usr/local/worker-cli/demo_indirect_invocation.sh -p 9912 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/demo_indirect_invocation.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -W wss://integritee-worker-2 -B 2012 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/docker/demo-sidechain.yml
+++ b/docker/demo-sidechain.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s    
-      /usr/local/worker-cli/demo_sidechain.sh -p 9912 -A 2011 -B 2012 -u ws://integritee-node 
+    entrypoint:
+      "/usr/local/worker-cli/demo_sidechain.sh -p 9912 -A 2011 -B 2012 -u ws://integritee-node
       -V wss://integritee-worker-1 -W wss://integritee-worker-2 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/docker/demo-smart-contract.yml
+++ b/docker/demo-smart-contract.yml
@@ -6,13 +6,19 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,itc_rpc_client=warn
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s
-      /usr/local/worker-cli/demo_smart_contract.sh -p 9912 -u ws://integritee-node
+    entrypoint:
+      "/usr/local/worker-cli/demo_smart_contract.sh -p 9912 -u ws://integritee-node
       -V wss://integritee-worker-1 -A 2011 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/docker/demo-teeracle-generic.yml
+++ b/docker/demo-teeracle-generic.yml
@@ -10,13 +10,20 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: [ 'integritee-node' ]
+    depends_on:
+      integritee-node:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=info,integritee_service::teeracle=debug,ita_stf=warn,ita_oracle=debug
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s
-        /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker 
+    healthcheck:
+      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 25
+    entrypoint:
+        "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker
         -u ws://integritee-node -U ws://integritee-teeracle-worker -P 2011 -w 2101 -p 9912 -h 4645
         run --dev --skip-ra --teeracle-interval ${TEERACLE_INTERVAL_SECONDS}s"
     restart: always
@@ -27,13 +34,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-teeracle-worker']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-teeracle-worker:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,sp_io=warn,integritee_cli::exchange_oracle=debug
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-teeracle-worker:4645/is_initialized -timeout 250s    
-      /usr/local/worker-cli/demo_teeracle_generic.sh 
+    entrypoint:
+      "/usr/local/worker-cli/demo_teeracle_generic.sh
       -u ws://integritee-node -p 9912
       -V wss://integritee-teeracle-worker -P 2011
       -d 21 -i ${TEERACLE_INTERVAL_SECONDS}

--- a/docker/demo-teeracle-generic.yml
+++ b/docker/demo-teeracle-generic.yml
@@ -18,7 +18,7 @@ services:
     networks:
       - integritee-test-network
     healthcheck:
-      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      test: curl -s -f http://integritee-teeracle-worker:4645/is_initialized || exit 1
       interval: 10s
       timeout: 10s
       retries: 25

--- a/docker/demo-teeracle.yml
+++ b/docker/demo-teeracle.yml
@@ -21,7 +21,7 @@ services:
     networks:
       - integritee-test-network
     healthcheck:
-      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      test: curl -s -f http://integritee-teeracle-worker:4645/is_initialized || exit 1
       interval: 10s
       timeout: 10s
       retries: 25

--- a/docker/demo-teeracle.yml
+++ b/docker/demo-teeracle.yml
@@ -12,14 +12,21 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: [ 'integritee-node' ]
+    depends_on:
+      integritee-node:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=info,integritee_service::teeracle=debug,ita_stf=warn,ita_exchange_oracle=debug
       - COINMARKETCAP_KEY
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s
-        /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker 
+    healthcheck:
+      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 25
+    entrypoint:
+        "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-teeracle-worker -T wss://integritee-teeracle-worker
         -u ws://integritee-node -U ws://integritee-teeracle-worker -P 2011 -w 2101 -p 9912 -h 4645
         run --dev --skip-ra --teeracle-interval ${TEERACLE_INTERVAL_SECONDS}s"
     restart: always
@@ -30,13 +37,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-teeracle-worker']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-teeracle-worker:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,sp_io=warn,integritee_cli::exchange_oracle=debug
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-teeracle-worker:4645/is_initialized -timeout 250s    
-      /usr/local/worker-cli/demo_teeracle_whitelist.sh 
+    entrypoint:
+      "/usr/local/worker-cli/demo_teeracle_whitelist.sh
       -u ws://integritee-node -p 9912
       -V wss://integritee-teeracle-worker -P 2011
       -d 21 -i ${TEERACLE_INTERVAL_SECONDS}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,11 @@ services:
     container_name: integritee-node
     networks:
       - integritee-test-network
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "9912"]
+      interval: 10s
+      timeout: 10s
+      retries: 6
     command: --dev --rpc-methods unsafe --ws-external --rpc-external --ws-port 9912
     #logging:
       #driver: local
@@ -14,13 +19,20 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: ['integritee-node']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait tcp://integritee-node:9912 -timeout 30s
-      /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-1 -T wss://integritee-worker-1
+    healthcheck:
+      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 25
+    entrypoint:
+      "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-1 -T wss://integritee-worker-1
       -u ws://integritee-node -U ws://integritee-worker-1 -P 2011 -w 2101 -p 9912 -h 4645
       run --dev --skip-ra"
     restart: "no"
@@ -31,13 +43,22 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-worker
-    depends_on: ['integritee-node', 'integritee-worker-1']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
     environment:
       - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-1:4645/is_initialized -timeout 150s
-      /usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-2 -T wss://integritee-worker-2
+    healthcheck:
+      test: curl -s -f http://localhost:4646/is_initialized || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 25
+    entrypoint:
+      "/usr/local/bin/integritee-service --clean-reset --ws-external -M integritee-worker-2 -T wss://integritee-worker-2
       -u ws://integritee-node -U ws://integritee-worker-2 -P 2012 -w 2102 -p 9912 -h 4646
       run --dev --skip-ra --request-state"
     restart: "no"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     networks:
       - integritee-test-network
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "9912"]
+      test: ["CMD", "nc", "-z", "integritee-node", "9912"]
       interval: 10s
       timeout: 10s
       retries: 6
@@ -27,7 +27,7 @@ services:
     networks:
       - integritee-test-network
     healthcheck:
-      test: curl -s -f http://localhost:4645/is_initialized || exit 1
+      test: curl -s -f http://integritee-worker-1:4645/is_initialized || exit 1
       interval: 10s
       timeout: 10s
       retries: 25
@@ -53,7 +53,7 @@ services:
     networks:
       - integritee-test-network
     healthcheck:
-      test: curl -s -f http://localhost:4646/is_initialized || exit 1
+      test: curl -s -f http://integritee-worker-2:4646/is_initialized || exit 1
       interval: 10s
       timeout: 10s
       retries: 25

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   integritee-node:
-    image: "integritee/integritee-node-dev:1.0.28"
+    image: "integritee/integritee-node-dev:1.0.32"
     container_name: integritee-node
     networks:
       - integritee-test-network

--- a/docker/fork-inducer.yml
+++ b/docker/fork-inducer.yml
@@ -14,13 +14,19 @@ services:
     build:
       context: .
       dockerfile: fork.Dockerfile
-    depends_on: [ 'integritee-node', 'integritee-worker-1', 'integritee-worker-2' ]
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s
-     pumba --interval 3m netem --interface eth0 --duration 30s delay --time 1000 integritee-worker-2"
+    entrypoint:
+      "pumba --interval 3m netem --interface eth0 --duration 30s delay --time 1000 integritee-worker-2"
 networks:
   integritee-test-network:
     driver: bridge

--- a/docker/sidechain-benchmark.yml
+++ b/docker/sidechain-benchmark.yml
@@ -16,7 +16,7 @@ services:
     networks:
       - integritee-test-network
     entrypoint:
-      "/"usr/local/worker-cli/benchmark.sh -p 9912 -A 2011 -u ws://integritee-node
+      "/usr/local/worker-cli/benchmark.sh -p 9912 -A 2011 -u ws://integritee-node
       -V wss://integritee-worker-1 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:

--- a/docker/sidechain-benchmark.yml
+++ b/docker/sidechain-benchmark.yml
@@ -6,11 +6,17 @@ services:
       context: ..
       dockerfile: build.Dockerfile
       target: deployed-client
-    depends_on: ['integritee-node', 'integritee-worker-1', 'integritee-worker-2']
+    depends_on:
+      integritee-node:
+        condition: service_healthy
+      integritee-worker-1:
+        condition: service_healthy
+      integritee-worker-2:
+        condition: service_healthy
     networks:
       - integritee-test-network
-    entrypoint: "dockerize -wait http://integritee-worker-2:4646/is_initialized -timeout 250s 
-      /usr/local/worker-cli/benchmark.sh -p 9912 -A 2011 -u ws://integritee-node 
+    entrypoint:
+      "/"usr/local/worker-cli/benchmark.sh -p 9912 -A 2011 -u ws://integritee-node
       -V wss://integritee-worker-1 -C /usr/local/bin/integritee-cli 2>&1"
     restart: "no"
 networks:


### PR DESCRIPTION
This PR replaces `dockerize` with docker [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck), reasons:

- a built-in functionality of docker, thus more standard and doesn't rely on third-party services
- better control over retrying/intervals
- better integration with docker view (logs/inspect)

It uses `nc` to test the availability of the node and `curl` to test the workers.