### PR TITLE
service: handle not running Marblerun Prometheus metrics server more gracefully

### DIFF
--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -757,7 +757,11 @@ fn register_quotes_from_marblerun(
 	marblerun_base_url: String,
 ) {
 	let enclave = enclave.as_ref();
-	let events = prometheus_metrics::fetch_marblerun_events(&marblerun_base_url).unwrap();
+	let events = prometheus_metrics::fetch_marblerun_events(&marblerun_base_url)
+		.map_err(|e| {
+			info!("Fetching events from Marblerun failed with: {:?}, continuing with 0 events.", e);
+		})
+		.unwrap_or_default();
 	let quotes: Vec<&[u8]> =
 		events.iter().map(|event| event.get_quote_without_prepended_bytes()).collect();
 


### PR DESCRIPTION
Previously if the feature `dcap` was enabled then the `integritee-service` would crash if it could not fetch Marblerun events:
```bash
Custom("Failed to fetch marblerun prometheus events from: http://localhost:9944/, error: Error: IO error"
```

This PR addresses this issue.