### PR TITLE
Fix unchecked indexing in decode_hex

### DIFF
--- a/core-primitives/utils/src/hex.rs
+++ b/core-primitives/utils/src/hex.rs
@@ -57,10 +57,12 @@ pub fn hex_encode(data: &[u8]) -> String {
 
 /// Helper method for decoding hex.
 pub fn decode_hex<T: AsRef<[u8]>>(message: T) -> Result<Vec<u8>> {
-	let mut message = message.as_ref();
-	if message[..2] == [b'0', b'x'] {
-		message = &message[2..]
-	}
+	let message = message.as_ref();
+	let message = match message {
+		[b'0', b'x', hex_value @ ..] => hex_value,
+		_ => &message,
+	};
+
 	let decoded_message = hex::decode(message).map_err(Error::Hex)?;
 	Ok(decoded_message)
 }
@@ -78,6 +80,26 @@ mod tests {
 			String::decode(&mut decode_hex(hex_encoded_data).unwrap().as_slice()).unwrap();
 
 		assert_eq!(data, decoded_data);
+	}
+
+	#[test]
+	fn hex_encode_decode_works_empty_input() {
+		let data = String::new();
+
+		let hex_encoded_data = hex_encode(&data.encode());
+		let decoded_data =
+			String::decode(&mut decode_hex(hex_encoded_data).unwrap().as_slice()).unwrap();
+
+		assert_eq!(data, decoded_data);
+	}
+
+	#[test]
+	fn hex_encode_decode_works_empty_input_for_decode() {
+		let data = String::new();
+
+		let decoded_data = decode_hex(&data).unwrap();
+
+		assert!(decoded_data.is_empty());
 	}
 
 	#[test]

--- a/core-primitives/utils/src/hex.rs
+++ b/core-primitives/utils/src/hex.rs
@@ -60,7 +60,7 @@ pub fn decode_hex<T: AsRef<[u8]>>(message: T) -> Result<Vec<u8>> {
 	let message = message.as_ref();
 	let message = match message {
 		[b'0', b'x', hex_value @ ..] => hex_value,
-		_ => &message,
+		_ => message,
 	};
 
 	let decoded_message = hex::decode(message).map_err(Error::Hex)?;

--- a/sidechain/consensus/common/src/is_descendant_of_builder.rs
+++ b/sidechain/consensus/common/src/is_descendant_of_builder.rs
@@ -49,7 +49,7 @@ where
 				// If the current hash is the head and the parent is the base, then we know that
 				// this current hash is the descendant of the parent. Otherwise we can set the
 				// head to the parent and find the lowest common ancestor between `head`
-				/// and `base` in the tree.
+				// and `base` in the tree.
 				if current_hash == head {
 					if current_parent_hash == base {
 						return Ok(true)


### PR DESCRIPTION
During the attesteer testing I found this bug, where if the input was an empy file (from the cli), then the worker (integritee-service) would crash.

This PR fixes that and adds a test case as well.

```
thread '<unnamed>' panicked at 'range end index 2 out of range for slice of length 0', core-primitives/utils/src/hex.rs:61:8
fatal runtime error: failed to initiate panic, error 5
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Sgx(SGX_ERROR_ENCLAVE_CRASHED)', service/src/main.rs:391:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I also found a warning when running `cargo test --all`, fixed it as well.