### PR TITLE
GHA: fix teeracle failure by increasing the update interval of the API

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -159,7 +159,7 @@ jobs:
       WORKER_IMAGE_TAG: integritee-worker:dev
       CLIENT_IMAGE_TAG: integritee-cli:dev
       COINMARKETCAP_KEY: ${{ secrets.COINMARKETCAP_KEY }}
-      TEERACLE_INTERVAL_SECONDS: 4
+      TEERACLE_INTERVAL_SECONDS: 10
 
     strategy:
       fail-fast: false

--- a/app-libs/oracle/src/oracle_sources/coin_gecko.rs
+++ b/app-libs/oracle/src/oracle_sources/coin_gecko.rs
@@ -43,7 +43,7 @@ const COINGECKO_URL: &str = "https://api.coingecko.com";
 const COINGECKO_PARAM_CURRENCY: &str = "vs_currency";
 const COINGECKO_PARAM_COIN: &str = "ids";
 const COINGECKO_PATH: &str = "api/v3/coins/markets";
-const COINGECKO_TIMEOUT: Duration = Duration::from_secs(10u64);
+const COINGECKO_TIMEOUT: Duration = Duration::from_secs(20u64);
 const COINGECKO_ROOT_CERTIFICATE: &str = include_str!("../certificates/lets_encrypt_root_cert.pem");
 
 lazy_static! {

--- a/app-libs/oracle/src/oracle_sources/coin_gecko.rs
+++ b/app-libs/oracle/src/oracle_sources/coin_gecko.rs
@@ -29,6 +29,7 @@ use itc_rest_client::{
 	RestGet, RestPath,
 };
 use lazy_static::lazy_static;
+use log::debug;
 use serde::{Deserialize, Serialize};
 use std::{
 	collections::HashMap,
@@ -42,7 +43,7 @@ const COINGECKO_URL: &str = "https://api.coingecko.com";
 const COINGECKO_PARAM_CURRENCY: &str = "vs_currency";
 const COINGECKO_PARAM_COIN: &str = "ids";
 const COINGECKO_PATH: &str = "api/v3/coins/markets";
-const COINGECKO_TIMEOUT: Duration = Duration::from_secs(3u64);
+const COINGECKO_TIMEOUT: Duration = Duration::from_secs(5u64);
 const COINGECKO_ROOT_CERTIFICATE: &str = include_str!("../certificates/lets_encrypt_root_cert.pem");
 
 lazy_static! {
@@ -111,6 +112,7 @@ impl<OracleSourceInfo: Into<TradingInfo>> OracleSource<OracleSourceInfo> for Coi
 			)
 			.map_err(Error::RestClient)?;
 
+		debug!("coingecko received response: {:#?}", &response);
 		let list = response.0;
 		if list.is_empty() {
 			return Err(Error::NoValidData(COINGECKO_URL.to_string(), trading_pair.key()))

--- a/app-libs/oracle/src/oracle_sources/coin_gecko.rs
+++ b/app-libs/oracle/src/oracle_sources/coin_gecko.rs
@@ -43,7 +43,7 @@ const COINGECKO_URL: &str = "https://api.coingecko.com";
 const COINGECKO_PARAM_CURRENCY: &str = "vs_currency";
 const COINGECKO_PARAM_COIN: &str = "ids";
 const COINGECKO_PATH: &str = "api/v3/coins/markets";
-const COINGECKO_TIMEOUT: Duration = Duration::from_secs(5u64);
+const COINGECKO_TIMEOUT: Duration = Duration::from_secs(10u64);
 const COINGECKO_ROOT_CERTIFICATE: &str = include_str!("../certificates/lets_encrypt_root_cert.pem");
 
 lazy_static! {

--- a/app-libs/oracle/src/oracles/exchange_rate_oracle.rs
+++ b/app-libs/oracle/src/oracles/exchange_rate_oracle.rs
@@ -118,21 +118,6 @@ where
 				},
 			}
 		}
-
-		match self
-			.oracle_source
-			.execute_exchange_rate_request(&mut rest_client, trading_pair.clone())
-		{
-			Ok(exchange_rate) => {
-				self.metrics_exporter.record_response_time(source_id.clone(), timer_start);
-				self.metrics_exporter
-					.update_exchange_rate(source_id, exchange_rate, trading_pair);
-
-				debug!("Successfully executed exchange rate request");
-				Ok((exchange_rate, base_url))
-			},
-			Err(e) => Err(e),
-		}
 	}
 }
 

--- a/app-libs/oracle/src/oracles/exchange_rate_oracle.rs
+++ b/app-libs/oracle/src/oracles/exchange_rate_oracle.rs
@@ -72,7 +72,7 @@ where
 		let http_client = HttpClient::new(
 			SendWithCertificateVerification::new(root_certificate),
 			true,
-			request_timeout.clone(),
+			request_timeout,
 			None,
 			None,
 		);
