### PR TITLE
gha: Node.js 12 depracation, bump cancel-action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Fail-fast; cancel other jobs
         if: failure()
-        uses: andymckay/cancel-action@0.2
+        uses: andymckay/cancel-action@0.3
 
   fmt:
     runs-on: ubuntu-22.04
@@ -149,7 +149,7 @@ jobs:
 
       - name: Fail-fast; cancel other jobs
         if: failure()
-        uses: andymckay/cancel-action@0.2
+        uses: andymckay/cancel-action@0.3
 
   integration-tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This action only runs when `clippy` or `taplo/cargo fmt` steps fail, that is why it is hard to encounter the deprecation warning.

See https://github.com/integritee-network/worker/actions/runs/4434784169 for a recent failure.