### PR TITLE
CI: fix concurrent cache access

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -68,9 +68,9 @@ WORKDIR $WORKHOME/worker
 
 COPY . .
 
-RUN --mount=type=cache,id=cargo-registry-cache,target=/opt/rust/registry/cache \
-    --mount=type=cache,id=cargo-registry-index,target=/opt/rust/registry/index \
-	--mount=type=cache,id=cargo-git,target=/opt/rust/git/db \
+RUN --mount=type=cache,id=cargo-registry-cache,target=/opt/rust/registry/cache,sharing=private \
+	--mount=type=cache,id=cargo-registry-index,target=/opt/rust/registry/index,sharing=private \
+	--mount=type=cache,id=cargo-git,target=/opt/rust/git/db,sharing=private \
 	--mount=type=cache,id=cargo-sccache-${WORKER_MODE}${ADDITIONAL_FEATURES},target=/home/ubuntu/.cache/sccache \
 	echo ${FINGERPRINT} && make && make identity && cargo test --release && sccache --show-stats
 


### PR DESCRIPTION
Sometimes the CI would fail with errors that resemble race conditions (e.g. some state was expected, but another was found), this should take care of it.

>  `sharing`: One of `shared`, `private`, or `locked`. Defaults to `shared`. A `shared` cache mount can be used concurrently by multiple writers. `private` creates a new mount if there are multiple writers. `locked` pauses the second writer until the first one releases the mount.
