### PR TITLE
Bump `integritee-dev` image, switch to Ubuntu 22.04 Jammy

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -93,7 +93,7 @@ jobs:
           path: integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }}.tar.gz
 
   clippy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: "integritee/integritee-dev:0.1.13"
     steps:
       - uses: actions/checkout@v3
@@ -131,7 +131,7 @@ jobs:
         uses: andymckay/cancel-action@0.2
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: init rust
@@ -252,7 +252,7 @@ jobs:
   release:
     name: Draft Release
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [build-test, integration-tests]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -94,7 +94,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    container: "integritee/integritee-dev:0.1.12"
+    container: "integritee/integritee-dev:0.1.13"
     steps:
       - uses: actions/checkout@v3
       - name: init rust

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -21,14 +21,14 @@ env:
 jobs:
   cancel_previous_runs:
     name: Cancel Previous Runs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
   build-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -152,7 +152,7 @@ jobs:
         uses: andymckay/cancel-action@0.2
 
   integration-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ always() }}
     needs: build-test
     env:

--- a/.github/workflows/delete-release.yml
+++ b/.github/workflows/delete-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   purge-image:
     name: Delete image from ghcr.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         binary: ["integritee-client", "integritee-demo-validateer"]

--- a/.github/workflows/label-checker.yml
+++ b/.github/workflows/label-checker.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     check_for_matching_labels:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       if: github.base_ref == 'master' && github.event.pull_request.draft == false
       steps:
         - name: Label check

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Push Integritee Services to Dockerhub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         binary: ["integritee-demo-validateer", "integritee-client"]

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish-draft-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM integritee/integritee-dev:0.1.12
+FROM integritee/integritee-dev:0.1.13
 LABEL maintainer="zoltan@integritee.network"
 
 # By default we warp the service

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -17,7 +17,7 @@
 
 ### Builder Stage
 ##################################################
-FROM integritee/integritee-dev:0.1.12 AS builder
+FROM integritee/integritee-dev:0.1.13 AS builder
 LABEL maintainer="zoltan@integritee.network"
 
 # set environment variables
@@ -49,7 +49,7 @@ RUN cargo test --release
 # A builder stage that uses sccache to speed up local builds with docker
 # Installation and setup of sccache should be moved to the integritee-dev image, so we don't
 # always need to compile and install sccache on CI (where we have no caching so far).
-FROM integritee/integritee-dev:0.1.12 AS cached-builder
+FROM integritee/integritee-dev:0.1.13 AS cached-builder
 LABEL maintainer="zoltan@integritee.network"
 
 # set environment variables
@@ -81,7 +81,7 @@ RUN --mount=type=cache,id=cargo,target=/root/work/.cache/sccache cargo test --re
 
 ### Base Runner Stage
 ##################################################
-FROM ubuntu:20.04 AS runner
+FROM ubuntu:22.04 AS runner
 
 RUN apt update && apt install -y libssl-dev iproute2 curl
 


### PR DESCRIPTION
Question: 
- I saw some `runs-on: ubuntu-latest` parameters, should I leave them as is, or set the version explicitly there as well?