### PR TITLE
[itc-parentchain-test] better re-exports to simplify imports

### DIFF
--- a/core-primitives/stf-executor/src/executor_tests.rs
+++ b/core-primitives/stf-executor/src/executor_tests.rs
@@ -22,7 +22,7 @@ use ita_stf::{
 	test_genesis::{endowed_account, test_genesis_setup},
 	State, TrustedCall,
 };
-use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+use itc_parentchain_test::ParentchainHeaderBuilder;
 use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_externalities::SgxExternalitiesTrait;

--- a/core/parentchain/indirect-calls-executor/src/executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/executor.rs
@@ -232,7 +232,7 @@ mod test {
 	};
 	use codec::{Decode, Encode};
 	use ita_stf::TrustedOperation;
-	use itc_parentchain_test::parentchain_block_builder::ParentchainBlockBuilder;
+	use itc_parentchain_test::ParentchainBlockBuilder;
 	use itp_node_api::{
 		api_client::{
 			ExtrinsicParams, ParentchainAdditionalParams, ParentchainExtrinsicParams,

--- a/core/parentchain/light-client/src/mocks/validator_mock.rs
+++ b/core/parentchain/light-client/src/mocks/validator_mock.rs
@@ -19,7 +19,7 @@ use crate::{
 	error::Result, state::RelayState, ExtrinsicSender, HashFor, LightClientState,
 	LightValidationState, Validator,
 };
-use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+use itc_parentchain_test::ParentchainHeaderBuilder;
 use itp_types::Block;
 use sp_runtime::{generic::SignedBlock, traits::Block as BlockT, OpaqueExtrinsic};
 use std::vec::Vec;

--- a/core/parentchain/light-client/src/mocks/validator_mock_seal.rs
+++ b/core/parentchain/light-client/src/mocks/validator_mock_seal.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{error::Error, state::RelayState, LightValidationState};
-use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+use itc_parentchain_test::ParentchainHeaderBuilder;
 use itp_sgx_io::StaticSealedIO;
 use itp_types::Block;
 

--- a/core/parentchain/test/src/lib.rs
+++ b/core/parentchain/test/src/lib.rs
@@ -20,5 +20,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub mod parentchain_block_builder;
-pub mod parentchain_header_builder;
+mod parentchain_block_builder;
+mod parentchain_header_builder;
+
+pub use parentchain_block_builder::{Block, ParentchainBlockBuilder, SignedBlock};
+pub use parentchain_header_builder::{BlockNumber, Header, ParentchainHeaderBuilder, H256};

--- a/core/parentchain/test/src/parentchain_block_builder.rs
+++ b/core/parentchain/test/src/parentchain_block_builder.rs
@@ -20,13 +20,12 @@
 
 extern crate alloc;
 
-use crate::parentchain_header_builder::ParentchainHeaderBuilder;
+use crate::ParentchainHeaderBuilder;
 use alloc::vec::Vec;
 use itp_types::parentchain::Header;
-use sp_runtime::{
-	generic::{Block, SignedBlock},
-	traits::MaybeSerialize,
-};
+use sp_runtime::traits::MaybeSerialize;
+
+pub use sp_runtime::generic::{Block, SignedBlock};
 
 pub struct ParentchainBlockBuilder<Extrinsic> {
 	header: Header,

--- a/core/parentchain/test/src/parentchain_header_builder.rs
+++ b/core/parentchain/test/src/parentchain_header_builder.rs
@@ -18,8 +18,8 @@
 
 //! Builder pattern for a parentchain header.
 
-use itp_types::{BlockNumber, Header, H256};
-use sp_runtime::generic::Digest;
+pub use itp_types::{BlockNumber, Header, H256};
+pub use sp_runtime::generic::Digest;
 
 #[derive(Default)]
 pub struct ParentchainHeaderBuilder {

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -35,7 +35,7 @@ use ita_stf::{
 	Balance, StatePayload, TrustedCall, TrustedOperation,
 };
 use itc_parentchain::light_client::mocks::validator_access_mock::ValidatorAccessMock;
-use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+use itc_parentchain_test::ParentchainHeaderBuilder;
 use itp_extrinsics_factory::mock::ExtrinsicsFactoryMock;
 use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_ocall_api::EnclaveAttestationOCallApi;

--- a/enclave-runtime/src/test/sidechain_event_tests.rs
+++ b/enclave-runtime/src/test/sidechain_event_tests.rs
@@ -30,7 +30,7 @@ use crate::{
 use ita_sgx_runtime::Runtime;
 use ita_stf::helpers::set_block_number;
 use itc_parentchain::light_client::mocks::validator_access_mock::ValidatorAccessMock;
-use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+use itc_parentchain_test::ParentchainHeaderBuilder;
 use itp_extrinsics_factory::mock::ExtrinsicsFactoryMock;
 use itp_node_api::metadata::{metadata_mocks::NodeMetadataMock, provider::NodeMetadataRepository};
 use itp_settings::{

--- a/enclave-runtime/src/test/top_pool_tests.rs
+++ b/enclave-runtime/src/test/top_pool_tests.rs
@@ -38,10 +38,7 @@ use itc_parentchain::indirect_calls_executor::{
 	parentchain_extrinsic_parser::ParentchainExtrinsicParser, ExecuteIndirectCalls,
 	IndirectCallsExecutor,
 };
-use itc_parentchain_test::{
-	parentchain_block_builder::ParentchainBlockBuilder,
-	parentchain_header_builder::ParentchainHeaderBuilder,
-};
+use itc_parentchain_test::{ParentchainBlockBuilder, ParentchainHeaderBuilder};
 use itp_node_api::{
 	api_client::{
 		ExtrinsicParams, ParentchainAdditionalParams, ParentchainExtrinsicParams,

--- a/service/src/tests/mocks/parentchain_api_mock.rs
+++ b/service/src/tests/mocks/parentchain_api_mock.rs
@@ -15,10 +15,7 @@
 
 */
 
-use itc_parentchain_test::{
-	parentchain_block_builder::ParentchainBlockBuilder,
-	parentchain_header_builder::ParentchainHeaderBuilder,
-};
+use itc_parentchain_test::{ParentchainBlockBuilder, ParentchainHeaderBuilder};
 use itp_node_api::api_client::{ApiResult, ChainApi, SignedBlock};
 use itp_types::{
 	parentchain::{Hash, Header, StorageProof},

--- a/service/src/tests/parentchain_handler_test.rs
+++ b/service/src/tests/parentchain_handler_test.rs
@@ -22,7 +22,7 @@ use crate::{
 use itc_parentchain::{
 	light_client::light_client_init_params::SimpleParams, primitives::ParentchainInitParams,
 };
-use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+use itc_parentchain_test::ParentchainHeaderBuilder;
 use itp_node_api::api_client::ChainApi;
 use std::sync::Arc;
 

--- a/sidechain/block-verification/src/lib.rs
+++ b/sidechain/block-verification/src/lib.rs
@@ -204,7 +204,7 @@ mod tests {
 	use super::*;
 	use core::assert_matches::assert_matches;
 	use frame_support::assert_ok;
-	use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+	use itc_parentchain_test::ParentchainHeaderBuilder;
 	use itp_types::{AccountId, Block as ParentchainBlock};
 	use its_primitives::types::{block::SignedBlock, header::SidechainHeader as Header};
 	use its_test::{

--- a/sidechain/consensus/aura/src/lib.rs
+++ b/sidechain/consensus/aura/src/lib.rs
@@ -260,10 +260,7 @@ mod tests {
 		mocks::environment_mock::EnvironmentMock,
 	};
 	use itc_parentchain_block_import_dispatcher::trigger_parentchain_block_import_mock::TriggerParentchainBlockImportMock;
-	use itc_parentchain_test::{
-		parentchain_block_builder::ParentchainBlockBuilder,
-		parentchain_header_builder::ParentchainHeaderBuilder,
-	};
+	use itc_parentchain_test::{ParentchainBlockBuilder, ParentchainHeaderBuilder};
 	use itp_test::mock::onchain_mock::OnchainMock;
 	use itp_types::{
 		Block as ParentchainBlock, Enclave, Header as ParentchainHeader,

--- a/sidechain/consensus/aura/src/test/block_importer_tests.rs
+++ b/sidechain/consensus/aura/src/test/block_importer_tests.rs
@@ -19,10 +19,7 @@ use crate::{block_importer::BlockImporter, test::fixtures::validateer, ShardIden
 use codec::Encode;
 use core::assert_matches::assert_matches;
 use itc_parentchain_block_import_dispatcher::trigger_parentchain_block_import_mock::TriggerParentchainBlockImportMock;
-use itc_parentchain_test::{
-	parentchain_block_builder::ParentchainBlockBuilder,
-	parentchain_header_builder::ParentchainHeaderBuilder,
-};
+use itc_parentchain_test::{ParentchainBlockBuilder, ParentchainHeaderBuilder};
 use itp_sgx_crypto::{aes::Aes, mocks::KeyRepositoryMock, StateCrypto};
 use itp_sgx_externalities::SgxExternalitiesDiffType;
 use itp_stf_state_handler::handle_state::HandleState;

--- a/sidechain/consensus/common/src/peer_block_sync.rs
+++ b/sidechain/consensus/common/src/peer_block_sync.rs
@@ -223,7 +223,7 @@ mod tests {
 		block_importer_mock::BlockImportMock, confirm_block_import_mock::ConfirmBlockImportMock,
 	};
 	use core::assert_matches::assert_matches;
-	use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+	use itc_parentchain_test::ParentchainHeaderBuilder;
 	use itp_test::mock::sidechain_ocall_api_mock::SidechainOCallApiMock;
 	use itp_types::Block as ParentchainBlock;
 	use its_primitives::types::block::SignedBlock as SignedSidechainBlock;

--- a/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
+++ b/sidechain/consensus/slots/src/per_shard_slot_worker_tests.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{mocks::SimpleSlotWorkerMock, PerShardSlotWorkerScheduler, SlotInfo};
-use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+use itc_parentchain_test::ParentchainHeaderBuilder;
 use itp_settings::sidechain::SLOT_DURATION;
 use itp_time_utils::duration_now;
 use itp_types::{Block as ParentchainBlock, ShardIdentifier};

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -205,7 +205,7 @@ pub mod sgx {
 mod tests {
 	use super::*;
 	use core::assert_matches::assert_matches;
-	use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+	use itc_parentchain_test::ParentchainHeaderBuilder;
 	use itp_sgx_io::StaticSealedIO;
 	use itp_types::Block as ParentchainBlock;
 	use its_primitives::{

--- a/sidechain/validateer-fetch/src/validateer.rs
+++ b/sidechain/validateer-fetch/src/validateer.rs
@@ -69,7 +69,7 @@ impl<OnchainStorage: EnclaveOnChainOCallApi> ValidateerFetch for OnchainStorage 
 mod tests {
 	use super::*;
 	use codec::Encode;
-	use itc_parentchain_test::parentchain_header_builder::ParentchainHeaderBuilder;
+	use itc_parentchain_test::ParentchainHeaderBuilder;
 	use itp_test::mock::onchain_mock::{validateer_set, OnchainMock};
 	use std::string::ToString;
 


### PR DESCRIPTION
I was bothered by setting up tests for the light-client-db in the other PR.