### PR TITLE
Minor fixes for `is_descendant_builder`

### DIFF
--- a/sidechain/consensus/common/src/header_db.rs
+++ b/sidechain/consensus/common/src/header_db.rs
@@ -15,7 +15,7 @@
 
 */
 use itp_types::H256;
-use its_primitives::{traits::Header as HeaderT, types::header::SidechainHeader};
+use its_primitives::traits::Header as HeaderT;
 use std::{collections::HashMap, convert::From, hash::Hash as HashT};
 
 /// Normally implemented on the `client` in substrate.
@@ -33,12 +33,12 @@ impl<Hash, Header> HeaderDbTrait for HeaderDb<Hash, Header>
 where
 	// TODO: the H256 trait bounds are needed because: #1203
 	Hash: PartialEq + HashT + Into<H256> + From<H256> + core::cmp::Eq + Clone,
-	Header: HeaderT + Clone + Into<SidechainHeader>,
+	Header: HeaderT + Clone,
 {
-	type Header = SidechainHeader;
+	type Header = Header;
 
 	fn header(&self, hash: &H256) -> Option<Self::Header> {
 		let header = self.0.get(&Hash::from(*hash))?;
-		Some(header.clone().into())
+		Some(header.clone())
 	}
 }

--- a/sidechain/consensus/common/src/is_descendant_of_builder.rs
+++ b/sidechain/consensus/common/src/is_descendant_of_builder.rs
@@ -19,7 +19,6 @@ use core::{hash::Hash as HashT, marker::PhantomData};
 use itp_types::H256;
 use its_primitives::traits::Header as HeaderT;
 
-#[allow(dead_code)]
 pub struct IsDescendantOfBuilder<Hash, HeaderDb, Error>(PhantomData<(Hash, HeaderDb, Error)>);
 
 impl<'a, Hash, HeaderDb, Error> IsDescendantOfBuilder<Hash, HeaderDb, Error>
@@ -30,7 +29,6 @@ where
 {
 	/// Build the `is_descendant_of` closure for the fork-tree structure
 	/// to utilize when adding and removing nodes from the tree.
-	#[allow(dead_code)]
 	pub fn build_is_descendant_of(
 		current: Option<(&'a Hash, &'a Hash)>,
 		header_db: &'a HeaderDb,
@@ -69,7 +67,6 @@ where
 	}
 }
 
-#[allow(dead_code)]
 pub struct LowestCommonAncestorFinder<Hash, HeaderDb>(PhantomData<(Hash, HeaderDb)>);
 
 impl<Hash, HeaderDb> LowestCommonAncestorFinder<Hash, HeaderDb>
@@ -78,7 +75,6 @@ where
 	HeaderDb: HeaderDbTrait,
 {
 	/// Used by the `build_is_descendant_of` to find the LCA of two nodes in the fork-tree.
-	#[allow(dead_code)]
 	fn find_lowest_common_ancestor(a: &Hash, b: &Hash, header_db: &HeaderDb) -> Result<Hash, ()> {
 		let header_1 = header_db.header(&a.clone().into()).ok_or(())?;
 		let header_2 = header_db.header(&b.clone().into()).ok_or(())?;

--- a/sidechain/consensus/common/src/lib.rs
+++ b/sidechain/consensus/common/src/lib.rs
@@ -37,8 +37,11 @@ mod block_import_confirmation_handler;
 mod block_import_queue_worker;
 mod error;
 mod header_db;
-mod is_descendant_of_builder;
 mod peer_block_sync;
+
+// The feature flag will be removed once we use the module outside of tests.
+#[cfg(test)]
+mod is_descendant_of_builder;
 
 #[cfg(test)]
 mod test;

--- a/sidechain/consensus/common/src/test/mocks/block_import_queue_worker_mock.rs
+++ b/sidechain/consensus/common/src/test/mocks/block_import_queue_worker_mock.rs
@@ -105,6 +105,7 @@ impl std::fmt::Display for TestError {
 
 impl std::error::Error for TestError {}
 
+#[cfg(test)]
 mod tests {
 	use super::*;
 


### PR DESCRIPTION
I tested that it builds and `cargo test -p its-consensus-common` passes.