### PR TITLE
Intermediate release won't make SDK release

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -507,6 +507,7 @@ jobs:
           body: |
             ${{ steps.Changelog.outputs.changelog }}
           draft: true
+          name: Docker ${{ github.ref_name }}
           files: |
             integritee-worker-teeracle-${{ github.ref_name }}.tar.gz
             integritee-client

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -3,7 +3,7 @@ name: Release - Publish draft
 on:
   push:
     tags:
-      # Catches v1.2.3 and v1.2.3
+      # Catches only v1.2.3 (-dev,-rc1 etc won't be released as SDK)
       - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -3,8 +3,8 @@ name: Release - Publish draft
 on:
   push:
     tags:
-      # Catches v1.2.3 and v1.2.3-rc1
-      - v[0-9]+.[0-9]+.[0-9]+*
+      # Catches v1.2.3 and v1.2.3
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   publish-draft-release:


### PR DESCRIPTION
We have decided to have 2 release functions
1. If the tag pattern is v[0-9]+.[0-9]+.[0-9]+ than it is an official release we publish both SDK and Docker releases
2. In case of any other: v[0-9]+.[0-9]+.[0-9]+-dev it will create a Docker release only.