### PR TITLE
Fix backup of light-client db and introduce light-client-db subdirectory

### DIFF
--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -43,7 +43,7 @@ pub mod files {
 
 	// used by enclave
 	/// Path to the light-client db.
-	pub const LIGHT_CLIENT_DB_PATH: &str = "LIGHT_CLIENT_DB_PATH";
+	pub const LIGHT_CLIENT_DB_PATH: &str = "light_client_db";
 
 	pub const RA_DUMP_CERT_DER_FILE: &str = "ra_dump_cert.der";
 

--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -42,7 +42,8 @@ pub mod files {
 	pub static SIDECHAIN_PURGE_LIMIT: u64 = 100; // keep the last.. sidechainblocks when purging
 
 	// used by enclave
-	pub const LIGHT_CLIENT_DB: &str = "light_client_db.bin";
+	/// Path to the light-client db.
+	pub const LIGHT_CLIENT_DB_PATH: &str = "LIGHT_CLIENT_DB_PATH";
 
 	pub const RA_DUMP_CERT_DER_FILE: &str = "ra_dump_cert.der";
 

--- a/core/parentchain/light-client/src/io.rs
+++ b/core/parentchain/light-client/src/io.rs
@@ -49,13 +49,14 @@ pub struct LightClientStateSeal<B, LightClientState> {
 }
 
 impl<B, L> LightClientStateSeal<B, L> {
-	pub fn new(base_path: PathBuf) -> Self {
-		Self {
+	pub fn new(base_path: PathBuf) -> Result<Self> {
+		std::fs::create_dir_all(&base_path)?;
+		Ok(Self {
 			base_path: base_path.clone(),
 			db_path: base_path.clone().join(DB_FILE),
 			backup_path: base_path.join(BACKUP_FILE),
 			_phantom: Default::default(),
-		}
+		})
 	}
 
 	pub fn base_path(&self) -> &Path {
@@ -255,7 +256,7 @@ pub mod sgx_tests {
 	pub fn init_parachain_light_client_works() {
 		let parachain_params = default_simple_params();
 		let temp_dir = TempDir::with_prefix("init_parachain_light_client_works").unwrap();
-		let seal = TestSeal::new(temp_dir.path().to_path_buf());
+		let seal = TestSeal::new(temp_dir.path().to_path_buf()).unwrap();
 
 		let validator = read_or_init_parachain_validator::<TestBlock, OnchainMock, _>(
 			parachain_params.clone(),
@@ -276,7 +277,7 @@ pub mod sgx_tests {
 	pub fn sealing_creates_backup() {
 		let params = default_simple_params();
 		let temp_dir = TempDir::with_prefix("sealing_creates_backup").unwrap();
-		let seal = TestSeal::new(temp_dir.path().to_path_buf());
+		let seal = TestSeal::new(temp_dir.path().to_path_buf()).unwrap();
 		let state = RelayState::new(params.genesis_header, Default::default()).into();
 
 		seal.seal(&state).unwrap();

--- a/core/parentchain/light-client/src/io.rs
+++ b/core/parentchain/light-client/src/io.rs
@@ -72,7 +72,7 @@ impl<B, L> LightClientStateSeal<B, L> {
 
 	pub fn backup(&self) -> Result<()> {
 		if self.db_path().exists() {
-			let _bytes = fs::copy(self.db_path(), &self.backup_path())?;
+			let _bytes = fs::copy(self.db_path(), self.backup_path())?;
 		} else {
 			info!("{} does not exist yet, skipping backup...", self.db_path().display())
 		}

--- a/core/parentchain/light-client/src/light_validation_state.rs
+++ b/core/parentchain/light-client/src/light_validation_state.rs
@@ -23,7 +23,7 @@ use sp_runtime::traits::Block as ParentchainBlockTrait;
 
 pub use sp_finality_grandpa::SetId;
 
-#[derive(Encode, Decode, Clone, Debug)]
+#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
 pub struct LightValidationState<Block: ParentchainBlockTrait> {
 	pub(crate) relay_state: RelayState<Block>,
 }

--- a/core/parentchain/light-client/src/state.rs
+++ b/core/parentchain/light-client/src/state.rs
@@ -23,7 +23,7 @@ use sp_runtime::{
 };
 use std::{fmt, vec::Vec};
 
-#[derive(Encode, Decode, Clone, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
 pub struct RelayState<Block: BlockT> {
 	pub last_finalized_block_header: Block::Header,
 	pub penultimate_finalized_block_header: Block::Header,
@@ -35,7 +35,7 @@ pub struct RelayState<Block: BlockT> {
 	pub scheduled_change: Option<ScheduledChangeAtBlock<Block::Header>>, // Scheduled Authorities change as indicated in the header's digest.
 }
 
-#[derive(Encode, Decode, Clone, PartialEq)]
+#[derive(Encode, Decode, Clone, Eq, PartialEq)]
 pub struct ScheduledChangeAtBlock<Header: HeaderT> {
 	pub at_block: Header::Number,
 	pub next_authority_list: AuthorityList,

--- a/enclave-runtime/src/initialization/parentchain/parachain.rs
+++ b/enclave-runtime/src/initialization/parentchain/parachain.rs
@@ -63,7 +63,7 @@ impl FullParachainHandler {
 
 		let genesis_header = params.genesis_header.clone();
 
-		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB_PATH));
+		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB_PATH))?;
 		let validator = itc_parentchain::light_client::io::read_or_init_parachain_validator::<
 			ParachainBlock,
 			EnclaveOCallApi,

--- a/enclave-runtime/src/initialization/parentchain/parachain.rs
+++ b/enclave-runtime/src/initialization/parentchain/parachain.rs
@@ -34,7 +34,7 @@ use codec::Encode;
 use itc_parentchain::light_client::{concurrent_access::ValidatorAccess, LightClientState};
 use itp_component_container::{ComponentGetter, ComponentInitializer};
 use itp_settings::{
-	files::LIGHT_CLIENT_DB,
+	files::LIGHT_CLIENT_DB_PATH,
 	worker_mode::{ProvideWorkerMode, WorkerMode},
 };
 use std::{path::PathBuf, sync::Arc, vec::Vec};
@@ -63,7 +63,7 @@ impl FullParachainHandler {
 
 		let genesis_header = params.genesis_header.clone();
 
-		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB));
+		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB_PATH));
 		let validator = itc_parentchain::light_client::io::read_or_init_parachain_validator::<
 			ParachainBlock,
 			EnclaveOCallApi,

--- a/enclave-runtime/src/initialization/parentchain/solochain.rs
+++ b/enclave-runtime/src/initialization/parentchain/solochain.rs
@@ -62,7 +62,7 @@ impl FullSolochainHandler {
 
 		let genesis_header = params.genesis_header.clone();
 
-		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB_PATH));
+		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB_PATH))?;
 		let validator = itc_parentchain::light_client::io::read_or_init_grandpa_validator::<
 			SolochainBlock,
 			EnclaveOCallApi,

--- a/enclave-runtime/src/initialization/parentchain/solochain.rs
+++ b/enclave-runtime/src/initialization/parentchain/solochain.rs
@@ -34,7 +34,7 @@ use codec::Encode;
 use itc_parentchain::light_client::{concurrent_access::ValidatorAccess, LightClientState};
 use itp_component_container::{ComponentGetter, ComponentInitializer};
 use itp_settings::{
-	files::LIGHT_CLIENT_DB,
+	files::LIGHT_CLIENT_DB_PATH,
 	worker_mode::{ProvideWorkerMode, WorkerMode},
 };
 use std::{path::PathBuf, sync::Arc, vec::Vec};
@@ -62,7 +62,7 @@ impl FullSolochainHandler {
 
 		let genesis_header = params.genesis_header.clone();
 
-		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB));
+		let light_client_seal = EnclaveLightClientSeal::new(base_path.join(LIGHT_CLIENT_DB_PATH));
 		let validator = itc_parentchain::light_client::io::read_or_init_grandpa_validator::<
 			SolochainBlock,
 			EnclaveOCallApi,

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -163,6 +163,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 
 		// light-client-test
 		itc_parentchain::light_client::io::sgx_tests::init_parachain_light_client_works,
+		itc_parentchain::light_client::io::sgx_tests::sealing_creates_backup,
 
 		// these unit test (?) need an ipfs node running..
 		// ipfs::test_creates_ipfs_content_struct_works,

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -20,7 +20,7 @@ use crate::error::{Error, ServiceResult};
 use codec::Encode;
 use itp_enclave_api::{enclave_base::EnclaveBase, Enclave};
 use itp_settings::files::{
-	LAST_SLOT_BIN, LIGHT_CLIENT_DB, SHARDS_PATH, SHIELDING_KEY_FILE, SIDECHAIN_STORAGE_PATH,
+	LAST_SLOT_BIN, LIGHT_CLIENT_DB_PATH, SHARDS_PATH, SHIELDING_KEY_FILE, SIDECHAIN_STORAGE_PATH,
 	SIGNING_KEY_FILE,
 };
 use itp_types::ShardIdentifier;
@@ -98,7 +98,7 @@ fn purge_files(root_directory: &Path) -> ServiceResult<()> {
 	remove_dir_if_it_exists(root_directory, SIDECHAIN_STORAGE_PATH)?;
 
 	remove_file_if_it_exists(root_directory, LAST_SLOT_BIN)?;
-	remove_file_if_it_exists(root_directory, LIGHT_CLIENT_DB)?;
+	remove_file_if_it_exists(root_directory, LIGHT_CLIENT_DB_PATH)?;
 	remove_file_if_it_exists(root_directory, light_client_backup_file().as_str())?;
 
 	Ok(())
@@ -121,7 +121,7 @@ fn remove_file_if_it_exists(root_directory: &Path, file_name: &str) -> ServiceRe
 }
 
 fn light_client_backup_file() -> String {
-	format!("{}.1", LIGHT_CLIENT_DB)
+	format!("{}.1", LIGHT_CLIENT_DB_PATH)
 }
 
 #[cfg(test)]
@@ -148,7 +148,7 @@ mod tests {
 		fs::File::create(&sidechain_db_path.join("sidechain_db_3.bin")).unwrap();
 
 		fs::File::create(&root_directory.join(LAST_SLOT_BIN)).unwrap();
-		fs::File::create(&root_directory.join(LIGHT_CLIENT_DB)).unwrap();
+		fs::File::create(&root_directory.join(LIGHT_CLIENT_DB_PATH)).unwrap();
 		fs::File::create(&root_directory.join(light_client_backup_file())).unwrap();
 
 		purge_files(&root_directory).unwrap();
@@ -156,7 +156,7 @@ mod tests {
 		assert!(!shards_path.exists());
 		assert!(!sidechain_db_path.exists());
 		assert!(!root_directory.join(LAST_SLOT_BIN).exists());
-		assert!(!root_directory.join(LIGHT_CLIENT_DB).exists());
+		assert!(!root_directory.join(LIGHT_CLIENT_DB_PATH).exists());
 		assert!(!root_directory.join(light_client_backup_file()).exists());
 	}
 


### PR DESCRIPTION
This is a bug that was introduced with #1288.

The problem was that `self.path().join(".1")` actually added a subdirectory instead of appending ".1" to the file name, which made the backup fail, as the subdirectory did not exist.

Other change:
* All the light-client files live in the `LIGHT_CLIENT_DB_PATH` directory now, instead of being individual files in the top-level directory. I think it is better domain-specific files are grouped in the same subdirectory to simplify file-management.