### PR TITLE
integritee-cli: separate into library and binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,6 +1172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2686,7 @@ dependencies = [
  "serde 1.0.158",
  "serde_json 1.0.94",
  "sgx_crypto_helper",
+ "snafu",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",
@@ -7358,6 +7365,28 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snafu"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
+dependencies = [
+ "doc-comment",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,12 +1172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,7 +2680,6 @@ dependencies = [
  "serde 1.0.158",
  "serde_json 1.0.94",
  "sgx_crypto_helper",
- "snafu",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",
@@ -7365,28 +7358,6 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "snafu"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
-dependencies = [
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "socket2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,6 @@ rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-snafu = { version = "0.7", default-features = false }
 thiserror = "1.0"
 ws = { version = "0.9.1", features = ["ssl"] }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,6 +21,7 @@ rayon = "1.5.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+snafu = { version = "0.7", default-features = false }
 thiserror = "1.0"
 ws = { version = "0.9.1", features = ["ssl"] }
 

--- a/cli/src/base_cli/commands/balance.rs
+++ b/cli/src/base_cli/commands/balance.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	command_utils::{get_accountid_from_str, get_chain_api},
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use substrate_api_client::GetAccountInformation;
 
@@ -28,11 +28,12 @@ pub struct BalanceCommand {
 }
 
 impl BalanceCommand {
-	pub(crate) fn run(&self, cli: &Cli) {
+	pub(crate) fn run(&self, cli: &Cli) -> CliResult {
 		let api = get_chain_api(cli);
 		let accountid = get_accountid_from_str(&self.account);
 		let balance =
 			if let Some(data) = api.get_account_data(&accountid).unwrap() { data.free } else { 0 };
 		println!("{}", balance);
+		Ok(CliResultOk::Balance { balance })
 	}
 }

--- a/cli/src/base_cli/commands/faucet.rs
+++ b/cli/src/base_cli/commands/faucet.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	command_utils::{get_accountid_from_str, get_chain_api},
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use itp_node_api::api_client::ParentchainExtrinsicSigner;
 use my_node_runtime::{BalancesCall, RuntimeCall};
@@ -36,7 +36,7 @@ pub struct FaucetCommand {
 }
 
 impl FaucetCommand {
-	pub(crate) fn run(&self, cli: &Cli) {
+	pub(crate) fn run(&self, cli: &Cli) -> CliResult {
 		let mut api = get_chain_api(cli);
 		api.set_signer(ParentchainExtrinsicSigner::new(AccountKeyring::Alice.pair()));
 		let mut nonce = api.get_nonce().unwrap();
@@ -56,5 +56,7 @@ impl FaucetCommand {
 			let _blockh = api.submit_extrinsic(xt).unwrap();
 			nonce += 1;
 		}
+
+		Ok(CliResultOk::None)
 	}
 }

--- a/cli/src/base_cli/commands/listen.rs
+++ b/cli/src/base_cli/commands/listen.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::{command_utils::get_chain_api, Cli};
+use crate::{command_utils::get_chain_api, Cli, CliResult, CliResultOk};
 use base58::ToBase58;
 use codec::Encode;
 use log::*;
@@ -34,7 +34,7 @@ pub struct ListenCommand {
 }
 
 impl ListenCommand {
-	pub(crate) fn run(&self, cli: &Cli) {
+	pub(crate) fn run(&self, cli: &Cli) -> CliResult {
 		println!("{:?} {:?}", self.events, self.blocks);
 		let api = get_chain_api(cli);
 		info!("Subscribing to events");
@@ -44,12 +44,12 @@ impl ListenCommand {
 		loop {
 			if let Some(e) = self.events {
 				if count >= e {
-					return
+					return Ok(CliResultOk::None)
 				}
 			};
 			if let Some(b) = self.blocks {
 				if blocks >= b {
-					return
+					return Ok(CliResultOk::None)
 				}
 			};
 

--- a/cli/src/base_cli/commands/shield_funds.rs
+++ b/cli/src/base_cli/commands/shield_funds.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	command_utils::{get_accountid_from_str, get_chain_api, *},
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use base58::FromBase58;
 use codec::{Decode, Encode};
@@ -42,7 +42,7 @@ pub struct ShieldFundsCommand {
 }
 
 impl ShieldFundsCommand {
-	pub(crate) fn run(&self, cli: &Cli) {
+	pub(crate) fn run(&self, cli: &Cli) -> CliResult {
 		let mut chain_api = get_chain_api(cli);
 
 		let shard_opt = match self.shard.from_base58() {
@@ -77,5 +77,7 @@ impl ShieldFundsCommand {
 
 		let tx_hash = chain_api.submit_and_watch_extrinsic_until(xt, XtStatus::Finalized).unwrap();
 		println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
+
+		Ok(CliResultOk::None)
 	}
 }

--- a/cli/src/base_cli/commands/transfer.rs
+++ b/cli/src/base_cli/commands/transfer.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	command_utils::{get_accountid_from_str, get_chain_api, *},
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use itp_node_api::api_client::{Address, ParentchainExtrinsicSigner};
 use log::*;
@@ -40,7 +40,7 @@ pub struct TransferCommand {
 }
 
 impl TransferCommand {
-	pub(crate) fn run(&self, cli: &Cli) {
+	pub(crate) fn run(&self, cli: &Cli) -> CliResult {
 		let from_account = get_pair_from_str(&self.from);
 		let to_account = get_accountid_from_str(&self.to);
 		info!("from ss58 is {}", from_account.public().to_ss58check());
@@ -54,6 +54,9 @@ impl TransferCommand {
 			.extrinsic_hash;
 		println!("[+] TrustedOperation got finalized. Hash: {:?}\n", tx_hash);
 		let result = api.get_account_data(&to_account).unwrap().unwrap();
-		println!("balance for {} is now {}", to_account, result.free);
+		let balance = result.free;
+		println!("balance for {} is now {}", to_account, balance);
+
+		Ok(CliResultOk::Balance { balance })
 	}
 }

--- a/cli/src/base_cli/mod.rs
+++ b/cli/src/base_cli/mod.rs
@@ -21,7 +21,7 @@ use crate::{
 		shield_funds::ShieldFundsCommand, transfer::TransferCommand,
 	},
 	command_utils::*,
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use base58::ToBase58;
 use chrono::{DateTime, Utc};
@@ -73,7 +73,7 @@ pub enum BaseCommand {
 }
 
 impl BaseCommand {
-	pub fn run(&self, cli: &Cli) {
+	pub fn run(&self, cli: &Cli) -> CliResult {
 		match self {
 			BaseCommand::Balance(cmd) => cmd.run(cli),
 			BaseCommand::NewAccount => new_account(),
@@ -89,42 +89,63 @@ impl BaseCommand {
 	}
 }
 
-fn new_account() {
+fn new_account() -> CliResult {
 	let store = LocalKeystore::open(PathBuf::from(&KEYSTORE_PATH), None).unwrap();
 	let key: sr25519::AppPair = store.generate().unwrap();
+	let key_base58 = key.public().to_ss58check();
 	drop(store);
-	println!("{}", key.public().to_ss58check());
+	println!("{}", key_base58);
+	Ok(CliResultOk::PubKeysBase58 {
+		pubkeys_sr25519: Some(vec![key_base58]),
+		pubkeys_ed25519: None,
+	})
 }
 
-fn list_accounts() {
+fn list_accounts() -> CliResult {
 	let store = LocalKeystore::open(PathBuf::from(&KEYSTORE_PATH), None).unwrap();
 	println!("sr25519 keys:");
+	let mut keys_sr25519 = vec![];
 	for pubkey in store.public_keys::<sr25519::AppPublic>().unwrap().into_iter() {
-		println!("{}", pubkey.to_ss58check());
+		let key_ss58 = pubkey.to_ss58check();
+		println!("{}", key_ss58);
+		keys_sr25519.push(key_ss58);
 	}
 	println!("ed25519 keys:");
+	let mut keys_ed25519 = vec![];
 	for pubkey in store.public_keys::<ed25519::AppPublic>().unwrap().into_iter() {
-		println!("{}", pubkey.to_ss58check());
+		let key_ss58 = pubkey.to_ss58check();
+		println!("{}", key_ss58);
+		keys_ed25519.push(key_ss58);
 	}
 	drop(store);
+
+	Ok(CliResultOk::PubKeysBase58 {
+		pubkeys_sr25519: Some(keys_sr25519),
+		pubkeys_ed25519: Some(keys_ed25519),
+	})
 }
 
-fn print_metadata(cli: &Cli) {
+fn print_metadata(cli: &Cli) -> CliResult {
 	let api = get_chain_api(cli);
 	let meta = api.metadata();
 	println!("Metadata:\n {}", Metadata::pretty_format(&meta.runtime_metadata()).unwrap());
+	Ok(CliResultOk::Metadata { metadata: meta.clone() })
 }
 
-fn print_sgx_metadata(cli: &Cli) {
+fn print_sgx_metadata(cli: &Cli) -> CliResult {
 	let worker_api_direct = get_worker_api_direct(cli);
 	let metadata = worker_api_direct.get_state_metadata().unwrap();
 	println!("Metadata:\n {}", Metadata::pretty_format(metadata.runtime_metadata()).unwrap());
+	Ok(CliResultOk::Metadata { metadata })
 }
 
-fn list_workers(cli: &Cli) {
+fn list_workers(cli: &Cli) -> CliResult {
 	let api = get_chain_api(cli);
 	let wcount = api.enclave_count(None).unwrap();
 	println!("number of workers registered: {}", wcount);
+
+	let mut mr_enclaves = Vec::with_capacity(wcount as usize);
+
 	for w in 1..=wcount {
 		let enclave = api.enclave(w, None).unwrap();
 		if enclave.is_none() {
@@ -134,10 +155,15 @@ fn list_workers(cli: &Cli) {
 		let enclave = enclave.unwrap();
 		let timestamp =
 			DateTime::<Utc>::from(UNIX_EPOCH + Duration::from_millis(enclave.timestamp));
+		let mr_enclave = enclave.mr_enclave.to_base58();
 		println!("Enclave {}", w);
 		println!("   AccountId: {}", enclave.pubkey.to_ss58check());
-		println!("   MRENCLAVE: {}", enclave.mr_enclave.to_base58());
+		println!("   MRENCLAVE: {}", mr_enclave);
 		println!("   RA timestamp: {}", timestamp);
 		println!("   URL: {}", enclave.url);
+
+		mr_enclaves.push(mr_enclave);
 	}
+
+	Ok(CliResultOk::MrEnclaveBase58 { mr_enclaves })
 }

--- a/cli/src/benchmark/mod.rs
+++ b/cli/src/benchmark/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 		decode_balance, get_identifiers, get_keystore_path, get_pair_from_str,
 	},
 	trusted_operation::{get_json_request, get_state, perform_trusted_operation, wait_until},
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use codec::Decode;
 use hdrhistogram::Histogram;
@@ -113,7 +113,7 @@ struct BenchmarkTransaction {
 }
 
 impl BenchmarkCommand {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let random_wait_before_transaction_ms: (u32, u32) = (
 			self.random_wait_before_transaction_min_ms,
 			self.random_wait_before_transaction_max_ms,
@@ -247,7 +247,9 @@ impl BenchmarkCommand {
 			overall_start.elapsed().as_millis()
 		);
 
-		print_benchmark_statistic(outputs, self.wait_for_confirmation)
+		print_benchmark_statistic(outputs, self.wait_for_confirmation);
+
+		Ok(CliResultOk::None)
 	}
 }
 
@@ -262,7 +264,7 @@ fn get_balance(
 	);
 
 	let getter_start_timer = Instant::now();
-	let getter_result = get_state(direct_client, shard, &getter);
+	let getter_result = get_state(direct_client, shard, &getter).unwrap_or_default();
 	let getter_execution_time = getter_start_timer.elapsed().as_millis();
 
 	let balance = decode_balance(getter_result);
@@ -282,7 +284,7 @@ fn get_nonce(
 	);
 
 	let getter_start_timer = Instant::now();
-	let getter_result = get_state(direct_client, shard, &getter);
+	let getter_result = get_state(direct_client, shard, &getter).unwrap_or_default();
 	let getter_execution_time = getter_start_timer.elapsed().as_millis();
 
 	let nonce = match getter_result {

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -44,7 +44,6 @@ pub enum Commands {
 }
 
 pub fn match_command(cli: &Cli) -> CliResult {
-	#[allow(non_snake_case, unused_variables)]
 	match &cli.command {
 		Commands::Base(cmd) => cmd.run(cli),
 		Commands::Trusted(trusted_cli) => trusted_cli.run(cli),

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -16,7 +16,7 @@
 */
 
 extern crate chrono;
-use crate::{base_cli::BaseCommand, trusted_cli::TrustedCli, Cli};
+use crate::{base_cli::BaseCommand, trusted_cli::TrustedCli, Cli, CliResult, CliResultOk};
 use clap::Subcommand;
 
 #[cfg(feature = "teeracle")]
@@ -43,12 +43,19 @@ pub enum Commands {
 	Attesteer(AttesteerCommand),
 }
 
-pub fn match_command(cli: &Cli) {
+pub fn match_command(cli: &Cli) -> CliResult {
+	#[allow(non_snake_case, unused_variables)]
 	match &cli.command {
 		Commands::Base(cmd) => cmd.run(cli),
 		Commands::Trusted(trusted_cli) => trusted_cli.run(cli),
 		#[cfg(feature = "teeracle")]
-		Commands::Oracle(cmd) => cmd.run(cli),
-		Commands::Attesteer(cmd) => cmd.run(cli),
-	};
+		Commands::Oracle(cmd) => {
+			cmd.run(cli);
+			Ok(CliResultOk::None)
+		},
+		Commands::Attesteer(cmd) => {
+			cmd.run(cli);
+			Ok(CliResultOk::None)
+		},
+	}
 }

--- a/cli/src/evm/commands/evm_call.rs
+++ b/cli/src/evm/commands/evm_call.rs
@@ -20,7 +20,7 @@ use crate::{
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
 	trusted_operation::perform_trusted_operation,
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use codec::Decode;
 use ita_stf::{Index, TrustedCall, TrustedGetter, TrustedOperation};
@@ -43,7 +43,7 @@ pub struct EvmCallCommands {
 }
 
 impl EvmCallCommands {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let sender = get_pair_from_str(trusted_args, &self.from);
 		let sender_acc: AccountId = sender.public().into();
 
@@ -80,6 +80,7 @@ impl EvmCallCommands {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(sender)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		let _ = perform_trusted_operation(cli, trusted_args, &function_call);
+		Ok(perform_trusted_operation(cli, trusted_args, &function_call)
+			.map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/evm/commands/evm_command_utils.rs
+++ b/cli/src/evm/commands/evm_command_utils.rs
@@ -20,15 +20,10 @@ macro_rules! get_layer_two_evm_nonce {
 		let top: TrustedOperation = TrustedGetter::evm_nonce($signer_pair.public().into())
 			.sign(&KeyPair::Sr25519(Box::new($signer_pair.clone())))
 			.into();
-		let res = perform_trusted_operation($cli, $trusted_args, &top);
-		let nonce: Index = if let Some(n) = res {
-			if let Ok(nonce) = Index::decode(&mut n.as_slice()) {
-				nonce
-			} else {
-				0
-			}
-		} else {
-			0
+		let res = perform_trusted_operation($cli, $trusted_args, &top).unwrap_or_default();
+		let nonce = match res {
+			Some(n) => Index::decode(&mut n.as_slice()).unwrap_or(0),
+			None => 0,
 		};
 		debug!("got evm nonce: {:?}", nonce);
 		nonce

--- a/cli/src/evm/commands/evm_create.rs
+++ b/cli/src/evm/commands/evm_create.rs
@@ -20,7 +20,7 @@ use crate::{
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
 	trusted_operation::perform_trusted_operation,
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use codec::Decode;
 use ita_stf::{
@@ -44,7 +44,7 @@ pub struct EvmCreateCommands {
 }
 
 impl EvmCreateCommands {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let from = get_pair_from_str(trusted_args, &self.from);
 		let from_acc: AccountId = from.public().into();
 		println!("from ss58 is {}", from.public().to_ss58check());
@@ -80,10 +80,11 @@ impl EvmCreateCommands {
 		.sign(&from.into(), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
 
-		let _ = perform_trusted_operation(cli, trusted_args, &top);
+		let _ = perform_trusted_operation(cli, trusted_args, &top)?;
 
 		let execution_address = evm_create_address(sender_evm_acc, evm_account_nonce);
 		info!("trusted call evm_create executed");
 		println!("Created the smart contract with address {:?}", execution_address);
+		Ok(CliResultOk::H160 { hash: execution_address })
 	}
 }

--- a/cli/src/evm/mod.rs
+++ b/cli/src/evm/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 		evm_call::EvmCallCommands, evm_create::EvmCreateCommands, evm_read::EvmReadCommands,
 	},
 	trusted_cli::TrustedCli,
-	Cli,
+	Cli, CliResult,
 };
 
 mod commands;
@@ -39,7 +39,7 @@ pub enum EvmCommand {
 }
 
 impl EvmCommand {
-	pub fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		match self {
 			EvmCommand::EvmCreate(cmd) => cmd.run(cli, trusted_args),
 			EvmCommand::EvmRead(cmd) => cmd.run(cli, trusted_args),

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -45,9 +45,9 @@ pub mod commands;
 
 use crate::commands::Commands;
 use clap::Parser;
-use snafu::prelude::*;
 use sp_core::{H160, H256};
 use substrate_api_client::Metadata;
+use thiserror::Error;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -104,11 +104,11 @@ pub enum CliResultOk {
 	None,
 }
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Error)]
 pub enum CliError {
-	#[snafu(display("trusted operation error: {:?}", msg))]
+	#[error("trusted operation error: {:?}", msg)]
 	TrustedOp { msg: String },
-	#[snafu(display("EvmReadCommands error: {:?}", msg))]
+	#[error("EvmReadCommands error: {:?}", msg)]
 	EvmRead { msg: String },
 }
 

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,125 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! an RPC client to Integritee using websockets
+//!
+//! examples
+//! integritee_cli 127.0.0.1:9944 transfer //Alice 5G9RtsTbiYJYQYMHbWfyPoeuuxNaCbC16tZ2JGrZ4gRKwz14 1000
+//!
+#![feature(rustc_private)]
+#[macro_use]
+extern crate clap;
+extern crate chrono;
+extern crate env_logger;
+extern crate log;
+
+mod attesteer;
+mod base_cli;
+mod benchmark;
+mod command_utils;
+mod error;
+#[cfg(feature = "evm")]
+mod evm;
+#[cfg(feature = "teeracle")]
+mod oracle;
+mod trusted_base_cli;
+mod trusted_cli;
+mod trusted_command_utils;
+mod trusted_operation;
+
+pub mod commands;
+
+use crate::commands::Commands;
+use clap::Parser;
+use snafu::prelude::*;
+use sp_core::{H160, H256};
+use substrate_api_client::Metadata;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Parser)]
+#[clap(name = "integritee-cli")]
+#[clap(version = VERSION)]
+#[clap(author = "Integritee AG <hello@integritee.network>")]
+#[clap(about = "interact with integritee-node and workers", long_about = None)]
+#[clap(after_help = "stf subcommands depend on the stf crate this has been built against")]
+pub struct Cli {
+	/// node url
+	#[clap(short = 'u', long, default_value_t = String::from("ws://127.0.0.1"))]
+	node_url: String,
+
+	/// node port
+	#[clap(short = 'p', long, default_value_t = String::from("9944"))]
+	node_port: String,
+
+	/// worker url
+	#[clap(short = 'U', long, default_value_t = String::from("wss://127.0.0.1"))]
+	worker_url: String,
+
+	/// worker direct invocation port
+	#[clap(short = 'P', long, default_value_t = String::from("2000"))]
+	trusted_worker_port: String,
+
+	#[clap(subcommand)]
+	command: Commands,
+}
+
+pub enum CliResultOk {
+	PubKeysBase58 {
+		pubkeys_sr25519: Option<Vec<String>>,
+		pubkeys_ed25519: Option<Vec<String>>,
+	},
+	Balance {
+		balance: u128,
+	},
+	MrEnclaveBase58 {
+		mr_enclaves: Vec<String>,
+	},
+	Metadata {
+		metadata: Metadata,
+	},
+	H256 {
+		hash: H256,
+	},
+	/// Result of "EvmCreateCommands": execution_address
+	H160 {
+		hash: H160,
+	},
+	// TODO should ideally be removed; or at least drastically less used
+	// We WANT all commands exposed by the cli to return something useful for the caller(ie instead of printing)
+	None,
+}
+
+#[derive(Debug, Snafu)]
+pub enum CliError {
+	#[snafu(display("trusted operation error: {:?}", msg))]
+	TrustedOp { msg: String },
+	#[snafu(display("EvmReadCommands error: {:?}", msg))]
+	EvmRead { msg: String },
+}
+
+pub type CliResult = Result<CliResultOk, CliError>;
+
+/// This is used for the commands that directly call `perform_trusted_operation`
+/// which typically return `CliResultOk::None`
+///
+/// eg: `SetBalanceCommand`,`TransferCommand`,`UnshieldFundsCommand`
+impl From<trusted_operation::TrustedOperationError> for CliError {
+	fn from(value: trusted_operation::TrustedOperationError) -> Self {
+		CliError::TrustedOp { msg: value.to_string() }
+	}
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -15,69 +15,13 @@
 
 */
 
-//! an RPC client to Integritee using websockets
-//!
-//! examples
-//! integritee_cli 127.0.0.1:9944 transfer //Alice 5G9RtsTbiYJYQYMHbWfyPoeuuxNaCbC16tZ2JGrZ4gRKwz14 1000
-//!
-#![feature(rustc_private)]
-#[macro_use]
-extern crate clap;
-extern crate chrono;
-extern crate env_logger;
-extern crate log;
-
-mod attesteer;
-mod base_cli;
-mod benchmark;
-mod command_utils;
-mod commands;
-mod error;
-#[cfg(feature = "evm")]
-mod evm;
-#[cfg(feature = "teeracle")]
-mod oracle;
-mod trusted_base_cli;
-mod trusted_cli;
-mod trusted_command_utils;
-mod trusted_operation;
-
-use crate::commands::Commands;
 use clap::Parser;
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-#[derive(Parser)]
-#[clap(name = "integritee-cli")]
-#[clap(version = VERSION)]
-#[clap(author = "Integritee AG <hello@integritee.network>")]
-#[clap(about = "interact with integritee-node and workers", long_about = None)]
-#[clap(after_help = "stf subcommands depend on the stf crate this has been built against")]
-pub struct Cli {
-	/// node url
-	#[clap(short = 'u', long, default_value_t = String::from("ws://127.0.0.1"))]
-	node_url: String,
-
-	/// node port
-	#[clap(short = 'p', long, default_value_t = String::from("9944"))]
-	node_port: String,
-
-	/// worker url
-	#[clap(short = 'U', long, default_value_t = String::from("wss://127.0.0.1"))]
-	worker_url: String,
-
-	/// worker direct invocation port
-	#[clap(short = 'P', long, default_value_t = String::from("2000"))]
-	trusted_worker_port: String,
-
-	#[clap(subcommand)]
-	command: Commands,
-}
+use integritee_cli::{commands, Cli};
 
 fn main() {
 	env_logger::init();
 
 	let cli = Cli::parse();
 
-	commands::match_command(&cli);
+	commands::match_command(&cli).unwrap();
 }

--- a/cli/src/trusted_base_cli/commands/balance.rs
+++ b/cli/src/trusted_base_cli/commands/balance.rs
@@ -15,7 +15,9 @@
 
 */
 
-use crate::{trusted_cli::TrustedCli, trusted_command_utils::get_balance, Cli};
+use crate::{
+	trusted_cli::TrustedCli, trusted_command_utils::get_balance, Cli, CliResult, CliResultOk,
+};
 
 #[derive(Parser)]
 pub struct BalanceCommand {
@@ -24,7 +26,9 @@ pub struct BalanceCommand {
 }
 
 impl BalanceCommand {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
-		println!("{}", get_balance(cli, trusted_args, &self.account).unwrap_or_default());
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
+		let balance = get_balance(cli, trusted_args, &self.account).unwrap_or_default();
+		println!("{}", balance);
+		Ok(CliResultOk::Balance { balance })
 	}
 }

--- a/cli/src/trusted_base_cli/commands/nonce.rs
+++ b/cli/src/trusted_base_cli/commands/nonce.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	get_layer_two_nonce, trusted_cli::TrustedCli, trusted_command_utils::get_pair_from_str,
-	trusted_operation::perform_trusted_operation, Cli,
+	trusted_operation::perform_trusted_operation, Cli, CliResult, CliResultOk,
 };
 use codec::Decode;
 use ita_stf::{Index, TrustedGetter, TrustedOperation};
@@ -32,8 +32,9 @@ pub struct NonceCommand {
 }
 
 impl NonceCommand {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let who = get_pair_from_str(trusted_args, &self.account);
 		println!("{}", get_layer_two_nonce!(who, cli, trusted_args));
+		Ok(CliResultOk::None)
 	}
 }

--- a/cli/src/trusted_base_cli/commands/set_balance.rs
+++ b/cli/src/trusted_base_cli/commands/set_balance.rs
@@ -20,7 +20,7 @@ use crate::{
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
 	trusted_operation::perform_trusted_operation,
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use codec::Decode;
 use ita_stf::{Index, TrustedCall, TrustedGetter, TrustedOperation};
@@ -40,7 +40,7 @@ pub struct SetBalanceCommand {
 }
 
 impl SetBalanceCommand {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let who = get_pair_from_str(trusted_args, &self.account);
 		let signer = get_pair_from_str(trusted_args, "//Alice");
 		info!("account ss58 is {}", who.public().to_ss58check());
@@ -57,6 +57,6 @@ impl SetBalanceCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		let _ = perform_trusted_operation(cli, trusted_args, &top);
+		Ok(perform_trusted_operation(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/trusted_base_cli/commands/transfer.rs
+++ b/cli/src/trusted_base_cli/commands/transfer.rs
@@ -20,7 +20,7 @@ use crate::{
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_accountid_from_str, get_identifiers, get_pair_from_str},
 	trusted_operation::perform_trusted_operation,
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use codec::Decode;
 use ita_stf::{Index, TrustedCall, TrustedGetter, TrustedOperation};
@@ -43,7 +43,7 @@ pub struct TransferCommand {
 }
 
 impl TransferCommand {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let from = get_pair_from_str(trusted_args, &self.from);
 		let to = get_accountid_from_str(&self.to);
 		info!("from ss58 is {}", from.public().to_ss58check());
@@ -62,7 +62,8 @@ impl TransferCommand {
 			TrustedCall::balance_transfer(from.public().into(), to, self.amount)
 				.sign(&KeyPair::Sr25519(Box::new(from)), nonce, &mrenclave, &shard)
 				.into_trusted_operation(trusted_args.direct);
-		let _ = perform_trusted_operation(cli, trusted_args, &top);
+		let res = perform_trusted_operation(cli, trusted_args, &top).map(|_| CliResultOk::None)?;
 		info!("trusted call transfer executed");
+		Ok(res)
 	}
 }

--- a/cli/src/trusted_base_cli/commands/unshield_funds.rs
+++ b/cli/src/trusted_base_cli/commands/unshield_funds.rs
@@ -20,7 +20,7 @@ use crate::{
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_accountid_from_str, get_identifiers, get_pair_from_str},
 	trusted_operation::perform_trusted_operation,
-	Cli,
+	Cli, CliResult, CliResultOk,
 };
 use codec::Decode;
 use ita_stf::{Index, TrustedCall, TrustedGetter, TrustedOperation};
@@ -43,7 +43,7 @@ pub struct UnshieldFundsCommand {
 }
 
 impl UnshieldFundsCommand {
-	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let from = get_pair_from_str(trusted_args, &self.from);
 		let to = get_accountid_from_str(&self.to);
 		println!("from ss58 is {}", from.public().to_ss58check());
@@ -62,6 +62,6 @@ impl UnshieldFundsCommand {
 			TrustedCall::balance_unshield(from.public().into(), to, self.amount, shard)
 				.sign(&KeyPair::Sr25519(Box::new(from)), nonce, &mrenclave, &shard)
 				.into_trusted_operation(trusted_args.direct);
-		let _ = perform_trusted_operation(cli, trusted_args, &top);
+		Ok(perform_trusted_operation(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/trusted_cli.rs
+++ b/cli/src/trusted_cli.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::{benchmark::BenchmarkCommand, Cli};
+use crate::{benchmark::BenchmarkCommand, Cli, CliResult};
 
 #[cfg(feature = "evm")]
 use crate::evm::EvmCommand;
@@ -57,7 +57,7 @@ pub enum TrustedCommand {
 }
 
 impl TrustedCli {
-	pub(crate) fn run(&self, cli: &Cli) {
+	pub(crate) fn run(&self, cli: &Cli) -> CliResult {
 		match &self.command {
 			TrustedCommand::BaseTrusted(cmd) => cmd.run(cli, self),
 			TrustedCommand::Benchmark(cmd) => cmd.run(cli, self),

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -34,7 +34,6 @@ use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use log::*;
 use my_node_runtime::{Hash, RuntimeEvent};
 use pallet_teerex::Event as TeerexEvent;
-use snafu::prelude::*;
 use sp_core::{sr25519 as sr25519_core, H256};
 use std::{
 	result::Result as StdResult,
@@ -45,10 +44,11 @@ use substrate_api_client::{
 	compose_extrinsic, GetHeader, SubmitAndWatch, SubscribeEvents, XtStatus,
 };
 use teerex_primitives::Request;
+use thiserror::Error;
 
-#[derive(Debug, Snafu)]
+#[derive(Debug, Error)]
 pub(crate) enum TrustedOperationError {
-	#[snafu(display("default error: {:?}", msg))]
+	#[error("default error: {msg:?}")]
 	Default { msg: String },
 }
 

--- a/cli/tests/basic_tests.rs
+++ b/cli/tests/basic_tests.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use integritee_cli::{commands, Cli};
+use integritee_cli::Cli;
 
 fn init() {
 	env_logger::try_init();

--- a/cli/tests/basic_tests.rs
+++ b/cli/tests/basic_tests.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+use integritee_cli::{commands, Cli};
+
+fn init() {
+	env_logger::try_init();
+}
+
+#[test]
+fn test_version() {
+	init();
+
+	let res = Cli::try_parse_from(vec!["placeholder_cli_path", "--version"]);
+
+	assert!(matches!(res, Err(clap::Error { kind: clap::ErrorKind::DisplayVersion, .. })));
+}
+
+#[test]
+fn test_help() {
+	init();
+
+	let res = Cli::try_parse_from(vec!["placeholder_cli_path", "--help"]);
+
+	assert!(matches!(res, Err(clap::Error { kind: clap::ErrorKind::DisplayHelp, .. })));
+}


### PR DESCRIPTION
Hello,

Following up on https://github.com/integritee-network/worker/issues/1167 I have started a basic refactoring of the cli.
I needed to use `integritee-cli` from Android(and soon iOs) as a library so I cherry-picked and cleanup the required changes from our current branch and I am proposing this refactor.

NOTE: For this first draft, I aimed for the "minimal changeset" and not really for the "cleanest lib interface"... 
I am open for feedback!

Overview of the changes:
- most code from main.rs moved to lib.rs; with added structs `CliResultOk`, `CliError`, `CliResult`
- all `*Commands` return `CliResult`
- most of the logic changes are in `cli/src/trusted_operation.rs`
	- `perform_trusted_operation` now return new struct `TrustedOpResult`
	- I tried to correctly identify the previous "None means an error" vs "None means there was nothing to return"

TBD:
- do you want me to "go deeper" refactoring and expose a "proper lib"
  ie expose all `Subcommand` directly as `pub fn`[ideally keeping the `integritee-cli` as-is to not break anything]
- I could also in the PR ensure the cli works on Android; to do this two options: patch `sp-wasm-interface` and remove deps on `wasmi`+`wasmtime`; or patch `wasmtime` to allow compiling on Android+Emulator
  - For this option, not sure how to implement it; in my project I have a [dirty "patch"](https://github.com/Interstellar-Network/wallet-app/compare/master...cli-refactor-without-wasm) but ideally it should be done in this repo instead