### PR TITLE
Better error logs for remote attestation + make skip_ra work for dcap

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -291,12 +291,6 @@ jobs:
           cd docker
           docker compose -f <(envsubst < docker-compose.yml) -f <(envsubst < ${{ matrix.demo_name }}.yml) -p ${PROJECT} stop
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
       - name: Integration Test ${{ matrix.test }}-${{ matrix.flavor_id }}
         run: |
           cd docker

--- a/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -367,7 +367,7 @@ where
 			temporary state – the same request can be repeated after
 			some time. ",
 			_ => {
-				error!("DBG:{:?}", resp_code);
+				error!("Error, received unknown HTTP response: {:?}", resp_code);
 				"Unknown error occured"
 			},
 		};

--- a/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -356,16 +356,16 @@ where
 
 	fn log_resp_code(&self, resp_code: &mut Option<u16>) {
 		let msg = match resp_code {
-			Some(200) => "OK Operation Successful",
+			Some(200) => "OK, operation successful",
 			Some(400) => "Bad request, quote is invalid, or linkability of quote/subscription does not match.",
-			Some(401) => "Unauthorized Failed to authenticate or authorize request.",
-			Some(404) => "Not Found GID does not refer to a valid EPID group ID.",
-			Some(500) => "Internal error occurred",
+			Some(401) => "Unauthorized, failed to authenticate or authorize request.",
+			Some(404) => "Not found, GID does not refer to a valid EPID group ID.",
+			Some(500) => "Internal error occurred.",
 			Some(503) =>
 				"Service is currently not able to process the request (due to
 			a temporary overloading or maintenance). This is a
 			temporary state – the same request can be repeated after
-			some time. ",
+			some time.",
 			_ => {
 				error!("Error, received unknown HTTP response: {:?}", resp_code);
 				"Unknown error occured"

--- a/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -357,6 +357,7 @@ where
 	fn log_resp_code(&self, resp_code: &mut Option<u16>) {
 		let msg = match resp_code {
 			Some(200) => "OK Operation Successful",
+			Some(400) => "Bad request, quote is invalid, or linkability of quote/subscription does not match.",
 			Some(401) => "Unauthorized Failed to authenticate or authorize request.",
 			Some(404) => "Not Found GID does not refer to a valid EPID group ID.",
 			Some(500) => "Internal error occurred",

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -759,14 +759,17 @@ fn register_collateral(
 	is_development_mode: bool,
 	skip_ra: bool,
 ) {
+	//TODO generate_dcap_ra_quote() does not really need skip_ra, rethink how many layers skip_ra should be passed along
 	let dcap_quote = enclave.generate_dcap_ra_quote(skip_ra).unwrap();
-	let (fmspc, _tcb_info) = extract_tcb_info_from_raw_dcap_quote(&dcap_quote).unwrap();
+	if !skip_ra {
+		let (fmspc, _tcb_info) = extract_tcb_info_from_raw_dcap_quote(&dcap_quote).unwrap();
 
-	let xt = enclave.generate_register_quoting_enclave_extrinsic(fmspc).unwrap();
-	send_extrinsic(xt, api, accountid, is_development_mode);
+		let uxt = enclave.generate_register_quoting_enclave_extrinsic(fmspc).unwrap();
+		send_extrinsic(&uxt, api, accountid, is_development_mode);
 
-	let xt = enclave.generate_register_tcb_info_extrinsic(fmspc).unwrap();
-	send_extrinsic(xt, api, accountid, is_development_mode);
+		let uxt = enclave.generate_register_tcb_info_extrinsic(fmspc).unwrap();
+		send_extrinsic(&uxt, api, accountid, is_development_mode);
+	}
 }
 
 fn send_extrinsic(


### PR DESCRIPTION
As I was testing the different attestations I stumbled upon two small issues:
- DCAP attestation and `--skip-ra` flag did not work together, because `generate_dcap_ra_quote()`  returned an empty quote in case the skip_ra is specified, however the `extract_tcb_info_from_raw_dcap_quote()` function needs a valid quote, so it would fail.
The current solution is rather a workaround, I think it would make sense to open a new issues about the `--skip-ra` handling.
- EPID attestation: if the linkability of the quote and subscription does not match, then the API responds with `400, Bad request` as the [documentations](https://api.trustedservices.intel.com/documents/sgx-attestation-api-spec.pdf) says:
>In case the Service Provider registered with a linkable EPID signature policy but uses
unlinkable EPID signatures (and vice versa), IAS will respond with “400 Bad Request” to Verify
Attestation Evidence call.

However the error message itself does not mention it: `Invalid Attestation Evidence Payload. The client should not repeat the request without modifications.`