@@ -107,7 +107,7 @@ where
 						);
 						debug!("Check that the API endpoint is available, for coingecko: https://status.coingecko.com/");
 						thread::sleep(
-							request_timeout.unwrap_or(Duration::from_secs(number_of_tries)),
+							request_timeout.unwrap_or_else(|| Duration::from_secs(number_of_tries)),
 						);
 					}
 					error!(

--- a/app-libs/oracle/src/oracles/exchange_rate_oracle.rs
+++ b/app-libs/oracle/src/oracles/exchange_rate_oracle.rs
@@ -29,7 +29,11 @@ use itc_rest_client::{
 	rest_client::RestClient,
 };
 use log::*;
-use std::{sync::Arc, time::Instant};
+use std::{
+	sync::Arc,
+	thread,
+	time::{Duration, Instant},
+};
 use url::Url;
 
 #[allow(unused)]
@@ -61,19 +65,59 @@ where
 
 		let base_url = self.oracle_source.base_url()?;
 		let root_certificate = self.oracle_source.root_certificate_content();
+		let request_timeout = self.oracle_source.request_timeout();
 
 		debug!("Get exchange rate from URI: {}, trading pair: {:?}", base_url, trading_pair);
 
 		let http_client = HttpClient::new(
 			SendWithCertificateVerification::new(root_certificate),
 			true,
-			self.oracle_source.request_timeout(),
+			request_timeout.clone(),
 			None,
 			None,
 		);
 		let mut rest_client = RestClient::new(http_client, base_url.clone());
 
+		// Due to possible failures that may be temporarily this function tries to fetch the exchange rates `number_of_tries` times.
+		// If it still fails for the last attempt, then only in that case will it be considered a non-recoverable error.
+		let number_of_tries = 3;
 		let timer_start = Instant::now();
+		for i in 0..number_of_tries {
+			let result = self
+				.oracle_source
+				.execute_exchange_rate_request(&mut rest_client, trading_pair.clone());
+
+			match result {
+				Ok(exchange_rate) => {
+					self.metrics_exporter.record_response_time(source_id.clone(), timer_start);
+					self.metrics_exporter.update_exchange_rate(
+						source_id,
+						exchange_rate,
+						trading_pair,
+					);
+
+					debug!("Successfully executed exchange rate request");
+					return Ok((exchange_rate, base_url))
+				},
+				Err(e) => {
+					if i < number_of_tries {
+						error!(
+							"Getting exchange rate from {} failed with {}, trying again in {:#?}.",
+							&base_url, e, request_timeout
+						);
+						debug!("Check that the API endpoint is available, for coingecko: https://status.coingecko.com/");
+						thread::sleep(
+							request_timeout.unwrap_or(Duration::from_secs(number_of_tries)),
+						);
+					}
+					error!(
+						"Getting exchange rate from {} failed {} times, latest error is: {}.",
+						&base_url, number_of_tries, &e
+					);
+					return Err(e)
+				},
+			}
+		}
 
 		match self
 			.oracle_source

--- a/core/rest-client/src/http_client.rs
+++ b/core/rest-client/src/http_client.rs
@@ -110,9 +110,13 @@ impl Send for SendWithCertificateVerification {
 		request: &mut Request,
 		writer: &mut Vec<u8>,
 	) -> Result<Response, Error> {
-		request
-			.send_with_pem_certificate(writer, Some(self.root_certificate.to_string()))
-			.map_err(Error::HttpReqError)
+		match request.send_with_pem_certificate(writer, Some(self.root_certificate.to_string())) {
+			Ok(response) => Ok(response),
+			Err(e) => {
+				error!("SendWithCertificateVerification::execute_send_request received error: {:#?}", &e);
+				Err(Error::HttpReqError(e))
+			},
+		}
 	}
 }
 
@@ -237,7 +241,7 @@ where
 			.read_timeout(self.timeout)
 			.write_timeout(self.timeout);
 
-		trace!("{:?}", request);
+		trace!("request is: {:?}", request);
 
 		let mut writer = Vec::new();
 

--- a/core/rest-client/src/http_client.rs
+++ b/core/rest-client/src/http_client.rs
@@ -113,7 +113,10 @@ impl Send for SendWithCertificateVerification {
 		match request.send_with_pem_certificate(writer, Some(self.root_certificate.to_string())) {
 			Ok(response) => Ok(response),
 			Err(e) => {
-				error!("SendWithCertificateVerification::execute_send_request received error: {:#?}", &e);
+				error!(
+					"SendWithCertificateVerification::execute_send_request received error: {:#?}",
+					&e
+				);
 				Err(Error::HttpReqError(e))
 			},
 		}


### PR DESCRIPTION
This is the split off commit from #1222 as that PR is not yet ready to be merged (RA should be added as well).

EDIT: I also realized that the unit test passed on the `sgx_runner` branch because it is much faster than the default GHA Runner. I tested it with my laptop as well and sometimes 3 seconds were not enough for the request to run, resulting in `HttpReqError(IO(OS(WouldBlock))` error.

Fixes #1221.