### PR TITLE
Minor light-client refactor

### DIFF
--- a/core/offchain-worker-executor/src/executor.rs
+++ b/core/offchain-worker-executor/src/executor.rs
@@ -155,7 +155,7 @@ impl<
 
 	fn get_latest_parentchain_header(&self) -> Result<ParentchainBlock::Header> {
 		let header = self.validator_accessor.execute_on_validator(|v| {
-			let latest_parentchain_header = v.latest_finalized_header(v.num_relays())?;
+			let latest_parentchain_header = v.latest_finalized_header()?;
 			Ok(latest_parentchain_header)
 		})?;
 		Ok(header)

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -21,8 +21,7 @@ use crate::{error::Result, ImportParentchainBlocks};
 use ita_stf::ParentchainHeader;
 use itc_parentchain_indirect_calls_executor::ExecuteIndirectCalls;
 use itc_parentchain_light_client::{
-	concurrent_access::ValidatorAccess, BlockNumberOps, ExtrinsicSender, LightClientState,
-	Validator,
+	concurrent_access::ValidatorAccess, BlockNumberOps, ExtrinsicSender, Validator,
 };
 use itp_extrinsics_factory::CreateExtrinsics;
 use itp_stf_executor::traits::StfUpdateState;
@@ -127,9 +126,9 @@ impl<
 			// Check if there are any extrinsics in the to-be-imported block that we sent and cached in the light-client before.
 			// If so, remove them now from the cache.
 			if let Err(e) = self.validator_accessor.execute_mut_on_validator(|v| {
-				v.check_xt_inclusion(v.num_relays(), &signed_block.block)?;
+				v.check_xt_inclusion(&signed_block.block)?;
 
-				v.submit_block(v.num_relays(), &signed_block)
+				v.submit_block(&signed_block)
 			}) {
 				error!("[Validator] Header submission failed: {:?}", e);
 				return Err(e.into())

--- a/core/parentchain/light-client/src/concurrent_access.rs
+++ b/core/parentchain/light-client/src/concurrent_access.rs
@@ -105,10 +105,8 @@ where
 	where
 		F: FnOnce(&Self::ValidatorType) -> Result<R>,
 	{
-		let mut light_validation_lock =
+		let light_validation_lock =
 			self.light_validation.write().map_err(|_| Error::PoisonedLock)?;
-		let state = Seal::unseal_from_static_file()?;
-		light_validation_lock.set_state(state);
 		getter_function(&light_validation_lock)
 	}
 
@@ -118,8 +116,6 @@ where
 	{
 		let mut light_validation_lock =
 			self.light_validation.write().map_err(|_| Error::PoisonedLock)?;
-		let state = Seal::unseal_from_static_file()?;
-		light_validation_lock.set_state(state);
 		let result = mutating_function(&mut light_validation_lock);
 		Seal::seal_to_static_file(light_validation_lock.get_state())?;
 		result

--- a/core/parentchain/light-client/src/error.rs
+++ b/core/parentchain/light-client/src/error.rs
@@ -45,8 +45,6 @@ pub enum Error {
 	ValidatorSetMismatch,
 	#[error("Invalid ancestry proof")]
 	InvalidAncestryProof,
-	#[error("No such relay exists")]
-	NoSuchRelayExists,
 	#[error("Invalid Finality Proof: {0}")]
 	InvalidFinalityProof(#[from] JustificationError),
 	#[error("Header ancestry mismatch")]

--- a/core/parentchain/light-client/src/error.rs
+++ b/core/parentchain/light-client/src/error.rs
@@ -37,6 +37,8 @@ pub enum JustificationError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+	#[error("Genesis header not found")]
+	NoGenesis,
 	#[error(transparent)]
 	Storage(#[from] itp_storage::Error),
 	#[error("Validator set mismatch")]

--- a/core/parentchain/light-client/src/error.rs
+++ b/core/parentchain/light-client/src/error.rs
@@ -37,8 +37,6 @@ pub enum JustificationError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-	#[error("Genesis header not found")]
-	NoGenesis,
 	#[error(transparent)]
 	Storage(#[from] itp_storage::Error),
 	#[error("Validator set mismatch")]

--- a/core/parentchain/light-client/src/io.rs
+++ b/core/parentchain/light-client/src/io.rs
@@ -19,7 +19,8 @@ use crate::{
 	error::Result,
 	finality::{Finality, GrandpaFinality, ParachainFinality},
 	light_client_init_params::{GrandpaParams, SimpleParams},
-	light_validation::LightValidation,
+	light_validation::{check_validator_set_proof, LightValidation},
+	state::RelayState,
 	Error, LightValidationState, NumberFor, Validator,
 };
 use codec::{Decode, Encode};
@@ -28,7 +29,6 @@ use itp_ocall_api::EnclaveOnChainOCallApi;
 use itp_settings::files::LIGHT_CLIENT_DB;
 use itp_sgx_io::{seal, unseal, StaticSealedIO};
 use log::*;
-use sp_finality_grandpa::AuthorityList;
 use sp_runtime::traits::{Block, Header};
 use std::{boxed::Box, fs, sgxfs::SgxFile, sync::Arc};
 
@@ -68,26 +68,43 @@ where
 	NumberFor<B>: finality_grandpa::BlockNumberOps,
 	OCallApi: EnclaveOnChainOCallApi,
 {
+	check_validator_set_proof::<B>(
+		params.genesis_header.state_root(),
+		params.authority_proof,
+		&params.authorities,
+	)?;
+
 	// FIXME: That should be an unique path.
 	if SgxFile::open(LIGHT_CLIENT_DB).is_err() {
 		info!("[Enclave] ChainRelay DB not found, creating new! {}", LIGHT_CLIENT_DB);
-		return init_grandpa_validator::<B, OCallApi>(params, ocall_api)
+		let validator = init_grandpa_validator::<B, OCallApi>(
+			ocall_api,
+			RelayState::new(params.genesis_header, params.authorities).into(),
+		)?;
+		LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(
+			validator.get_state(),
+		)?;
+		return Ok(validator)
 	}
 
 	let (validation_state, genesis_hash) = get_validation_state::<B>()?;
 
-	let mut validator = init_grandpa_validator::<B, OCallApi>(params.clone(), ocall_api)?;
-
-	if genesis_hash == params.genesis_header.hash() {
-		validator.set_state(validation_state);
-		// The init_grandpa_validator function clear the state every time,
-		// so we should write the state again.
-		LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(
-			validator.get_state(),
-		)?;
+	let init_state = if genesis_hash == params.genesis_header.hash() {
 		info!("Found already initialized light client with Genesis Hash: {:?}", genesis_hash);
-	}
+		validation_state
+	} else {
+		info!(
+			"Previous light client db belongs to another parentchain genesis. Creating new: {:?}",
+			genesis_hash
+		);
+		RelayState::new(params.genesis_header, params.authorities).into()
+	};
+
+	let validator = init_grandpa_validator::<B, OCallApi>(ocall_api, init_state)?;
+
 	info!("light client state: {:?}", validator);
+
+	LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(validator.get_state())?;
 	Ok(validator)
 }
 
@@ -103,45 +120,50 @@ where
 	// FIXME: That should be an unique path.
 	if SgxFile::open(LIGHT_CLIENT_DB).is_err() {
 		info!("[Enclave] ChainRelay DB not found, creating new! {}", LIGHT_CLIENT_DB);
-		return init_parachain_validator::<B, OCallApi>(params, ocall_api)
+		let validator = init_parachain_validator::<B, OCallApi>(
+			ocall_api,
+			RelayState::new(params.genesis_header, Default::default()).into(),
+		)?;
+		LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(
+			validator.get_state(),
+		)?;
+		return Ok(validator)
 	}
 
 	let (validation_state, genesis_hash) = get_validation_state::<B>()?;
 
-	let mut validator = init_parachain_validator::<B, OCallApi>(params.clone(), ocall_api)?;
-
-	if genesis_hash == params.genesis_header.hash() {
-		validator.set_state(validation_state);
-		// The init_parachain_validator function clear the state every time,
-		// so we should write the state again.
-		LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(
-			validator.get_state(),
-		)?;
+	let init_state = if genesis_hash == params.genesis_header.hash() {
 		info!("Found already initialized light client with Genesis Hash: {:?}", genesis_hash);
-	}
+		validation_state
+	} else {
+		info!(
+			"Previous light client db belongs to another parentchain genesis. Creating new: {:?}",
+			genesis_hash
+		);
+		RelayState::new(params.genesis_header, vec![]).into()
+	};
+
+	let validator = init_parachain_validator::<B, OCallApi>(ocall_api, init_state)?;
 	info!("light client state: {:?}", validator);
+
+	LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(validator.get_state())?;
 	Ok(validator)
 }
 
-fn get_validation_state<B: Block>() -> Result<(LightValidationState<B>, B::Hash)>
-where
-	B: Block,
-{
+// Todo: Implement this on the `LightClientStateSeal` itself.
+fn get_validation_state<B: Block>() -> Result<(LightValidationState<B>, B::Hash)> {
 	let validation_state =
 		LightClientStateSeal::<B, LightValidationState<B>>::unseal_from_static_file()?;
 
-	let relay = validation_state
-		.tracked_relays
-		.get(&validation_state.num_relays)
-		.ok_or(Error::NoSuchRelayExists)?;
+	let relay = validation_state.get_relay();
 	let genesis_hash = relay.header_hashes[0];
 
 	Ok((validation_state, genesis_hash))
 }
 
 fn init_grandpa_validator<B, OCallApi>(
-	params: GrandpaParams<B::Header>,
 	ocall_api: Arc<OCallApi>,
+	state: LightValidationState<B>,
 ) -> Result<LightValidation<B, OCallApi>>
 where
 	B: Block,
@@ -149,21 +171,16 @@ where
 	OCallApi: EnclaveOnChainOCallApi,
 {
 	let finality: Arc<Box<dyn Finality<B> + Sync + Send + 'static>> =
-		Arc::new(Box::new(GrandpaFinality {}));
-	let mut validator = LightValidation::<B, OCallApi>::new(ocall_api, finality);
-	validator.initialize_grandpa_relay(
-		params.genesis_header,
-		params.authorities,
-		params.authority_proof,
-	)?;
+		Arc::new(Box::new(GrandpaFinality));
 
-	LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(validator.get_state())?;
+	let validator = LightValidation::<B, OCallApi>::new(ocall_api, finality, state);
+
 	Ok(validator)
 }
 
 fn init_parachain_validator<B, OCallApi>(
-	params: SimpleParams<B::Header>,
 	ocall_api: Arc<OCallApi>,
+	state: LightValidationState<B>,
 ) -> Result<LightValidation<B, OCallApi>>
 where
 	B: Block,
@@ -171,10 +188,8 @@ where
 	OCallApi: EnclaveOnChainOCallApi,
 {
 	let finality: Arc<Box<dyn Finality<B> + Sync + Send + 'static>> =
-		Arc::new(Box::new(ParachainFinality {}));
-	let mut validator = LightValidation::<B, OCallApi>::new(ocall_api, finality);
-	validator.initialize_parachain_relay(params.genesis_header, AuthorityList::default())?;
+		Arc::new(Box::new(ParachainFinality));
 
-	LightClientStateSeal::<B, LightValidationState<B>>::seal_to_static_file(validator.get_state())?;
+	let validator = LightValidation::<B, OCallApi>::new(ocall_api, finality, state);
 	Ok(validator)
 }

--- a/core/parentchain/light-client/src/lib.rs
+++ b/core/parentchain/light-client/src/lib.rs
@@ -32,7 +32,6 @@ pub use sp_finality_grandpa::{AuthorityList, SetId};
 
 use crate::light_validation_state::LightValidationState;
 use error::Error;
-use itp_storage::StorageProof;
 use sp_finality_grandpa::{AuthorityId, AuthorityWeight, ConsensusLog, GRANDPA_ENGINE_ID};
 use sp_runtime::{
 	generic::{Digest, OpaqueDigestItemId, SignedBlock},
@@ -73,28 +72,9 @@ pub trait Validator<Block: ParentchainBlockTrait>
 where
 	NumberFor<Block>: finality_grandpa::BlockNumberOps,
 {
-	fn initialize_grandpa_relay(
-		&mut self,
-		block_header: Block::Header,
-		validator_set: AuthorityList,
-		validator_set_proof: StorageProof,
-	) -> Result<RelayId, Error>;
+	fn submit_block(&mut self, signed_block: &SignedBlock<Block>) -> Result<(), Error>;
 
-	fn initialize_parachain_relay(
-		&mut self,
-		block_header: Block::Header,
-		validator_set: AuthorityList,
-	) -> Result<RelayId, Error>;
-
-	fn submit_block(
-		&mut self,
-		relay_id: RelayId,
-		signed_block: &SignedBlock<Block>,
-	) -> Result<(), Error>;
-
-	fn check_xt_inclusion(&mut self, relay_id: RelayId, block: &Block) -> Result<(), Error>;
-
-	fn set_state(&mut self, state: LightValidationState<Block>);
+	fn check_xt_inclusion(&mut self, block: &Block) -> Result<(), Error>;
 
 	fn get_state(&self) -> &LightValidationState<Block>;
 }
@@ -105,17 +85,14 @@ pub trait ExtrinsicSender {
 }
 
 pub trait LightClientState<Block: ParentchainBlockTrait> {
-	fn num_xt_to_be_included(&self, relay_id: RelayId) -> Result<usize, Error>;
+	fn num_xt_to_be_included(&self) -> Result<usize, Error>;
 
-	fn genesis_hash(&self, relay_id: RelayId) -> Result<HashFor<Block>, Error>;
+	fn genesis_hash(&self) -> Result<HashFor<Block>, Error>;
 
-	fn latest_finalized_header(&self, relay_id: RelayId) -> Result<Block::Header, Error>;
+	fn latest_finalized_header(&self) -> Result<Block::Header, Error>;
 
 	// Todo: Check if we still need this after #423
-	fn penultimate_finalized_block_header(&self, relay_id: RelayId)
-		-> Result<Block::Header, Error>;
-
-	fn num_relays(&self) -> RelayId;
+	fn penultimate_finalized_block_header(&self) -> Result<Block::Header, Error>;
 }
 
 pub fn grandpa_log<Block: ParentchainBlockTrait>(

--- a/core/parentchain/light-client/src/light_validation.rs
+++ b/core/parentchain/light-client/src/light_validation.rs
@@ -19,8 +19,7 @@
 
 use crate::{
 	error::Error, finality::Finality, light_validation_state::LightValidationState,
-	state::RelayState, AuthorityList, AuthorityListRef, ExtrinsicSender, HashFor, HashingFor,
-	LightClientState, NumberFor, RelayId, Validator,
+	AuthorityListRef, ExtrinsicSender, HashFor, HashingFor, LightClientState, NumberFor, Validator,
 };
 use codec::Encode;
 use core::iter::Iterator;
@@ -47,45 +46,9 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 	pub fn new(
 		ocall_api: Arc<OcallApi>,
 		finality: Arc<Box<dyn Finality<Block> + Sync + Send + 'static>>,
+		light_validation_state: LightValidationState<Block>,
 	) -> Self {
-		Self { light_validation_state: LightValidationState::new(), ocall_api, finality }
-	}
-
-	fn initialize_relay(
-		&mut self,
-		block_header: Block::Header,
-		validator_set: AuthorityList,
-	) -> Result<RelayId, Error> {
-		let relay_info = RelayState::new(block_header, validator_set);
-
-		let new_relay_id = self.light_validation_state.num_relays + 1;
-		self.light_validation_state.tracked_relays.insert(new_relay_id, relay_info);
-
-		self.light_validation_state.num_relays = new_relay_id;
-
-		Ok(new_relay_id)
-	}
-
-	fn check_validator_set_proof(
-		state_root: &HashFor<Block>,
-		proof: StorageProof,
-		validator_set: AuthorityListRef,
-	) -> Result<(), Error> {
-		let checker = StorageProofChecker::<HashingFor<Block>>::new(*state_root, proof)?;
-
-		// By encoding the given set we should have an easy way to compare
-		// with the stuff we get out of storage via `read_value`
-		let mut encoded_validator_set = validator_set.encode();
-		encoded_validator_set.insert(0, 1); // Add AUTHORITIES_VERISON == 1
-		let actual_validator_set = checker
-			.read_value(b":grandpa_authorities")?
-			.ok_or(StorageError::StorageValueUnavailable)?;
-
-		if encoded_validator_set == actual_validator_set {
-			Ok(())
-		} else {
-			Err(Error::ValidatorSetMismatch)
-		}
+		Self { light_validation_state, ocall_api, finality }
 	}
 
 	// A naive way to check whether a `child` header is a descendant
@@ -115,12 +78,11 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 
 	fn submit_finalized_headers(
 		&mut self,
-		relay_id: RelayId,
 		header: Block::Header,
 		ancestry_proof: Vec<Block::Header>,
 		justifications: Option<Justifications>,
 	) -> Result<(), Error> {
-		let relay = self.light_validation_state.get_tracked_relay_mut(relay_id)?;
+		let relay = self.light_validation_state.get_relay_mut();
 
 		let validator_set = relay.current_validator_set.clone();
 		let validator_set_id = relay.current_validator_set_id;
@@ -156,12 +118,8 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 		Ok(())
 	}
 
-	fn submit_xt_to_be_included(
-		&mut self,
-		relay_id: RelayId,
-		extrinsic: OpaqueExtrinsic,
-	) -> Result<(), Error> {
-		let relay = self.light_validation_state.get_tracked_relay_mut(relay_id)?;
+	fn submit_xt_to_be_included(&mut self, extrinsic: OpaqueExtrinsic) -> Result<(), Error> {
+		let relay = self.light_validation_state.get_relay_mut();
 		relay.verify_tx_inclusion.push(extrinsic);
 
 		debug!(
@@ -179,45 +137,21 @@ where
 	Block: ParentchainBlockTrait,
 	OCallApi: EnclaveOnChainOCallApi,
 {
-	fn initialize_grandpa_relay(
-		&mut self,
-		block_header: Block::Header,
-		validator_set: AuthorityList,
-		validator_set_proof: StorageProof,
-	) -> Result<RelayId, Error> {
-		let state_root = block_header.state_root();
-		Self::check_validator_set_proof(state_root, validator_set_proof, &validator_set)?;
-
-		self.initialize_relay(block_header, validator_set)
-	}
-
-	fn initialize_parachain_relay(
-		&mut self,
-		block_header: Block::Header,
-		validator_set: AuthorityList,
-	) -> Result<RelayId, Error> {
-		self.initialize_relay(block_header, validator_set)
-	}
-
-	fn submit_block(
-		&mut self,
-		relay_id: RelayId,
-		signed_block: &SignedBlock<Block>,
-	) -> Result<(), Error> {
+	fn submit_block(&mut self, signed_block: &SignedBlock<Block>) -> Result<(), Error> {
 		let header = signed_block.block.header();
 		let justifications = signed_block.justifications.clone();
 
-		let relay = self.light_validation_state.get_tracked_relay_mut(relay_id)?;
+		let relay = self.light_validation_state.get_relay_mut();
 
 		if relay.last_finalized_block_header.hash() != *header.parent_hash() {
 			return Err(Error::HeaderAncestryMismatch)
 		}
 
-		self.submit_finalized_headers(relay_id, header.clone(), vec![], justifications)
+		self.submit_finalized_headers(header.clone(), vec![], justifications)
 	}
 
-	fn check_xt_inclusion(&mut self, relay_id: RelayId, block: &Block) -> Result<(), Error> {
-		let relay = self.light_validation_state.get_tracked_relay_mut(relay_id)?;
+	fn check_xt_inclusion(&mut self, block: &Block) -> Result<(), Error> {
+		let relay = self.light_validation_state.get_relay_mut();
 
 		if relay.verify_tx_inclusion.is_empty() {
 			return Ok(())
@@ -249,10 +183,6 @@ where
 		Ok(())
 	}
 
-	fn set_state(&mut self, state: LightValidationState<Block>) {
-		self.light_validation_state = state;
-	}
-
 	fn get_state(&self) -> &LightValidationState<Block> {
 		&self.light_validation_state
 	}
@@ -266,7 +196,7 @@ where
 {
 	fn send_extrinsics(&mut self, extrinsics: Vec<OpaqueExtrinsic>) -> Result<(), Error> {
 		for xt in extrinsics.iter() {
-			self.submit_xt_to_be_included(self.num_relays(), xt.clone()).expect("No Relays");
+			self.submit_xt_to_be_included(xt.clone()).expect("No Relays");
 		}
 
 		self.ocall_api
@@ -281,31 +211,24 @@ where
 	Block: ParentchainBlockTrait,
 	OCallApi: EnclaveOnChainOCallApi,
 {
-	fn num_xt_to_be_included(&self, relay_id: RelayId) -> Result<usize, Error> {
-		let relay = self.light_validation_state.get_tracked_relay(relay_id)?;
+	fn num_xt_to_be_included(&self) -> Result<usize, Error> {
+		let relay = self.light_validation_state.get_relay();
 		Ok(relay.verify_tx_inclusion.len())
 	}
 
-	fn genesis_hash(&self, relay_id: RelayId) -> Result<HashFor<Block>, Error> {
-		let relay = self.light_validation_state.get_tracked_relay(relay_id)?;
+	fn genesis_hash(&self) -> Result<HashFor<Block>, Error> {
+		let relay = self.light_validation_state.get_relay();
 		Ok(relay.header_hashes[0])
 	}
 
-	fn latest_finalized_header(&self, relay_id: RelayId) -> Result<Block::Header, Error> {
-		let relay = self.light_validation_state.get_tracked_relay(relay_id)?;
+	fn latest_finalized_header(&self) -> Result<Block::Header, Error> {
+		let relay = self.light_validation_state.get_relay();
 		Ok(relay.last_finalized_block_header.clone())
 	}
 
-	fn penultimate_finalized_block_header(
-		&self,
-		relay_id: RelayId,
-	) -> Result<Block::Header, Error> {
-		let relay = self.light_validation_state.get_tracked_relay(relay_id)?;
+	fn penultimate_finalized_block_header(&self) -> Result<Block::Header, Error> {
+		let relay = self.light_validation_state.get_relay();
 		Ok(relay.penultimate_finalized_block_header.clone())
-	}
-
-	fn num_relays(&self) -> RelayId {
-		self.light_validation_state.num_relays
 	}
 }
 
@@ -318,8 +241,30 @@ where
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		write!(
 			f,
-			"LightValidation {{ num_relays: {}, tracked_relays: {:?} }}",
-			self.light_validation_state.num_relays, self.light_validation_state.tracked_relays
+			"LightValidation {{ relay_state: {:?} }}",
+			self.light_validation_state.relay_state
 		)
+	}
+}
+
+pub fn check_validator_set_proof<Block: ParentchainBlockTrait>(
+	state_root: &HashFor<Block>,
+	proof: StorageProof,
+	validator_set: AuthorityListRef,
+) -> Result<(), Error> {
+	let checker = StorageProofChecker::<HashingFor<Block>>::new(*state_root, proof)?;
+
+	// By encoding the given set we should have an easy way to compare
+	// with the stuff we get out of storage via `read_value`
+	let mut encoded_validator_set = validator_set.encode();
+	encoded_validator_set.insert(0, 1); // Add AUTHORITIES_VERISON == 1
+	let actual_validator_set = checker
+		.read_value(b":grandpa_authorities")?
+		.ok_or(StorageError::StorageValueUnavailable)?;
+
+	if encoded_validator_set == actual_validator_set {
+		Ok(())
+	} else {
+		Err(Error::ValidatorSetMismatch)
 	}
 }

--- a/core/parentchain/light-client/src/light_validation.rs
+++ b/core/parentchain/light-client/src/light_validation.rs
@@ -118,7 +118,7 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 		Ok(())
 	}
 
-	fn submit_xt_to_be_included(&mut self, extrinsic: OpaqueExtrinsic) -> Result<(), Error> {
+	fn submit_xt_to_be_included(&mut self, extrinsic: OpaqueExtrinsic) {
 		let relay = self.light_validation_state.get_relay_mut();
 		relay.verify_tx_inclusion.push(extrinsic);
 
@@ -126,8 +126,6 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 			"{} extrinsics in cache, waiting for inclusion verification",
 			relay.verify_tx_inclusion.len()
 		);
-
-		Ok(())
 	}
 }
 
@@ -196,7 +194,7 @@ where
 {
 	fn send_extrinsics(&mut self, extrinsics: Vec<OpaqueExtrinsic>) -> Result<(), Error> {
 		for xt in extrinsics.iter() {
-			self.submit_xt_to_be_included(xt.clone()).expect("No Relays");
+			self.submit_xt_to_be_included(xt.clone());
 		}
 
 		self.ocall_api

--- a/core/parentchain/light-client/src/light_validation_state.rs
+++ b/core/parentchain/light-client/src/light_validation_state.rs
@@ -17,39 +17,32 @@
 
 //! State of the light-client validation.
 
-use crate::{state::RelayState, Error, RelayId};
+use crate::state::RelayState;
 use codec::{Decode, Encode};
 pub use sp_finality_grandpa::SetId;
 use sp_runtime::traits::Block as ParentchainBlockTrait;
-use std::collections::BTreeMap;
 
 #[derive(Encode, Decode, Clone, Debug)]
 pub struct LightValidationState<Block: ParentchainBlockTrait> {
-	pub num_relays: RelayId,
-	pub tracked_relays: BTreeMap<RelayId, RelayState<Block>>,
+	pub(crate) relay_state: RelayState<Block>,
+}
+
+impl<Block: ParentchainBlockTrait> From<RelayState<Block>> for LightValidationState<Block> {
+	fn from(value: RelayState<Block>) -> Self {
+		Self::new(value)
+	}
 }
 
 impl<Block: ParentchainBlockTrait> LightValidationState<Block> {
-	pub fn new() -> Self {
-		Self { num_relays: Default::default(), tracked_relays: Default::default() }
+	pub fn new(relay_state: RelayState<Block>) -> Self {
+		Self { relay_state }
 	}
 
-	pub(crate) fn get_tracked_relay(&self, relay_id: RelayId) -> Result<&RelayState<Block>, Error> {
-		let relay = self.tracked_relays.get(&relay_id).ok_or(Error::NoSuchRelayExists)?;
-		Ok(relay)
+	pub(crate) fn get_relay(&self) -> &RelayState<Block> {
+		&self.relay_state
 	}
 
-	pub(crate) fn get_tracked_relay_mut(
-		&mut self,
-		relay_id: RelayId,
-	) -> Result<&mut RelayState<Block>, Error> {
-		let relay = self.tracked_relays.get_mut(&relay_id).ok_or(Error::NoSuchRelayExists)?;
-		Ok(relay)
-	}
-}
-
-impl<Block: ParentchainBlockTrait> Default for LightValidationState<Block> {
-	fn default() -> Self {
-		Self { num_relays: Default::default(), tracked_relays: Default::default() }
+	pub(crate) fn get_relay_mut(&mut self) -> &mut RelayState<Block> {
+		&mut self.relay_state
 	}
 }

--- a/core/parentchain/light-client/src/mocks/validator_mock.rs
+++ b/core/parentchain/light-client/src/mocks/validator_mock.rs
@@ -16,11 +16,10 @@
 */
 
 use crate::{
-	error::Result, AuthorityList, ExtrinsicSender, HashFor, LightClientState, LightValidationState,
-	RelayId, Validator,
+	error::Result, state::RelayState, ExtrinsicSender, HashFor, LightClientState,
+	LightValidationState, Validator,
 };
 use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
-use itp_storage::StorageProof;
 use itp_types::Block;
 use sp_runtime::{generic::SignedBlock, traits::Block as BlockT, OpaqueExtrinsic};
 use std::vec::Vec;
@@ -28,43 +27,30 @@ use std::vec::Vec;
 type Header = <Block as BlockT>::Header;
 
 /// Validator mock to be used in tests.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ValidatorMock {
 	light_validation_state: LightValidationState<Block>,
 }
 
+impl Default for ValidatorMock {
+	fn default() -> Self {
+		Self {
+			light_validation_state: RelayState::new(
+				ParentchainHeaderBuilder::default().build(),
+				Default::default(),
+			)
+			.into(),
+		}
+	}
+}
+
 impl Validator<Block> for ValidatorMock {
-	fn initialize_grandpa_relay(
-		&mut self,
-		_block_header: Header,
-		_validator_set: AuthorityList,
-		_validator_set_proof: StorageProof,
-	) -> Result<RelayId> {
-		todo!()
-	}
-
-	fn initialize_parachain_relay(
-		&mut self,
-		_block_header: Header,
-		_validator_set: AuthorityList,
-	) -> Result<RelayId> {
-		todo!()
-	}
-
-	fn submit_block(
-		&mut self,
-		_relay_id: RelayId,
-		_signed_block: &SignedBlock<Block>,
-	) -> Result<()> {
+	fn submit_block(&mut self, _signed_block: &SignedBlock<Block>) -> Result<()> {
 		Ok(())
 	}
 
-	fn check_xt_inclusion(&mut self, _relay_id: RelayId, _block: &Block) -> Result<()> {
+	fn check_xt_inclusion(&mut self, _block: &Block) -> Result<()> {
 		Ok(())
-	}
-
-	fn set_state(&mut self, state: LightValidationState<Block>) {
-		self.light_validation_state = state;
 	}
 
 	fn get_state(&self) -> &LightValidationState<Block> {
@@ -79,23 +65,19 @@ impl ExtrinsicSender for ValidatorMock {
 }
 
 impl LightClientState<Block> for ValidatorMock {
-	fn num_xt_to_be_included(&self, _relay_id: RelayId) -> Result<usize> {
+	fn num_xt_to_be_included(&self) -> Result<usize> {
 		todo!()
 	}
 
-	fn genesis_hash(&self, _relay_id: RelayId) -> Result<HashFor<Block>> {
+	fn genesis_hash(&self) -> Result<HashFor<Block>> {
 		todo!()
 	}
 
-	fn latest_finalized_header(&self, _relay_id: RelayId) -> Result<Header> {
+	fn latest_finalized_header(&self) -> Result<Header> {
 		Ok(ParentchainHeaderBuilder::default().build())
 	}
 
-	fn penultimate_finalized_block_header(&self, _relay_id: RelayId) -> Result<Header> {
+	fn penultimate_finalized_block_header(&self) -> Result<Header> {
 		Ok(ParentchainHeaderBuilder::default().build())
-	}
-
-	fn num_relays(&self) -> RelayId {
-		0
 	}
 }

--- a/core/parentchain/light-client/src/mocks/validator_mock_seal.rs
+++ b/core/parentchain/light-client/src/mocks/validator_mock_seal.rs
@@ -15,7 +15,8 @@
 
 */
 
-use crate::{error::Error, LightValidationState};
+use crate::{error::Error, state::RelayState, LightValidationState};
+use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
 use itp_sgx_io::StaticSealedIO;
 use itp_types::Block;
 
@@ -28,7 +29,10 @@ impl StaticSealedIO for LightValidationStateSealMock {
 	type Unsealed = LightValidationState<Block>;
 
 	fn unseal_from_static_file() -> Result<Self::Unsealed, Self::Error> {
-		Ok(LightValidationState::new())
+		Ok(LightValidationState::new(RelayState::new(
+			ParentchainHeaderBuilder::default().build(),
+			Default::default(),
+		)))
 	}
 
 	fn seal_to_static_file(_unsealed: &Self::Unsealed) -> Result<(), Self::Error> {

--- a/core/parentchain/light-client/src/state.rs
+++ b/core/parentchain/light-client/src/state.rs
@@ -23,7 +23,7 @@ use sp_runtime::{
 };
 use std::{fmt, vec::Vec};
 
-#[derive(Encode, Decode, Clone, PartialEq, Default)]
+#[derive(Encode, Decode, Clone, PartialEq)]
 pub struct RelayState<Block: BlockT> {
 	pub last_finalized_block_header: Block::Header,
 	pub penultimate_finalized_block_header: Block::Header,

--- a/core/parentchain/light-client/src/state.rs
+++ b/core/parentchain/light-client/src/state.rs
@@ -23,7 +23,7 @@ use sp_runtime::{
 };
 use std::{fmt, vec::Vec};
 
-#[derive(Encode, Decode, Clone, PartialEq)]
+#[derive(Encode, Decode, Clone, PartialEq, Default)]
 pub struct RelayState<Block: BlockT> {
 	pub last_finalized_block_header: Block::Header,
 	pub penultimate_finalized_block_header: Block::Header,

--- a/enclave-runtime/src/initialization/parentchain/parachain.rs
+++ b/enclave-runtime/src/initialization/parentchain/parachain.rs
@@ -61,11 +61,10 @@ impl FullParachainHandler {
 			ParachainBlock,
 			EnclaveOCallApi,
 		>(params, ocall_api.clone())?;
-		let latest_header = validator.latest_finalized_header(validator.num_relays())?;
+		let latest_header = validator.latest_finalized_header()?;
 		let validator_accessor = Arc::new(EnclaveValidatorAccessor::new(validator));
 
-		let genesis_hash =
-			validator_accessor.execute_on_validator(|v| v.genesis_hash(v.num_relays()))?;
+		let genesis_hash = validator_accessor.execute_on_validator(|v| v.genesis_hash())?;
 
 		let extrinsics_factory =
 			create_extrinsics_factory(genesis_hash, node_metadata_repository.clone())?;

--- a/enclave-runtime/src/initialization/parentchain/solochain.rs
+++ b/enclave-runtime/src/initialization/parentchain/solochain.rs
@@ -60,11 +60,10 @@ impl FullSolochainHandler {
 			SolochainBlock,
 			EnclaveOCallApi,
 		>(params, ocall_api.clone())?;
-		let latest_header = validator.latest_finalized_header(validator.num_relays())?;
+		let latest_header = validator.latest_finalized_header()?;
 		let validator_accessor = Arc::new(EnclaveValidatorAccessor::new(validator));
 
-		let genesis_hash =
-			validator_accessor.execute_on_validator(|v| v.genesis_hash(v.num_relays()))?;
+		let genesis_hash = validator_accessor.execute_on_validator(|v| v.genesis_hash())?;
 
 		let extrinsics_factory =
 			create_extrinsics_factory(genesis_hash, node_metadata_repository.clone())?;

--- a/enclave-runtime/src/top_pool_execution.rs
+++ b/enclave-runtime/src/top_pool_execution.rs
@@ -101,7 +101,7 @@ fn execute_top_pool_trusted_calls_internal() -> Result<()> {
 	// itself, will  operate on a parentchain block that is potentially outdated by one block
 	// (in case we have a block in the queue, but not imported yet).
 	let current_parentchain_header = validator_access.execute_on_validator(|v| {
-		let latest_parentchain_header = v.latest_finalized_header(v.num_relays())?;
+		let latest_parentchain_header = v.latest_finalized_header()?;
 		Ok(latest_parentchain_header)
 	})?;
 


### PR DESCRIPTION
Preliminary simplifications for #1081, which also helps with #1242.

* Remove `RelayId` of the light-client, we are going to support multiple parentchains differently; by instantiating multiple light-clients altogether.
* Instead of constructing and and setting the relay state-step separately, we set up the light-validation in the constructor exclusively now. This simplifies the code in various places.
* Don't read from disk when we execute on the validator state. The state is behind a global `RwLock`, there is no chance that the state on disk is more up-to-date than the one in memory.