### PR TITLE
Introduce CLI for a configurable data-dir

### DIFF
--- a/cli/tests/basic_tests.rs
+++ b/cli/tests/basic_tests.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use integritee_cli::Cli;
 
 fn init() {
-	env_logger::try_init();
+	let _ = env_logger::try_init();
 }
 
 #[test]

--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -25,6 +25,8 @@ extern "C" {
 		mu_ra_addr_size: u32,
 		untrusted_worker_addr: *const u8,
 		untrusted_worker_addr_size: u32,
+		encoded_base_dir_str: *const u8,
+		encoded_base_dir_size: u32,
 	) -> sgx_status_t;
 
 	pub fn init_enclave_sidechain_components(

--- a/core-primitives/enclave-api/src/enclave_base.rs
+++ b/core-primitives/enclave-api/src/enclave_base.rs
@@ -33,7 +33,12 @@ use sp_core::ed25519;
 /// Trait for base/common Enclave API functions
 pub trait EnclaveBase: Send + Sync + 'static {
 	/// Initialize the enclave (needs to be called once at application startup).
-	fn init(&self, mu_ra_addr: &str, untrusted_worker_addr: &str) -> EnclaveResult<()>;
+	fn init(
+		&self,
+		mu_ra_addr: &str,
+		untrusted_worker_addr: &str,
+		base_dir: &str,
+	) -> EnclaveResult<()>;
 
 	/// Initialize the enclave sidechain components.
 	fn init_enclave_sidechain_components(&self) -> EnclaveResult<()>;
@@ -67,11 +72,17 @@ pub trait EnclaveBase: Send + Sync + 'static {
 
 /// EnclaveApi implementation for Enclave struct
 impl EnclaveBase for Enclave {
-	fn init(&self, mu_ra_addr: &str, untrusted_worker_addr: &str) -> EnclaveResult<()> {
+	fn init(
+		&self,
+		mu_ra_addr: &str,
+		untrusted_worker_addr: &str,
+		base_dir: &str,
+	) -> EnclaveResult<()> {
 		let mut retval = sgx_status_t::SGX_SUCCESS;
 
 		let encoded_mu_ra_addr = mu_ra_addr.encode();
 		let encoded_untrusted_worker_addr = untrusted_worker_addr.encode();
+		let encoded_base_dir = base_dir.encode();
 
 		let result = unsafe {
 			ffi::init(
@@ -81,6 +92,8 @@ impl EnclaveBase for Enclave {
 				encoded_mu_ra_addr.len() as u32,
 				encoded_untrusted_worker_addr.as_ptr(),
 				encoded_untrusted_worker_addr.len() as u32,
+				encoded_base_dir.as_ptr(),
+				encoded_base_dir.len() as u32,
 			)
 		};
 

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -39,7 +39,8 @@ enclave {
 		/* define ECALLs here. */
 		public sgx_status_t init(
 			[in, size=mu_ra_addr_size] uint8_t* mu_ra_addr, uint32_t mu_ra_addr_size,
-			[in, size=untrusted_worker_addr_size] uint8_t* untrusted_worker_addr, uint32_t untrusted_worker_addr_size
+			[in, size=untrusted_worker_addr_size] uint8_t* untrusted_worker_addr, uint32_t untrusted_worker_addr_size,
+			[in, size=encoded_base_dir_size] uint8_t* encoded_base_dir_str, uint32_t encoded_base_dir_size
 		);
 
 		public sgx_status_t init_enclave_sidechain_components();

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -109,6 +109,9 @@ pub unsafe extern "C" fn init(
 	encoded_base_dir_str: *const u8,
 	encoded_base_dir_size: u32,
 ) -> sgx_status_t {
+	// Initialize the logging environment in the enclave.
+	env_logger::init();
+
 	let mu_ra_url =
 		match String::decode(&mut slice::from_raw_parts(mu_ra_addr, mu_ra_addr_size as usize))
 			.map_err(Error::Codec)

--- a/local-setup/config/one-worker.json
+++ b/local-setup/config/one-worker.json
@@ -30,7 +30,9 @@
         "2001",
         "-h",
         "4545",
-        "--ws-external"
+        "--ws-external",
+        "--data-dir",
+        "/tmp/data-dir"
       ],
       "subcommand_flags": [
         "--skip-ra",

--- a/local-setup/config/two-workers.json
+++ b/local-setup/config/two-workers.json
@@ -30,7 +30,9 @@
         "2001",
         "-h",
         "4545",
-        "--ws-external"
+        "--ws-external",
+        "--data-dir",
+        "/tmp/data-dir"
       ],
       "subcommand_flags": [
         "--skip-ra",
@@ -51,7 +53,9 @@
         "3001",
         "-h",
         "4546",
-        "--ws-external"
+        "--ws-external",
+        "--data-dir",
+        "/tmp/data-dir"
       ],
       "subcommand_flags": [
         "--skip-ra",

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -24,10 +24,10 @@ args:
           help: Set the websocket port to listen for substrate events
           takes_value: true
           default_value: "9944"
-    - base-dir:
+    - data-dir:
           short: d
-          long: base-dir
-          help: Base directory where the service operates.
+          long: data-dir
+          help: Data dir where the worker stores it's keys and other data.
           takes_value: true
     - ws-external:
         long: ws-external

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -19,11 +19,16 @@ args:
         takes_value: true
         default_value: "ws://127.0.0.1"
     - node-port:
-        short: p
-        long: node-port
-        help: Set the websocket port to listen for substrate events
-        takes_value: true
-        default_value: "9944"
+          short: p
+          long: node-port
+          help: Set the websocket port to listen for substrate events
+          takes_value: true
+          default_value: "9944"
+    - base-dir:
+          short: d
+          long: base-dir
+          help: Base directory where the service operates.
+          takes_value: true
     - ws-external:
         long: ws-external
         help: Set this flag in case the worker should listen to external requests.

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -19,7 +19,11 @@ use clap::ArgMatches;
 use itc_rest_client::rest_client::Url;
 use parse_duration::parse;
 use serde::{Deserialize, Serialize};
-use std::{fs, path::PathBuf, time::Duration};
+use std::{
+	fs,
+	path::{Path, PathBuf},
+	time::Duration,
+};
 
 static DEFAULT_NODE_SERVER: &str = "ws://127.0.0.1";
 static DEFAULT_NODE_PORT: &str = "9944";
@@ -53,7 +57,7 @@ pub struct Config {
 	/// Port for the untrusted HTTP server (e.g. for `is_initialized`)
 	untrusted_http_port: String,
 	/// Data directory used by all the services.
-	base_dir: PathBuf,
+	data_dir: PathBuf,
 	/// Config of the 'run' subcommand
 	run_config: Option<RunConfig>,
 }
@@ -89,7 +93,7 @@ impl Config {
 			enable_metrics_server,
 			metrics_server_port,
 			untrusted_http_port,
-			base_dir,
+			data_dir: base_dir,
 			run_config,
 		}
 	}
@@ -135,8 +139,8 @@ impl Config {
 		}
 	}
 
-	pub fn base_dir(&self) -> &PathBuf {
-		&self.base_dir
+	pub fn data_dir(&self) -> &Path {
+		self.data_dir.as_path()
 	}
 
 	pub fn run_config(&self) -> &Option<RunConfig> {
@@ -288,7 +292,7 @@ mod test {
 		assert!(config.mu_ra_external_address.is_none());
 		assert!(!config.enable_metrics_server);
 		assert_eq!(config.untrusted_http_port, DEFAULT_UNTRUSTED_HTTP_PORT);
-		assert_eq!(config.base_dir, pwd);
+		assert_eq!(config.data_dir, pwd);
 		assert!(config.run_config.is_none());
 	}
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -19,7 +19,7 @@ use clap::ArgMatches;
 use itc_rest_client::rest_client::Url;
 use parse_duration::parse;
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, time::Duration};
+use std::{fs, path::PathBuf, time::Duration};
 
 static DEFAULT_NODE_SERVER: &str = "ws://127.0.0.1";
 static DEFAULT_NODE_PORT: &str = "9944";
@@ -167,7 +167,16 @@ impl From<&ArgMatches<'_>> for Config {
 			m.value_of("untrusted-http-port").unwrap_or(DEFAULT_UNTRUSTED_HTTP_PORT);
 
 		let base_dir = match m.value_of("data-dir") {
-			Some(d) => PathBuf::from(d),
+			Some(d) => {
+				let p = PathBuf::from(d);
+				if !p.exists() {
+					log::info!("Creating new data-directory for the service {}.", p.display());
+					fs::create_dir_all(p.as_path()).unwrap();
+				} else {
+					log::info!("Starting service in existing directory {}.", p.display());
+				}
+				p
+			},
 			None => {
 				log::warn!("[Config] defaulting to data-dir = PWD because it was previous behaviour. This might change soon.\
 				Please pass the data-dir explicitly to ensure nothing breaks in your setup.");

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -166,7 +166,7 @@ impl From<&ArgMatches<'_>> for Config {
 		let untrusted_http_port =
 			m.value_of("untrusted-http-port").unwrap_or(DEFAULT_UNTRUSTED_HTTP_PORT);
 
-		let base_dir = match m.value_of("base-dir") {
+		let base_dir = match m.value_of("data-dir") {
 			Some(d) => PathBuf::from(d),
 			None => {
 				log::warn!("[Config] defaulting to data-dir = PWD because it was previous behaviour. This might change soon.\

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -266,7 +266,7 @@ mod test {
 		let empty_args = ArgMatches::default();
 		let config = Config::from(&empty_args);
 		let expected_worker_ip = "127.0.0.1";
-		let pwd = std::env::current_dir().unwrap().to_str().unwrap().to_string();
+		let pwd = pwd().to_str().unwrap().to_string();
 
 		assert_eq!(config.node_ip, DEFAULT_NODE_SERVER);
 		assert_eq!(config.node_port, DEFAULT_NODE_PORT);

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -279,7 +279,6 @@ mod test {
 		let empty_args = ArgMatches::default();
 		let config = Config::from(&empty_args);
 		let expected_worker_ip = "127.0.0.1";
-		let pwd = pwd().to_str().unwrap().to_string();
 
 		assert_eq!(config.node_ip, DEFAULT_NODE_SERVER);
 		assert_eq!(config.node_port, DEFAULT_NODE_PORT);
@@ -292,7 +291,7 @@ mod test {
 		assert!(config.mu_ra_external_address.is_none());
 		assert!(!config.enable_metrics_server);
 		assert_eq!(config.untrusted_http_port, DEFAULT_UNTRUSTED_HTTP_PORT);
-		assert_eq!(config.data_dir, pwd);
+		assert_eq!(config.data_dir, pwd());
 		assert!(config.run_config.is_none());
 	}
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -77,7 +77,7 @@ impl Config {
 		enable_metrics_server: bool,
 		metrics_server_port: String,
 		untrusted_http_port: String,
-		base_dir: PathBuf,
+		data_dir: PathBuf,
 		run_config: Option<RunConfig>,
 	) -> Self {
 		Self {
@@ -93,7 +93,7 @@ impl Config {
 			enable_metrics_server,
 			metrics_server_port,
 			untrusted_http_port,
-			data_dir: base_dir,
+			data_dir,
 			run_config,
 		}
 	}
@@ -170,7 +170,7 @@ impl From<&ArgMatches<'_>> for Config {
 		let untrusted_http_port =
 			m.value_of("untrusted-http-port").unwrap_or(DEFAULT_UNTRUSTED_HTTP_PORT);
 
-		let base_dir = match m.value_of("data-dir") {
+		let data_dir = match m.value_of("data-dir") {
 			Some(d) => {
 				let p = PathBuf::from(d);
 				if !p.exists() {
@@ -206,7 +206,7 @@ impl From<&ArgMatches<'_>> for Config {
 			is_metrics_server_enabled,
 			metrics_server_port.to_string(),
 			untrusted_http_port.to_string(),
-			base_dir,
+			data_dir,
 			run_config,
 		)
 	}

--- a/service/src/enclave/api.rs
+++ b/service/src/enclave/api.rs
@@ -110,7 +110,7 @@ pub fn enclave_init(config: &Config) -> EnclaveResult<Enclave> {
 	enclave_api.init(
 		&config.mu_ra_url_external(),
 		&config.untrusted_worker_url_external(),
-		&config.base_dir().display().to_string(),
+		&config.data_dir().display().to_string(),
 	)?;
 
 	Ok(enclave_api)

--- a/service/src/enclave/api.rs
+++ b/service/src/enclave/api.rs
@@ -15,8 +15,6 @@
 
 */
 
-//! keep this api free from chain-specific types!
-
 use crate::config::Config;
 use itp_enclave_api::{
 	enclave_base::EnclaveBase, error::Error as EnclaveApiError, Enclave, EnclaveResult,

--- a/service/src/enclave/api.rs
+++ b/service/src/enclave/api.rs
@@ -15,6 +15,8 @@
 
 */
 
+//! keep this api free from chain-specific types!
+
 use crate::config::Config;
 use itp_enclave_api::{
 	enclave_base::EnclaveBase, error::Error as EnclaveApiError, Enclave, EnclaveResult,
@@ -23,9 +25,11 @@ use itp_settings::files::{ENCLAVE_FILE, ENCLAVE_TOKEN};
 use log::*;
 use sgx_types::*;
 use sgx_urts::SgxEnclave;
-/// keep this api free from chain-specific types!
-use std::io::{Read, Write};
-use std::{fs::File, path::PathBuf};
+use std::{
+	fs::File,
+	io::{Read, Write},
+	path::PathBuf,
+};
 
 pub fn enclave_init(config: &Config) -> EnclaveResult<Enclave> {
 	const LEN: usize = 1024;
@@ -103,7 +107,11 @@ pub fn enclave_init(config: &Config) -> EnclaveResult<Enclave> {
 
 	// create an enclave API and initialize it
 	let enclave_api = Enclave::new(enclave);
-	enclave_api.init(&config.mu_ra_url_external(), &config.untrusted_worker_url_external())?;
+	enclave_api.init(
+		&config.mu_ra_url_external(),
+		&config.untrusted_worker_url_external(),
+		&config.base_dir().display().to_string(),
+	)?;
 
 	Ok(enclave_api)
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -132,7 +132,7 @@ fn main() {
 
 	let clean_reset = matches.is_present("clean-reset");
 	if clean_reset {
-		setup::purge_files_from_cwd().unwrap();
+		setup::purge_files_from_dir(config.data_dir()).unwrap();
 	}
 
 	// build the entire dependency tree

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -117,13 +117,6 @@ fn main() {
 	let yml = load_yaml!("cli.yml");
 	let matches = App::from_yaml(yml).get_matches();
 
-	// Todo: This will be changed to be a param of the CLI:
-	// https://github.com/integritee-network/worker/issues/1292
-	//
-	// Until the above task is finished, we just fall back to the
-	// static behaviour, which uses the PWD already.
-	let pwd = std::env::current_dir().expect("Works on all supported platforms; qed");
-
 	let config = Config::from(&matches);
 
 	GlobalTokioHandle::initialize();
@@ -144,8 +137,12 @@ fn main() {
 
 	// build the entire dependency tree
 	let tokio_handle = Arc::new(GlobalTokioHandle {});
-	let sidechain_blockstorage =
-		Arc::new(SidechainStorageLock::<SignedSidechainBlock>::from_base_path(pwd).unwrap());
+	let sidechain_blockstorage = Arc::new(
+		SidechainStorageLock::<SignedSidechainBlock>::from_base_path(
+			config.data_dir().to_path_buf(),
+		)
+		.unwrap(),
+	);
 	let node_api_factory =
 		Arc::new(NodeApiFactory::new(config.node_url(), AccountKeyring::Alice.pair()));
 	let enclave = Arc::new(enclave_init(&config).unwrap());

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -177,7 +177,7 @@ fn main() {
 		enclave_metrics_receiver,
 	)));
 
-	if let Some(run_config) = &config.run_config {
+	if let Some(run_config) = config.run_config() {
 		let shard = extract_shard(&run_config.shard, enclave.as_ref());
 
 		println!("Worker Config: {:?}", config);
@@ -296,7 +296,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	InitializationHandler: TrackInitialization + IsInitialized + Sync + Send + 'static,
 	WorkerModeProvider: ProvideWorkerMode,
 {
-	let run_config = config.run_config.clone().expect("Run config missing");
+	let run_config = config.run_config().clone().expect("Run config missing");
 	let skip_ra = run_config.skip_ra;
 
 	println!("Integritee Worker v{}", VERSION);
@@ -356,7 +356,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 
 	// ------------------------------------------------------------------------
 	// Start prometheus metrics server.
-	if config.enable_metrics_server {
+	if config.enable_metrics_server() {
 		let enclave_wallet =
 			Arc::new(EnclaveAccountInfoProvider::new(node_api.clone(), tee_accountid.clone()));
 		let metrics_handler = Arc::new(MetricsHandler::new(enclave_wallet));

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -27,12 +27,11 @@ use log::*;
 use std::{fs, fs::File, path::Path};
 
 /// Purge all worker files from the current working directory (cwd).
-pub(crate) fn purge_files_from_cwd() -> ServiceResult<()> {
-	let current_directory = std::env::current_dir().map_err(|e| Error::Custom(e.into()))?;
+pub(crate) fn purge_files_from_dir(dir: &Path) -> ServiceResult<()> {
 	println!("[+] Performing a clean reset of the worker");
 
 	println!("[+] Purge all files from previous runs");
-	purge_files(&current_directory)?;
+	purge_files(dir)?;
 
 	Ok(())
 }

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -26,7 +26,7 @@ use itp_types::ShardIdentifier;
 use log::*;
 use std::{fs, fs::File, path::Path};
 
-/// Purge all worker files from the current working directory (cwd).
+/// Purge all worker files from `dir`.
 pub(crate) fn purge_files_from_dir(dir: &Path) -> ServiceResult<()> {
 	println!("[+] Performing a clean reset of the worker");
 

--- a/service/src/tests/commons.rs
+++ b/service/src/tests/commons.rs
@@ -36,6 +36,7 @@ pub fn local_worker_config(
 	mu_ra_port: String,
 ) -> Config {
 	let mut url = worker_url.split(':');
+
 	Config::new(
 		Default::default(),
 		Default::default(),
@@ -49,6 +50,7 @@ pub fn local_worker_config(
 		false,
 		"8787".to_string(),
 		"4545".to_string(),
+		crate::config::pwd(),
 		None,
 	)
 }

--- a/service/src/tests/mocks/enclave_api_mock.rs
+++ b/service/src/tests/mocks/enclave_api_mock.rs
@@ -32,7 +32,7 @@ use sp_core::ed25519;
 pub struct EnclaveMock;
 
 impl EnclaveBase for EnclaveMock {
-	fn init(&self, _mu_ra_url: &str, _untrusted_url: &str) -> EnclaveResult<()> {
+	fn init(&self, _mu_ra_url: &str, _untrusted_url: &str, _base_dir: &str) -> EnclaveResult<()> {
 		Ok(())
 	}
 

--- a/service/src/tests/mod.rs
+++ b/service/src/tests/mod.rs
@@ -31,7 +31,7 @@ pub mod parentchain_handler_test;
 pub fn run_enclave_tests(matches: &ArgMatches) {
 	println!("*** Starting Test enclave");
 	let config = Config::from(matches);
-	setup::purge_files_from_dir(&config.data_dir()).unwrap();
+	setup::purge_files_from_dir(config.data_dir()).unwrap();
 	let enclave = enclave_init(&config).unwrap();
 
 	if matches.is_present("all") || matches.is_present("unit") {

--- a/service/src/tests/mod.rs
+++ b/service/src/tests/mod.rs
@@ -31,7 +31,7 @@ pub mod parentchain_handler_test;
 pub fn run_enclave_tests(matches: &ArgMatches) {
 	println!("*** Starting Test enclave");
 	let config = Config::from(matches);
-	setup::purge_files_from_cwd().unwrap();
+	setup::purge_files_from_dir(&config.data_dir()).unwrap();
 	let enclave = enclave_init(&config).unwrap();
 
 	if matches.is_present("all") || matches.is_present("unit") {


### PR DESCRIPTION
* Closes #1292 

This breaks nothing because it falls back to the current behaviour to use the pwd if the flag is not defined. However, it will print a warning that this behaviour will change in the future because it makes more sense to default to a well-defined default data-directory somewhere on the user path. (Todo: create an issue about that)

Example command for teeracle:

```
 ./integritee-service --data-dir /tmp/teeracle run --dev --skip-ra
```

Files that reside in the `--data-dir` after starting it with the above command:

```bash
ls /tmp/teeracle/
aes_key_and_iv_sealed_data.bin  ed25519_key_sealed.bin  light_client_db.bin  rsa3072_key_sealed.bin  sidechain_db  
```

Note: Backing up the light-client data fails currently, but the bug is unrelated to this PR and is solved in #1333. We can still merge this PR.