### PR TITLE
Fix production feature propagation into the itp-attestation-handler

### DIFF
--- a/core-primitives/attestation-handler/Cargo.toml
+++ b/core-primitives/attestation-handler/Cargo.toml
@@ -103,3 +103,4 @@ sgx = [
     "httparse/mesalock_sgx",
 ]
 test = []
+production = []

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -17,7 +17,7 @@ evm = [
     "ita-sgx-runtime/evm",
     "ita-stf/evm",
 ]
-production = ["itp-settings/production"]
+production = ["itp-settings/production", "itp-attestation-handler/production"]
 sidechain = ["itp-settings/sidechain", "itp-top-pool-author/sidechain"]
 offchain-worker = [
     "itp-settings/offchain-worker",


### PR DESCRIPTION
The `production` flag did not make into the `itp-attestation-handler`, which resulted in using the wrong IAS URL in production mode.

Kudos to @mosonyi for helping with the investigation.

Closes https://github.com/integritee-network/worker/issues/1233.