### PR TITLE
Add missing return to avoid closing the connection twice

### DIFF
--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -257,6 +257,7 @@ fn send_direct_request(
 							}
 							if connection_can_be_closed(status) {
 								direct_api.close().unwrap();
+								return Ok(None)
 							}
 						},
 						DirectRequestStatus::Ok => {


### PR DESCRIPTION
resolves https://github.com/integritee-network/worker/issues/1308

Without it the ws connection is closed twice and might cause panic.