### PR TITLE
Marblerun prometheus integration fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ Enclave_EDL_Files := enclave-runtime/Enclave_t.c enclave-runtime/Enclave_t.h ser
 
 ######## Integritee-service settings ########
 SRC_Files := $(shell find . -type f -name '*.rs') $(shell find . -type f -name 'Cargo.toml')
-Worker_Rust_Flags := $(CARGO_TARGET) $(WORKER_FEATURES),dcap
+Worker_Rust_Flags := $(CARGO_TARGET) $(WORKER_FEATURES)
 Worker_Include_Paths := -I ./service -I./include -I$(SGX_SDK)/include -I$(CUSTOM_EDL_PATH)
 Worker_C_Flags := $(SGX_COMMON_CFLAGS) -fPIC -Wno-attributes $(Worker_Include_Paths)
 

--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,12 @@ ifeq ($(SGX_PRODUCTION), 1)
 	SGX_ENCLAVE_MODE = "Production Mode"
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.production.xml"
 	SGX_SIGN_KEY = $(SGX_COMMERCIAL_KEY)
-	WORKER_FEATURES = --features=production,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES += --features=production,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 else
 	SGX_ENCLAVE_MODE = "Development Mode"
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.xml"
 	SGX_SIGN_KEY = "enclave-runtime/Enclave_private.pem"
-	WORKER_FEATURES = --features=default,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES += --features=default,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
 endif
 
 CLIENT_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)

--- a/Makefile
+++ b/Makefile
@@ -77,12 +77,12 @@ ifeq ($(SGX_PRODUCTION), 1)
 	SGX_ENCLAVE_MODE = "Production Mode"
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.production.xml"
 	SGX_SIGN_KEY = $(SGX_COMMERCIAL_KEY)
-	WORKER_FEATURES += --features=production,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES := --features=production,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
 else
 	SGX_ENCLAVE_MODE = "Development Mode"
 	SGX_ENCLAVE_CONFIG = "enclave-runtime/Enclave.config.xml"
 	SGX_SIGN_KEY = "enclave-runtime/Enclave_private.pem"
-	WORKER_FEATURES += --features=default,$(WORKER_MODE),$(ADDITIONAL_FEATURES)
+	WORKER_FEATURES := --features=default,$(WORKER_MODE),$(WORKER_FEATURES),$(ADDITIONAL_FEATURES)
 endif
 
 CLIENT_FEATURES = --features=$(WORKER_MODE),$(ADDITIONAL_FEATURES)

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ Enclave_EDL_Files := enclave-runtime/Enclave_t.c enclave-runtime/Enclave_t.h ser
 
 ######## Integritee-service settings ########
 SRC_Files := $(shell find . -type f -name '*.rs') $(shell find . -type f -name 'Cargo.toml')
-Worker_Rust_Flags := $(CARGO_TARGET) $(WORKER_FEATURES)
+Worker_Rust_Flags := $(CARGO_TARGET) $(WORKER_FEATURES),dcap
 Worker_Include_Paths := -I ./service -I./include -I$(SGX_SDK)/include -I$(CUSTOM_EDL_PATH)
 Worker_C_Flags := $(SGX_COMMON_CFLAGS) -fPIC -Wno-attributes $(Worker_Include_Paths)
 

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -272,7 +272,7 @@ pub fn generate_dcap_ra_extrinsic_from_quote_internal(
 ) -> EnclaveResult<OpaqueExtrinsic> {
 	let extrinsics_factory = get_extrinsic_factory_from_solo_or_parachain()?;
 	let node_metadata_repo = get_node_metadata_repository_from_solo_or_parachain()?;
-	info!("    [Enclave] Compose register enclave gettings callIDs:");
+	info!("    [Enclave] Compose register enclave getting callIDs:");
 
 	let call_ids = node_metadata_repo
 		.get_from_metadata(|m| m.register_dcap_enclave_call_indexes())?

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -272,7 +272,7 @@ pub fn generate_dcap_ra_extrinsic_from_quote_internal(
 ) -> EnclaveResult<OpaqueExtrinsic> {
 	let extrinsics_factory = get_extrinsic_factory_from_solo_or_parachain()?;
 	let node_metadata_repo = get_node_metadata_repository_from_solo_or_parachain()?;
-	info!("    [Enclave] Compose register enclave gettins callIDs:");
+	info!("    [Enclave] Compose register enclave gettings callIDs:");
 
 	let call_ids = node_metadata_repo
 		.get_from_metadata(|m| m.register_dcap_enclave_call_indexes())?

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -279,7 +279,7 @@ pub fn generate_dcap_ra_extrinsic_from_quote_internal(
 		.map_err(MetadataProviderError::MetadataError)?;
 	info!("    [Enclave] Compose register enclave call DCAP IDs: {:?}", call_ids);
 	let call = OpaqueCall::from_tuple(&(call_ids, quote, url));
-	info!("    [Enclave] Compose register enclave got call: {:#?}", &call);
+	trace!("    [Enclave] Compose register enclave got call: {:#?}", &call);
 
 	let extrinsic = extrinsics_factory.create_extrinsics(&[call], None)?;
 	info!("    [Enclave] Compose register enclave got extrinsic, returning");

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -279,7 +279,6 @@ pub fn generate_dcap_ra_extrinsic_from_quote_internal(
 		.map_err(MetadataProviderError::MetadataError)?;
 	info!("    [Enclave] Compose register enclave call DCAP IDs: {:?}", call_ids);
 	let call = OpaqueCall::from_tuple(&(call_ids, quote, url));
-	trace!("    [Enclave] Compose register enclave got call: {:#?}", &call);
 
 	let extrinsic = extrinsics_factory.create_extrinsics(&[call], None)?;
 	info!("    [Enclave] Compose register enclave got extrinsic, returning");

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -763,9 +763,11 @@ fn register_quotes_from_marblerun(
 
 	for quote in quotes {
 		match enclave.generate_dcap_ra_extrinsic_from_quote(url.clone(), &quote) {
-			Ok(xts) => send_extrinsic(&xts, api, accountid, is_development_mode),
+			Ok(xts) => {
+				send_extrinsic(&xts, api, accountid, is_development_mode);
+			},
 			Err(e) => {
-				error!("Extracting information from quote failed: {}", e.into())
+				error!("Extracting information from quote failed: {}", e)
 			},
 		}
 	}

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -741,7 +741,7 @@ fn fetch_marblerun_events_every_hour<E>(
 				marblerun_base_url.clone(),
 			);
 
-			thread::sleep(Duration::from_secs(POLL_INTERVAL_1_HOUR_IN_SECS));
+			thread::sleep(Duration::from_secs(POLL_INTERVAL_5_MINUTES_IN_SECS));
 		}
 	});
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -729,7 +729,7 @@ fn fetch_marblerun_events_every_hour<E>(
 {
 	let enclave = enclave.clone();
 	let handle = thread::spawn(move || {
-		const POLL_INTERVAL_1_HOUR_IN_SECS: u64 = 1 * 30;
+		const POLL_INTERVAL_5_MINUTES_IN_SECS: u64 = 5 * 60;
 		loop {
 			info!("Polling marblerun events for quotes to register");
 			register_quotes_from_marblerun(


### PR DESCRIPTION
This PR contains some fixes (match expression, poll time) that should have been in #1159.

Should the 
```rust
trace!(" [Enclave] Compose register enclave got call: {:#?}", &call);
```
log stay? It is not the actual quote that is logged here.

If so, I will format it to print it in hex as we have discussed @clangenb.

---

Just to make sure that the DCAP related things get compiled I temporarily added the dcap flag into the Makefile, this will be reverted once the CI ran.