### PR TITLE
Reduce docker image size

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -121,7 +121,7 @@ WORKDIR /usr/local/bin
 
 COPY --from=builder /opt/sgxsdk/lib64 /opt/sgxsdk/lib64
 COPY --from=builder /root/work/worker/bin/* ./
-COPY --from=builder /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
+COPY --from=builder /lib/x86_64-linux-gnu/libsgx* /lib/x86_64-linux-gnu/
 
 RUN touch spid.txt key.txt
 RUN chmod +x /usr/local/bin/integritee-service

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -122,6 +122,7 @@ WORKDIR /usr/local/bin
 COPY --from=builder /opt/sgxsdk/lib64 /opt/sgxsdk/lib64
 COPY --from=builder /root/work/worker/bin/* ./
 COPY --from=builder /lib/x86_64-linux-gnu/libsgx* /lib/x86_64-linux-gnu/
+COPY --from=builder /lib/x86_64-linux-gnu/libdcap* /lib/x86_64-linux-gnu/
 
 RUN touch spid.txt key.txt
 RUN chmod +x /usr/local/bin/integritee-service


### PR DESCRIPTION
This PR aims to decrease the docker image size. This should not break anything.

Currently integritee-service gets linked to the following SGX (/DCAP) related libraries:
```bash
ldd ./integritee-service | grep -E "dcap|sgx"
        libsgx_urts_sim.so => /opt/sgxsdk/sdk_libs/libsgx_urts_sim.so (0x00007fb804482000)
        libsgx_dcap_ql.so.1 => /lib/x86_64-linux-gnu/libsgx_dcap_ql.so.1 (0x00007fb804294000)
        libsgx_dcap_quoteverify.so.1 => /lib/x86_64-linux-gnu/libsgx_dcap_quoteverify.so.1 (0x00007fb80406b000)
        libdcap_quoteprov.so.1 => /lib/x86_64-linux-gnu/libdcap_quoteprov.so.1 (0x00007fb803ec3000)
        libsgx_uae_service_sim.so => /opt/sgxsdk/sdk_libs/libsgx_uae_service_sim.so (0x00007fb803b52000)
        libsgx_qe3_logic.so => /lib/x86_64-linux-gnu/libsgx_qe3_logic.so (0x00007fb8037c0000)
        libsgx_pce_logic.so.1 => /lib/x86_64-linux-gnu/libsgx_pce_logic.so.1 (0x00007fb8037ba000)
        libsgx_default_qcnl_wrapper.so.1 => /lib/x86_64-linux-gnu/libsgx_default_qcnl_wrapper.so.1 (0x00007fb803778000)
        libsgx_urts.so.2 => /lib/x86_64-linux-gnu/libsgx_urts.so.2 (0x00007fb80374f000)
        libsgx_enclave_common.so.1 => /lib/x86_64-linux-gnu/libsgx_enclave_common.so.1 (0x00007fb8036af000)

```

The zipped version went down from around 230 MBs to 117 MBs (roughly 50%).
Previously: https://github.com/integritee-network/worker/actions/runs/4254006364
Now: https://github.com/OverOrion/worker/actions/runs/4261005841

Fixes #1122.