### PR TITLE
Restore debuggability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ ifeq ($(SGX_ARCH), x86)
 	SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x86/sgx_sign
 	SGX_EDGER8R := $(SGX_SDK)/bin/x86/sgx_edger8r
 else
-	SGX_COMMON_CFLAGS := -m64
+	SGX_COMMON_CFLAGS := -m64 -ggdb
 	SGX_LIBRARY_PATH := $(SGX_SDK)/lib64
 	SGX_ENCLAVE_SIGNER := $(SGX_SDK)/bin/x64/sgx_sign
 	SGX_EDGER8R := $(SGX_SDK)/bin/x64/sgx_edger8r
@@ -63,12 +63,12 @@ ifeq ($(SGX_DEBUG), 1)
 	# we build with cargo --release, even in SGX DEBUG mode
 	SGX_COMMON_CFLAGS += -O0 -g -ggdb
 	# cargo sets this automatically, cannot use 'debug'
-	OUTPUT_PATH := release
-	CARGO_TARGET := --release
+	OUTPUT_PATH := debug
+	CARGO_TARGET :=
 else
 	SGX_COMMON_CFLAGS += -O2
-	OUTPUT_PATH := release
-	CARGO_TARGET := --release
+	OUTPUT_PATH := debug
+	CARGO_TARGET :=
 endif
 
 SGX_COMMON_CFLAGS += -fstack-protector

--- a/enclave-runtime/Makefile
+++ b/enclave-runtime/Makefile
@@ -35,11 +35,11 @@ Rust_Enclave_Files := $(wildcard src/*.rs) $(wildcard ../stf/src/*.rs)
 RUSTFLAGS :="-C target-feature=+avx2"
 
 ifeq ($(SGX_DEBUG), 1)
-	OUTPUT_PATH := release
-	CARGO_TARGET := --release
+	OUTPUT_PATH := debug
+	CARGO_TARGET := 
 else
-	OUTPUT_PATH := release
-	CARGO_TARGET := --release
+	OUTPUT_PATH := debug
+	CARGO_TARGET := 
 endif
 
 ifeq ($(SGX_PRODUCTION), 1)

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -402,3 +402,15 @@ fn internal_trigger_parentchain_block_import() -> Result<()> {
 	triggered_import_dispatcher.import_all()?;
 	Ok(())
 }
+
+#[cfg(debug_assertions)]
+#[no_mangle]
+pub extern "C" fn __assert_fail(
+	__assertion: *const u8,
+	__file: *const u8,
+	__line: u32,
+	__function: *const u8,
+) -> ! {
+	use core::intrinsics::abort;
+	unsafe { abort() }
+}

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -90,7 +90,6 @@ subcommands:
         args:
             - skip-ra:
                 long: skip-ra
-                short: s
                 help: skip remote attestation. Set this flag if running enclave in SW mode
             - shard:
                 required: false
@@ -115,12 +114,10 @@ subcommands:
         args:
             - shard:
                 long: shard
-                short: s
                 required: false
                 help: shard identifier base58 encoded. Defines the state that this worker shall operate on. Default is mrenclave
             - skip-ra:
                   long: skip-ra
-                  short: s
                   help: skip remote attestation. Set this flag if running enclave in SW mode
     - shielding-key:
         about: Get the public RSA3072 key from the TEE to be used to encrypt requests


### PR DESCRIPTION
This PR allows the worker to be fully debuggable.

The short flags were removed because they would interfere with clap's debug_assertions (see https://github.com/integritee-network/worker/issues/375 for details).
I also added the `__assert_fail` function, which was required (see https://github.com/integritee-network/worker/issues/761#issuecomment-1175992810).