### PR TITLE
Reregister Teeracle after a CLI configurable period

### DIFF
--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -101,5 +101,9 @@ pub mod enclave {}
 pub mod teeracle {
 	use core::time::Duration;
 	// Send extrinsic to update market exchange rate on the parentchain once per day
-	pub static DEFAULT_MARKET_DATA_UPDATE_INTERVAL: Duration = Duration::from_secs(86400);
+	pub static DEFAULT_MARKET_DATA_UPDATE_INTERVAL: Duration = ONE_DAY;
+
+	pub static ONE_DAY: Duration = Duration::from_secs(86400);
+
+	pub static THIRTY_MINUTES: Duration = Duration::from_secs(1800);
 }

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -114,6 +114,11 @@ subcommands:
                 short: i
                 help: Set the teeracle exchange rate update interval. Example of accepted syntax <5 seconds 15 minutes 2 hours 1 days> or short <5s15m2h1d>
                 takes_value: true
+            - reregister-teeracle-interval:
+                  required: false
+                  long: reregister
+                  help: Set the teeracle reregistration interval. Example of accepted syntax <5 seconds 15 minutes 2 hours 1 days> or short <5s15m2h1d>
+                  takes_value: true
     - request-state:
         about: join a shard by requesting key provisioning from another worker
         args:

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -115,10 +115,10 @@ subcommands:
                 help: Set the teeracle exchange rate update interval. Example of accepted syntax <5 seconds 15 minutes 2 hours 1 days> or short <5s15m2h1d>
                 takes_value: true
             - reregister-teeracle-interval:
-                  required: false
-                  long: reregister
-                  help: Set the teeracle reregistration interval. Example of accepted syntax <5 seconds 15 minutes 2 hours 1 days> or short <5s15m2h1d>
-                  takes_value: true
+                required: false
+                long: reregister
+                help: Set the teeracle reregistration interval. Example of accepted syntax <5 seconds 15 minutes 2 hours 1 days> or short <5s15m2h1d>
+                takes_value: true
     - request-state:
         about: join a shard by requesting key provisioning from another worker
         args:

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -17,7 +17,7 @@
 
 use clap::ArgMatches;
 use itc_rest_client::rest_client::Url;
-use itp_settings::teeracle::DEFAULT_MARKET_DATA_UPDATE_INTERVAL;
+use itp_settings::teeracle::{DEFAULT_MARKET_DATA_UPDATE_INTERVAL, ONE_DAY, THIRTY_MINUTES};
 use parse_duration::parse;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -225,6 +225,8 @@ pub struct RunConfig {
 	shard: Option<String>,
 	/// Optional teeracle update interval
 	teeracle_update_interval: Option<Duration>,
+	/// Optional teeracle reregistration interval
+	reregister_teeracle_interval: Option<Duration>,
 	/// Marblerun's Prometheus endpoint base URL
 	marblerun_base_url: Option<String>,
 }
@@ -250,6 +252,10 @@ impl RunConfig {
 		self.teeracle_update_interval.unwrap_or(DEFAULT_MARKET_DATA_UPDATE_INTERVAL)
 	}
 
+	pub fn reregister_teeracle_interval(&self) -> Duration {
+		self.reregister_teeracle_interval.unwrap_or(ONE_DAY - THIRTY_MINUTES)
+	}
+
 	pub fn marblerun_base_url(&self) -> &str {
 		// This conflicts with the default port of a substrate node, but it is indeed the
 		// default port of marblerun too:
@@ -267,13 +273,25 @@ impl From<&ArgMatches<'_>> for RunConfig {
 		let teeracle_update_interval = m.value_of("teeracle-interval").map(|i| {
 			parse(i).unwrap_or_else(|e| panic!("teeracle-interval parsing error {:?}", e))
 		});
+		let reregister_teeracle_interval = m.value_of("teeracle-interval").map(|i| {
+			parse(i).unwrap_or_else(|e| panic!("teeracle-interval parsing error {:?}", e))
+		});
+
 		let marblerun_base_url = m.value_of("marblerun-url").map(|i| {
 			Url::parse(i)
 				.unwrap_or_else(|e| panic!("marblerun-url parsing error: {:?}", e))
 				.to_string()
 		});
 
-		Self { skip_ra, dev, request_state, shard, teeracle_update_interval, marblerun_base_url }
+		Self {
+			skip_ra,
+			dev,
+			request_state,
+			shard,
+			teeracle_update_interval,
+			reregister_teeracle_interval,
+			marblerun_base_url,
+		}
 	}
 }
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -252,6 +252,10 @@ impl RunConfig {
 		self.teeracle_update_interval.unwrap_or(DEFAULT_MARKET_DATA_UPDATE_INTERVAL)
 	}
 
