### PR TITLE
Detect extrinsic failures on untrusted side

### DIFF
--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -72,8 +72,7 @@ use log::*;
 use my_node_runtime::{Hash, Header, RuntimeEvent};
 use sgx_types::*;
 use substrate_api_client::{
-	rpc::HandleSubscription, GetHeader, SubmitAndWatch, SubmitAndWatchUntilSuccess, SubscribeChain,
-	SubscribeEvents, XtStatus,
+	rpc::HandleSubscription, GetHeader, SubmitAndWatchUntilSuccess, SubscribeChain, SubscribeEvents,
 };
 
 #[cfg(feature = "dcap")]


### PR DESCRIPTION
closes #1312

Quick hotfix to detect when an extrinsic can fail in `send_extrinsic`