### PR TITLE
[integritee-service] introduce getters for `RunConfig` and make fields private

### DIFF
--- a/core-primitives/settings/src/lib.rs
+++ b/core-primitives/settings/src/lib.rs
@@ -98,7 +98,6 @@ pub mod sidechain {
 pub mod enclave {}
 
 /// Settings for the Teeracle
-#[cfg(feature = "teeracle")]
 pub mod teeracle {
 	use core::time::Duration;
 	// Send extrinsic to update market exchange rate on the parentchain once per day

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -17,6 +17,7 @@
 
 use clap::ArgMatches;
 use itc_rest_client::rest_client::Url;
+use itp_settings::teeracle::DEFAULT_MARKET_DATA_UPDATE_INTERVAL;
 use parse_duration::parse;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -215,17 +216,46 @@ impl From<&ArgMatches<'_>> for Config {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RunConfig {
 	/// Skip remote attestation. Set this flag if running enclave in SW mode
-	pub skip_ra: bool,
+	skip_ra: bool,
 	/// Set this flag if running in development mode to bootstrap enclave account on parentchain via //Alice.
-	pub dev: bool,
+	dev: bool,
 	/// Request key and state provisioning from a peer worker.
-	pub request_state: bool,
+	request_state: bool,
 	/// Shard identifier base58 encoded. Defines the shard that this worker operates on. Default is mrenclave.
-	pub shard: Option<String>,
+	shard: Option<String>,
 	/// Optional teeracle update interval
-	pub teeracle_update_interval: Option<Duration>,
+	teeracle_update_interval: Option<Duration>,
 	/// Marblerun's Prometheus endpoint base URL
-	pub marblerun_base_url: Option<String>,
+	marblerun_base_url: Option<String>,
+}
+
+impl RunConfig {
+	pub fn skip_ra(&self) -> bool {
+		self.skip_ra
+	}
+
+	pub fn dev(&self) -> bool {
+		self.dev
+	}
+
+	pub fn request_state(&self) -> bool {
+		self.request_state
+	}
+
+	pub fn shard(&self) -> Option<&str> {
+		self.shard.as_ref().map(|s| s.as_str())
+	}
+
+	pub fn teeracle_update_interval(&self) -> Duration {
+		self.teeracle_update_interval.unwrap_or(DEFAULT_MARKET_DATA_UPDATE_INTERVAL)
+	}
+
+	pub fn marblerun_base_url(&self) -> &str {
+		self.marblerun_base_url
+			.as_ref()
+			.map(|s| s.as_str())
+			.unwrap_or("http://localhost:9944")
+	}
 }
 
 impl From<&ArgMatches<'_>> for RunConfig {

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -243,7 +243,7 @@ impl RunConfig {
 	}
 
 	pub fn shard(&self) -> Option<&str> {
-		self.shard.as_ref().map(|s| s.as_str())
+		self.shard.as_deref()
 	}
 
 	pub fn teeracle_update_interval(&self) -> Duration {
@@ -251,10 +251,7 @@ impl RunConfig {
 	}
 
 	pub fn marblerun_base_url(&self) -> &str {
-		self.marblerun_base_url
-			.as_ref()
-			.map(|s| s.as_str())
-			.unwrap_or("http://localhost:9944")
+		self.marblerun_base_url.as_deref().unwrap_or("http://localhost:9944")
 	}
 }
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -251,6 +251,9 @@ impl RunConfig {
 	}
 
 	pub fn marblerun_base_url(&self) -> &str {
+		// This conflicts with the default port of a substrate node, but it is indeed the
+		// default port of marblerun too:
+		// https://github.com/edgelesssys/marblerun/blob/master/docs/docs/workflows/monitoring.md?plain=1#L26
 		self.marblerun_base_url.as_deref().unwrap_or("http://localhost:9944")
 	}
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -175,7 +175,7 @@ fn main() {
 	)));
 
 	if let Some(run_config) = config.run_config() {
-		let shard = extract_shard(&run_config.shard, enclave.as_ref());
+		let shard = extract_shard(run_config.shard(), enclave.as_ref());
 
 		println!("Worker Config: {:?}", config);
 
@@ -186,12 +186,12 @@ fn main() {
 		let node_api =
 			node_api_factory.create_api().expect("Failed to create parentchain node API");
 
-		if run_config.request_state {
+		if run_config.request_state() {
 			sync_state::sync_state::<_, _, WorkerModeProvider>(
 				&node_api,
 				&shard,
 				enclave.as_ref(),
-				run_config.skip_ra,
+				run_config.skip_ra(),
 			);
 		}
 
@@ -210,7 +210,7 @@ fn main() {
 			node_api_factory.create_api().expect("Failed to create parentchain node API");
 		sync_state::sync_state::<_, _, WorkerModeProvider>(
 			&node_api,
-			&extract_shard(&smatches.value_of("shard").map(|s| s.to_string()), enclave.as_ref()),
+			&extract_shard(smatches.value_of("shard"), enclave.as_ref()),
 			enclave.as_ref(),
 			smatches.is_present("skip-ra"),
 		);
@@ -235,7 +235,7 @@ fn main() {
 	} else if let Some(sub_matches) = matches.subcommand_matches("init-shard") {
 		setup::init_shard(
 			enclave.as_ref(),
-			&extract_shard(&sub_matches.value_of("shard").map(|s| s.to_string()), enclave.as_ref()),
+			&extract_shard(sub_matches.value_of("shard"), enclave.as_ref()),
 		);
 	} else if let Some(sub_matches) = matches.subcommand_matches("test") {
 		if sub_matches.is_present("provisioning-server") {
@@ -249,10 +249,7 @@ fn main() {
 			println!("[+] Done!");
 		} else if sub_matches.is_present("provisioning-client") {
 			println!("*** Running Enclave MU-RA TLS client\n");
-			let shard = extract_shard(
-				&sub_matches.value_of("shard").map(|s| s.to_string()),
-				enclave.as_ref(),
-			);
+			let shard = extract_shard(sub_matches.value_of("shard"), enclave.as_ref());
 			enclave_request_state_provisioning(
 				enclave.as_ref(),
 				sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
@@ -294,7 +291,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	WorkerModeProvider: ProvideWorkerMode,
 {
 	let run_config = config.run_config().clone().expect("Run config missing");
-	let skip_ra = run_config.skip_ra;
+	let skip_ra = run_config.skip_ra();
 
 	println!("Integritee Worker v{}", VERSION);
 	info!("starting worker on shard {}", shard.encode().to_base58());
@@ -313,7 +310,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	// ------------------------------------------------------------------------
 	// let new workers call us for key provisioning
 	println!("MU-RA server listening on {}", config.mu_ra_url());
-	let is_development_mode = run_config.dev;
+	let is_development_mode = run_config.dev();
 	let ra_url = config.mu_ra_url();
 	let enclave_api_key_prov = enclave.clone();
 	thread::spawn(move || {
@@ -478,7 +475,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	if WorkerModeProvider::worker_mode() == WorkerMode::Teeracle {
 		start_interval_market_update(
 			&node_api,
-			run_config.teeracle_update_interval,
+			run_config.teeracle_update_interval(),
 			enclave.as_ref(),
 			&teeracle_tokio_handle,
 		);

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -424,9 +424,6 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	register_collateral(&node_api, &*enclave, &tee_accountid, is_development_mode, skip_ra);
 
 	let trusted_url = config.trusted_worker_url_external();
-	#[cfg(feature = "attesteer")]
-	let marblerun_base_url =
-		run_config.marblerun_base_url.unwrap_or("http://localhost:9944".to_owned());
 
 	#[cfg(feature = "attesteer")]
 	fetch_marblerun_events_every_hour(
@@ -435,7 +432,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		tee_accountid.clone(),
 		is_development_mode,
 		trusted_url.clone(),
-		marblerun_base_url.clone(),
+		run_config.marblerun_base_url().to_string(),
 	);
 
 	// ------------------------------------------------------------------------
@@ -709,7 +706,7 @@ fn fetch_marblerun_events_every_hour<E>(
 				&accountid,
 				is_development_mode,
 				url.clone(),
-				marblerun_base_url.clone(),
+				&marblerun_base_url,
 			);
 
 			thread::sleep(Duration::from_secs(POLL_INTERVAL_5_MINUTES_IN_SECS));
@@ -725,10 +722,10 @@ fn register_quotes_from_marblerun(
 	accountid: &AccountId32,
 	is_development_mode: bool,
 	url: String,
-	marblerun_base_url: String,
+	marblerun_base_url: &str,
 ) {
 	let enclave = enclave.as_ref();
-	let events = prometheus_metrics::fetch_marblerun_events(&marblerun_base_url)
+	let events = prometheus_metrics::fetch_marblerun_events(marblerun_base_url)
 		.map_err(|e| {
 			info!("Fetching events from Marblerun failed with: {:?}, continuing with 0 events.", e);
 		})

--- a/service/src/teeracle/mod.rs
+++ b/service/src/teeracle/mod.rs
@@ -19,7 +19,6 @@ use crate::teeracle::interval_scheduling::schedule_on_repeating_intervals;
 use codec::{Decode, Encode};
 use itp_enclave_api::teeracle_api::TeeracleApi;
 use itp_node_api::api_client::ParentchainApi;
-use itp_settings::teeracle::DEFAULT_MARKET_DATA_UPDATE_INTERVAL;
 use itp_utils::hex::hex_encode;
 use log::*;
 use sp_runtime::OpaqueExtrinsic;
@@ -35,7 +34,7 @@ pub(crate) mod teeracle_metrics;
 /// with the current market data (for now only exchange rate).
 pub(crate) fn start_interval_market_update<E: TeeracleApi>(
 	api: &ParentchainApi,
-	maybe_interval: Option<Duration>,
+	interval: Duration,
 	enclave_api: &E,
 	tokio_handle: &Handle,
 ) {
@@ -47,7 +46,6 @@ pub(crate) fn start_interval_market_update<E: TeeracleApi>(
 	info!("Teeracle will update now");
 	updates_to_run();
 
-	let interval = maybe_interval.unwrap_or(DEFAULT_MARKET_DATA_UPDATE_INTERVAL);
 	info!("Starting teeracle interval for oracle update, interval of {:?}", interval);
 	schedule_on_repeating_intervals(updates_to_run, interval);
 }

--- a/service/src/utils.rs
+++ b/service/src/utils.rs
@@ -22,7 +22,7 @@ use itp_types::ShardIdentifier;
 use log::info;
 
 pub fn extract_shard<E: EnclaveBase>(
-	maybe_shard_str: &Option<String>,
+	maybe_shard_str: Option<&str>,
 	enclave_api: &E,
 ) -> ShardIdentifier {
 	match maybe_shard_str {


### PR DESCRIPTION
This pattern allows us to simplify default values and to coerce the fields into more ergonomic types.