+	/// The periodic registration period of the teeracle.
+	///
+	/// Defaults to 23h30m, as this is slightly below the currently configured automatic
+	/// deregistration period on the Integritee chains.
 	pub fn reregister_teeracle_interval(&self) -> Duration {
 		self.reregister_teeracle_interval.unwrap_or(ONE_DAY - THIRTY_MINUTES)
 	}

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -273,7 +273,7 @@ impl From<&ArgMatches<'_>> for RunConfig {
 		let teeracle_update_interval = m.value_of("teeracle-interval").map(|i| {
 			parse(i).unwrap_or_else(|e| panic!("teeracle-interval parsing error {:?}", e))
 		});
-		let reregister_teeracle_interval = m.value_of("teeracle-interval").map(|i| {
+		let reregister_teeracle_interval = m.value_of("reregister-teeracle-interval").map(|i| {
 			parse(i).unwrap_or_else(|e| panic!("teeracle-interval parsing error {:?}", e))
 		});
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -257,6 +257,7 @@ impl RunConfig {
 	/// Defaults to 23h30m, as this is slightly below the currently configured automatic
 	/// deregistration period on the Integritee chains.
 	pub fn reregister_teeracle_interval(&self) -> Duration {
+		// Todo: Derive this from chain https://github.com/integritee-network/worker/issues/1351
 		self.reregister_teeracle_interval.unwrap_or(ONE_DAY - THIRTY_MINUTES)
 	}
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -78,7 +78,7 @@ use substrate_api_client::{
 #[cfg(feature = "dcap")]
 use sgx_verify::extract_tcb_info_from_raw_dcap_quote;
 
-use crate::teeracle::interval_scheduling::schedule_on_repeating_intervals;
+use crate::teeracle::schedule_teeracle_reregistration;
 use sp_core::crypto::{AccountId32, Ss58Codec};
 use sp_keyring::AccountKeyring;
 use sp_runtime::traits::Header as HeaderTrait;
@@ -474,12 +474,8 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	// initialize teeracle interval
 	#[cfg(feature = "teeracle")]
 	if WorkerModeProvider::worker_mode() == WorkerMode::Teeracle {
-		schedule_on_repeating_intervals(
-			|| {
-				if let None = send_register_xt() {
-					error!("Could not re-register the teeracle")
-				}
-			},
+		schedule_teeracle_reregistration(
+			send_register_xt,
 			run_config.reregister_teeracle_interval(),
 		);
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(feature = "teeracle")]
-use crate::teeracle::{schedule_teeracle_reregistration_thread, start_periodic_market_update};
+use crate::teeracle::{schedule_periodic_reregistration_thread, start_periodic_market_update};
 
 #[cfg(not(feature = "dcap"))]
 use crate::utils::check_files;
@@ -478,7 +478,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	// initialize teeracle interval
 	#[cfg(feature = "teeracle")]
 	if WorkerModeProvider::worker_mode() == WorkerMode::Teeracle {
-		schedule_teeracle_reregistration_thread(
+		schedule_periodic_reregistration_thread(
 			send_register_xt,
 			run_config.reregister_teeracle_interval(),
 		);

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -78,6 +78,7 @@ use substrate_api_client::{
 #[cfg(feature = "dcap")]
 use sgx_verify::extract_tcb_info_from_raw_dcap_quote;
 
+#[cfg(feature = "teeracle")]
 use crate::teeracle::schedule_teeracle_reregistration;
 use sp_core::crypto::{AccountId32, Ss58Codec};
 use sp_keyring::AccountKeyring;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -450,7 +450,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	let enclave2 = enclave.clone();
 	let node_api2 = node_api.clone();
 	#[cfg(not(feature = "dcap"))]
-	let register_xt = move || enclave_2.generate_ias_ra_extrinsic(&trusted_url, skip_ra).unwrap();
+	let register_xt = move || enclave2.generate_ias_ra_extrinsic(&trusted_url, skip_ra).unwrap();
 	#[cfg(feature = "dcap")]
 	let register_xt = move || enclave2.generate_dcap_ra_extrinsic(&trusted_url, skip_ra).unwrap();
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(feature = "teeracle")]
-use crate::teeracle::start_interval_market_update;
+use crate::teeracle::{schedule_teeracle_reregistration_thread, start_interval_market_update};
 
 #[cfg(not(feature = "dcap"))]
 use crate::utils::check_files;
@@ -78,8 +78,6 @@ use substrate_api_client::{
 #[cfg(feature = "dcap")]
 use sgx_verify::extract_tcb_info_from_raw_dcap_quote;
 
-#[cfg(feature = "teeracle")]
-use crate::teeracle::schedule_teeracle_reregistration;
 use sp_core::crypto::{AccountId32, Ss58Codec};
 use sp_keyring::AccountKeyring;
 use sp_runtime::traits::Header as HeaderTrait;

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -18,7 +18,7 @@
 #![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(feature = "teeracle")]
-use crate::teeracle::{schedule_teeracle_reregistration_thread, start_interval_market_update};
+use crate::teeracle::{schedule_teeracle_reregistration_thread, start_periodic_market_update};
 
 #[cfg(not(feature = "dcap"))]
 use crate::utils::check_files;
@@ -483,7 +483,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 			run_config.reregister_teeracle_interval(),
 		);
 
-		start_interval_market_update(
+		start_periodic_market_update(
 			&node_api,
 			run_config.teeracle_update_interval(),
 			enclave.as_ref(),

--- a/service/src/teeracle/interval_scheduling.rs
+++ b/service/src/teeracle/interval_scheduling.rs
@@ -25,7 +25,7 @@ use std::{
 /// In case the task takes longer than is scheduled by the interval duration,
 /// the interval timing will drift. The task is responsible for
 /// ensuring it does not use up more time than is scheduled.
-pub(super) fn schedule_on_repeating_intervals<T>(task: T, interval_duration: Duration)
+pub fn schedule_on_repeating_intervals<T>(task: T, interval_duration: Duration)
 where
 	T: Fn(),
 {

--- a/service/src/teeracle/interval_scheduling.rs
+++ b/service/src/teeracle/interval_scheduling.rs
@@ -25,7 +25,7 @@ use std::{
 /// In case the task takes longer than is scheduled by the interval duration,
 /// the interval timing will drift. The task is responsible for
 /// ensuring it does not use up more time than is scheduled.
-pub fn schedule_on_repeating_intervals<T>(task: T, interval_duration: Duration)
+pub(super) fn schedule_on_repeating_intervals<T>(task: T, interval_duration: Duration)
 where
 	T: Fn(),
 {

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -43,8 +43,11 @@ pub(crate) fn schedule_teeracle_reregistration_thread(
 			schedule_on_repeating_intervals(
 				|| {
 					println!("Reregistering the teeracle.");
-					if let Some(_block_hash) = send_register_xt() {
-						println!("Successfully reregistered the teeracle. ")
+					if let Some(block_hash) = send_register_xt() {
+						println!(
+							"Successfully reregistered the teeracle. Block hash {}",
+							block_hash
+						)
 					} else {
 						error!("Could not reregister the teeracle")
 					}

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -42,7 +42,7 @@ pub(crate) fn schedule_teeracle_reregistration_thread(
 		.spawn(move || {
 			schedule_on_repeating_intervals(
 				|| {
-					println!("Re-registering the teeracle.");
+					println!("Reregistering the teeracle.");
 					if let Some(_block_hash) = send_register_xt() {
 						println!("Successfully reregistered the teeracle. ")
 					} else {

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -43,8 +43,10 @@ pub(crate) fn schedule_teeracle_reregistration_thread(
 			schedule_on_repeating_intervals(
 				|| {
 					println!("Re-registering the teeracle.");
-					if let None = send_register_xt() {
-						error!("Could not re-register the teeracle")
+					if let Some(_block_hash) = send_register_xt() {
+						println!("Successfully reregistered the teeracle. ")
+					} else {
+						error!("Could not reregister the teeracle")
 					}
 				},
 				interval,

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -15,10 +15,7 @@
 
 */
 
-use crate::{
-	error::{Error, ServiceResult},
-	teeracle::interval_scheduling::schedule_on_repeating_intervals,
-};
+use crate::{error::ServiceResult, teeracle::interval_scheduling::schedule_on_repeating_intervals};
 use codec::{Decode, Encode};
 use itp_enclave_api::teeracle_api::TeeracleApi;
 use itp_node_api::api_client::ParentchainApi;
@@ -73,7 +70,7 @@ where
 {
 	let oracle_xt = get_oracle_xt().map_err(|e| {
 		increment_number_of_request_failures();
-		Error::Custom(format!("{:?}", e).into())
+		e
 	})?;
 
 	let extrinsics = <Vec<OpaqueExtrinsic>>::decode(&mut oracle_xt.as_slice())?;

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -15,7 +15,10 @@
 
 */
 
-use crate::teeracle::interval_scheduling::schedule_on_repeating_intervals;
+use crate::{
+	error::{Error, ServiceResult},
+	teeracle::interval_scheduling::schedule_on_repeating_intervals,
+};
 use codec::{Decode, Encode};
 use itp_enclave_api::teeracle_api::TeeracleApi;
 use itp_node_api::api_client::ParentchainApi;
@@ -39,7 +42,10 @@ pub(crate) fn start_interval_market_update<E: TeeracleApi>(
 	tokio_handle: &Handle,
 ) {
 	let updates_to_run = || {
-		execute_market_update(api, enclave_api, tokio_handle);
+		if let Err(e) = execute_market_update(api, enclave_api, tokio_handle) {
+			error!("Error running teeracle update {:?}", e)
+		}
+
 		// TODO: Refactor and add this back according to ISSUE: https://github.com/integritee-network/worker/issues/1300
 		// execute_weather_update(api, enclave_api, tokio_handle);
 	};
@@ -55,23 +61,13 @@ fn execute_weather_update<E: TeeracleApi>(
 	node_api: &ParentchainApi,
 	enclave: &E,
 	tokio_handle: &Handle,
-) {
-	let updated_extrinsic = match enclave.update_weather_data_xt("54.32", "15.37") {
-		Err(e) => {
-			error!("{:?}", e);
-			increment_number_of_request_failures();
-			return
-		},
-		Ok(r) => r,
-	};
+) -> ServiceResult<()> {
+	let updated_extrinsic = enclave.update_weather_data_xt("54.32", "15.37").map_err(|e| {
+		increment_number_of_request_failures();
+		Error::Custom(format!("{:?}", e).into())
+	})?;
 
-	let extrinsics = match <Vec<OpaqueExtrinsic>>::decode(&mut updated_extrinsic.as_slice()) {
-		Ok(calls) => calls,
-		Err(e) => {
-			error!("Failed to decode opaque extrinsics(s): {:?}: ", e);
-			return
-		},
-	};
+	let extrinsics = <Vec<OpaqueExtrinsic>>::decode(&mut updated_extrinsic.as_slice())?;
 
 	extrinsics.into_iter().for_each(|call| {
 		let node_api_clone = node_api.clone();
@@ -96,30 +92,22 @@ fn execute_weather_update<E: TeeracleApi>(
 			println!("[<] Extrinsic got included into a block. Hash: {:?}\n", extrinsic_hash);
 		});
 	});
+
+	Ok(())
 }
 
 fn execute_market_update<E: TeeracleApi>(
 	node_api: &ParentchainApi,
 	enclave: &E,
 	tokio_handle: &Handle,
-) {
+) -> ServiceResult<()> {
 	// Get market data for usd (hardcoded)
-	let updated_extrinsic = match enclave.update_market_data_xt("TEER", "USD") {
-		Err(e) => {
-			error!("{:?}", e);
-			increment_number_of_request_failures();
-			return
-		},
-		Ok(r) => r,
-	};
+	let updated_extrinsic = enclave.update_market_data_xt("TEER", "USD").map_err(|e| {
+		increment_number_of_request_failures();
+		Error::Custom(format!("{:?}", e).into())
+	})?;
 
-	let extrinsics: Vec<OpaqueExtrinsic> = match Decode::decode(&mut updated_extrinsic.as_slice()) {
-		Ok(calls) => calls,
-		Err(e) => {
-			error!("Failed to decode opaque extrinsic(s): {:?}: ", e);
-			return
-		},
-	};
+	let extrinsics = <Vec<OpaqueExtrinsic>>::decode(&mut updated_extrinsic.as_slice())?;
 
 	// Send the extrinsics to the parentchain and wait for InBlock confirmation.
 	for call in extrinsics.into_iter() {
@@ -147,4 +135,6 @@ fn execute_market_update<E: TeeracleApi>(
 			println!("[<] Extrinsic got included into a block. Hash: {:?}\n", extrinsic_hash);
 		});
 	}
+
+	Ok(())
 }

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -49,14 +49,12 @@ pub(crate) fn start_interval_market_update<E: TeeracleApi>(
 			error!("Error running market update {:?}", e)
 		}
 
-		if let Err(e) = execute_oracle_update(api, tokio_handle, || {
-			enclave_api.update_weather_data_xt("54.32", "15.37")
-		}) {
-			error!("Error running weather update {:?}", e)
-		}
-
 		// TODO: Refactor and add this back according to ISSUE: https://github.com/integritee-network/worker/issues/1300
-		// execute_weather_update(api, enclave_api, tokio_handle);
+		// if let Err(e) = execute_oracle_update(api, tokio_handle, || {
+		// 	enclave_api.update_weather_data_xt("54.32", "15.37")
+		// }) {
+		// 	error!("Error running weather update {:?}", e)
+		// }
 	};
 	info!("Teeracle will update now");
 	updates_to_run();

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -49,11 +49,14 @@ pub(crate) fn schedule_periodic_reregistration_thread(
 		.spawn(move || {
 			schedule_periodic(
 				|| {
-					println!("Reregistering the teeracle.");
+					trace!("Reregistering the enclave.");
 					if let Some(block_hash) = send_register_xt() {
-						println!("Successfully reregistered the enclave. Block hash {}", block_hash)
+						println!(
+							"✅ Successfully reregistered the enclave. Block hash: {}.",
+							block_hash
+						)
 					} else {
-						error!("Could not reregister the enclave")
+						error!("❌ Could not reregister the enclave.")
 					}
 				},
 				period,

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -38,7 +38,7 @@ pub(crate) fn schedule_teeracle_reregistration_thread(
 	println!("Schedule the teeracle reregistration every: {:?}", interval);
 
 	std::thread::Builder::new()
-		.name("parentchain_sync_loop".to_owned())
+		.name("teeracle_reregistration_thread".to_owned())
 		.spawn(move || {
 			schedule_on_repeating_intervals(
 				|| {

--- a/service/src/teeracle/schedule_periodic.rs
+++ b/service/src/teeracle/schedule_periodic.rs
@@ -20,12 +20,12 @@ use std::{
 	time::{Duration, Instant},
 };
 
-/// Schedules a task on perpetually looping intervals.
+/// Schedules a periodic task in the current thread.
 ///
 /// In case the task takes longer than is scheduled by the interval duration,
 /// the interval timing will drift. The task is responsible for
 /// ensuring it does not use up more time than is scheduled.
-pub(super) fn schedule_on_repeating_intervals<T>(task: T, interval_duration: Duration)
+pub(super) fn schedule_periodic<T>(task: T, period: Duration)
 where
 	T: Fn(),
 {
@@ -33,13 +33,13 @@ where
 	loop {
 		let elapsed = interval_start.elapsed();
 
-		if elapsed >= interval_duration {
+		if elapsed >= period {
 			// update interval time
 			interval_start = Instant::now();
 			task();
 		} else {
 			// sleep for the rest of the interval
-			let sleep_time = interval_duration - elapsed;
+			let sleep_time = period - elapsed;
 			thread::sleep(sleep_time);
 		}
 	}


### PR DESCRIPTION
* Closes #1344 

Reregistration can be configured with `--regegister 10s` for instance. The allowed values for the time interval are the same as for the `teeracle-update-interval`.