### PR TITLE
[WIP] attesteer: fix marblerun quote decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 dependencies = [
  "lazy_static",
- "regex 1.8.1",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -18,7 +18,7 @@ version = "0.2.3"
 source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.39#d872c2ca4328a30222e4d470c8fc4921abad9f34"
 dependencies = [
  "ac-primitives",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-application-crypto",
  "sp-core",
@@ -36,10 +36,10 @@ dependencies = [
  "either",
  "frame-metadata 15.1.0 (git+https://github.com/paritytech/frame-metadata)",
  "hex",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sp-application-crypto",
  "sp-core",
@@ -62,7 +62,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sp-core",
  "sp-runtime",
@@ -85,7 +85,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli 0.27.2",
+ "gimli 0.27.3",
 ]
 
 [[package]]
@@ -131,8 +131,8 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.9",
- "once_cell 1.17.1",
+ "getrandom 0.2.10",
+ "once_cell 1.18.0",
  "version_check",
 ]
 
@@ -143,8 +143,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if 1.0.0",
- "getrandom 0.2.9",
- "once_cell 1.17.1",
+ "getrandom 0.2.10",
+ "once_cell 1.18.0",
  "version_check",
 ]
 
@@ -159,12 +159,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr 2.5.0",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -234,9 +240,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
 
 [[package]]
 name = "async-trait"
@@ -246,7 +252,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -298,7 +304,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide 0.6.2",
- "object 0.30.3",
+ "object 0.30.4",
  "rustc-demangle",
 ]
 
@@ -346,9 +352,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "base64ct"
@@ -362,7 +368,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -371,7 +377,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log 0.4.19",
 ]
 
 [[package]]
@@ -380,7 +386,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -397,7 +403,7 @@ dependencies = [
  "peeking_take_while",
  "proc-macro2",
  "quote",
- "regex 1.8.1",
+ "regex 1.8.4",
  "rustc-hash",
  "shlex",
 ]
@@ -432,7 +438,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -496,14 +502,14 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbd1d11282a1eb134d3c3b7cf8ce213b5161c6e5f73fb1b98618482c606b64"
+checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
 dependencies = [
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -514,12 +520,12 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr 2.5.0",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -533,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byte-slice-cast"
@@ -605,7 +611,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -614,7 +620,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -626,7 +632,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.17",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "thiserror 1.0.40",
 ]
@@ -682,15 +688,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer 0.1.45",
  "num-traits 0.2.15",
- "serde 1.0.163",
+ "serde 1.0.164",
  "time",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -713,7 +719,7 @@ dependencies = [
  "parity-scale-codec",
  "rustc-hex",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
  "sp-std",
@@ -757,7 +763,7 @@ dependencies = [
  "clap_derive",
  "clap_lex",
  "indexmap 1.9.3",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.16.0",
@@ -876,7 +882,7 @@ version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42ea692c7b450ad18b8c9889661505d51c09ec4380cf1c2d278dbb2da22cae1"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -911,22 +917,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.14"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1016,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+checksum = "e88abab2f5abbe4c56e8f1fb431b784d710b709888f35755a160e62e33fe38e8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1028,41 +1034,41 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+checksum = "5c0c11acd0e63bae27dcd2afced407063312771212b7a823b4fd72d633be30fb"
 dependencies = [
  "cc",
  "codespan-reporting",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+checksum = "8d3816ed957c008ccd4728485511e3d9aaf7db419aa321e3d2c5a2f3411e36c8"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.94"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+checksum = "a26acccf6f445af85ea056362561a24ef56cdc15fcc685f03aec50b9c702cb6d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
 
 [[package]]
 name = "der"
@@ -1147,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common",
@@ -1277,7 +1283,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.6",
+ "digest 0.10.7",
  "ff",
  "generic-array 0.14.7",
  "group",
@@ -1304,8 +1310,8 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.17",
- "regex 1.8.1",
+ "log 0.4.19",
+ "regex 1.8.4",
  "termcolor",
 ]
 
@@ -1317,8 +1323,8 @@ checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
  "humantime",
  "is-terminal",
- "log 0.4.17",
- "regex 1.8.1",
+ "log 0.4.19",
+ "regex 1.8.4",
  "termcolor",
 ]
 
@@ -1384,7 +1390,7 @@ dependencies = [
  "parity-scale-codec",
  "rlp",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sha3",
  "triehash",
 ]
@@ -1417,12 +1423,12 @@ dependencies = [
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "primitive-types",
  "rlp",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sha3",
 ]
 
@@ -1435,7 +1441,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -1537,7 +1543,7 @@ dependencies = [
  "either",
  "futures 0.3.28",
  "futures-timer",
- "log 0.4.17",
+ "log 0.4.19",
  "num-traits 0.2.15",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -1620,11 +1626,11 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
- "percent-encoding 2.2.0",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -1635,10 +1641,10 @@ dependencies = [
  "hex",
  "impl-serde",
  "libsecp256k1",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -1653,7 +1659,7 @@ dependencies = [
  "evm",
  "frame-support",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -1674,11 +1680,11 @@ dependencies = [
  "frame-support-procedural",
  "frame-system",
  "linregress",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "paste",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -1743,18 +1749,18 @@ dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
 name = "frame-metadata"
 version = "15.1.0"
-source = "git+https://github.com/paritytech/frame-metadata#438a5b098bb9d5b5a09bdc5b68275b2c5e63a010"
+source = "git+https://github.com/paritytech/frame-metadata#d6e6c2bf820bd2067aadd7420f361cacaddbb09e"
 dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -1767,12 +1773,12 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log 0.4.17",
- "once_cell 1.17.1",
+ "log 0.4.19",
+ "once_cell 1.18.0",
  "parity-scale-codec",
  "paste",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "smallvec 1.10.0",
  "sp-api",
  "sp-arithmetic",
@@ -1832,10 +1838,10 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "frame-support",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -2010,7 +2016,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -2135,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -2156,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -2175,8 +2181,8 @@ dependencies = [
  "aho-corasick 0.7.20",
  "bstr",
  "fnv 1.0.7",
- "log 0.4.17",
- "regex 1.8.1",
+ "log 0.4.19",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -2257,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "hashbrown_tstd"
 version = "0.12.0"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 
 [[package]]
 name = "hdrhistogram"
@@ -2366,7 +2372,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2418,7 +2424,7 @@ name = "http_req"
 version = "0.8.1"
 source = "git+https://github.com/integritee-network/http_req?branch=master#3723e88235f2b29bc1a31835853b072ffd0455fd"
 dependencies = [
- "log 0.4.17",
+ "log 0.4.19",
  "rustls 0.19.1",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2430,7 +2436,7 @@ name = "http_req"
 version = "0.8.1"
 source = "git+https://github.com/integritee-network/http_req#3723e88235f2b29bc1a31835853b072ffd0455fd"
 dependencies = [
- "log 0.4.17",
+ "log 0.4.19",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
  "sgx_tstd",
  "unicase 2.6.0 (git+https://github.com/mesalock-linux/unicase-sgx)",
@@ -2510,7 +2516,7 @@ dependencies = [
  "ct-logs",
  "futures-util 0.3.28",
  "hyper",
- "log 0.4.17",
+ "log 0.4.19",
  "rustls 0.19.1",
  "rustls-native-certs",
  "tokio",
@@ -2533,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2567,9 +2573,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi 0.3.13",
  "unicode-normalization 0.1.22",
@@ -2599,7 +2605,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -2631,7 +2637,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -2665,7 +2671,7 @@ dependencies = [
  "array-bytes 6.1.0",
  "base58",
  "blake2-rfc",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "clap 3.2.25",
  "env_logger 0.9.3",
  "frame-system",
@@ -2681,7 +2687,7 @@ dependencies = [
  "itp-time-utils",
  "itp-types",
  "itp-utils",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-balances",
  "pallet-evm",
  "pallet-teerex",
@@ -2690,7 +2696,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "sc-keystore",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sgx_crypto_helper",
  "sp-application-crypto",
@@ -2756,6 +2762,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base58",
+ "base64 0.13.1",
  "clap 2.34.0",
  "dirs",
  "env_logger 0.9.3",
@@ -2786,7 +2793,7 @@ dependencies = [
  "its-test",
  "jsonrpsee",
  "lazy_static",
- "log 0.4.17",
+ "log 0.4.19",
  "mockall",
  "pallet-balances",
  "parity-scale-codec",
@@ -2795,8 +2802,8 @@ dependencies = [
  "primitive-types",
  "prometheus",
  "scale-info",
- "serde 1.0.163",
- "serde_derive 1.0.163",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
  "serde_json 1.0.96",
  "sgx-verify",
  "sgx_crypto_helper",
@@ -2816,9 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
@@ -2857,7 +2864,7 @@ dependencies = [
  "hyper-multipart-rfc7578",
  "hyper-tls",
  "parity-multiaddr",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "serde_urlencoded",
  "tokio",
@@ -2875,7 +2882,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix 0.37.19",
+ "rustix 0.37.20",
  "windows-sys 0.48.0",
 ]
 
@@ -2887,16 +2894,16 @@ dependencies = [
  "itp-enclave-metrics",
  "itp-ocall-api",
  "lazy_static",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sgx_tstd",
  "substrate-fixed",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -2923,7 +2930,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -2956,7 +2963,7 @@ dependencies = [
  "itp-storage",
  "itp-types",
  "itp-utils",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-balances",
  "pallet-parentchain",
  "pallet-sudo",
@@ -2981,7 +2988,7 @@ dependencies = [
  "itp-utils",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "serde_json 1.0.96",
  "sgx_tstd",
@@ -3006,7 +3013,7 @@ dependencies = [
  "itp-test",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3037,7 +3044,7 @@ dependencies = [
  "itc-parentchain-block-importer",
  "itp-import-queue",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
@@ -3056,7 +3063,7 @@ dependencies = [
  "itp-settings",
  "itp-stf-executor",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3085,7 +3092,7 @@ dependencies = [
  "itp-test",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3111,7 +3118,7 @@ dependencies = [
  "itp-test",
  "itp-types",
  "lazy_static",
- "log 0.4.17",
+ "log 0.4.19",
  "num-traits 0.2.15",
  "parity-scale-codec",
  "sgx_tstd",
@@ -3132,10 +3139,10 @@ dependencies = [
  "frame-support",
  "frame-system",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -3151,15 +3158,15 @@ dependencies = [
  "http 0.2.9",
  "http_req 0.8.1 (git+https://github.com/integritee-network/http_req?branch=master)",
  "http_req 0.8.1 (git+https://github.com/integritee-network/http_req)",
- "log 0.4.17",
- "serde 1.0.163",
+ "log 0.4.19",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sgx_tstd",
  "sgx_types",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -3174,16 +3181,16 @@ dependencies = [
  "itp-rpc",
  "itp-types",
  "itp-utils",
- "log 0.4.17",
+ "log 0.4.19",
  "openssl",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rustls 0.19.1",
- "serde_derive 1.0.163",
+ "serde_derive 1.0.164",
  "serde_json 1.0.96",
  "sgx_crypto_helper",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
  "ws",
 ]
 
@@ -3202,7 +3209,7 @@ dependencies = [
  "its-storage",
  "its-test",
  "jsonrpsee",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "serde_json 1.0.96",
  "sp-core",
@@ -3214,9 +3221,9 @@ name = "itc-tls-websocket-server"
 version = "0.9.0"
 dependencies = [
  "bit-vec",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "env_logger 0.9.3",
- "log 0.4.17",
+ "log 0.4.19",
  "mio 0.6.21",
  "mio 0.6.23",
  "mio-extras 2.0.6 (git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b)",
@@ -3231,7 +3238,7 @@ dependencies = [
  "thiserror 1.0.9",
  "tungstenite 0.14.0",
  "tungstenite 0.15.0",
- "url 2.3.1",
+ "url 2.4.0",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
  "yasna 0.3.1",
@@ -3290,12 +3297,12 @@ dependencies = [
 name = "itp-attestation-handler"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "base64 0.13.1",
  "bit-vec",
  "chrono 0.4.11",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "hex",
  "httparse 1.4.1",
  "itertools",
@@ -3305,7 +3312,7 @@ dependencies = [
  "itp-sgx-io",
  "itp-time-utils",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "num-bigint 0.2.5",
  "parity-scale-codec",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3)",
@@ -3347,7 +3354,7 @@ dependencies = [
  "itp-settings",
  "itp-storage",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "serde_json 1.0.96",
  "sgx_crypto_helper",
@@ -3383,7 +3390,7 @@ dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3498,7 +3505,7 @@ version = "0.9.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sgx_tstd",
 ]
@@ -3516,11 +3523,11 @@ dependencies = [
  "itp-settings",
  "itp-sgx-io",
  "itp-sgx-temp-dir",
- "log 0.4.17",
+ "log 0.4.19",
  "ofb",
  "parity-scale-codec",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "serde_json 1.0.96",
  "sgx_crypto_helper",
@@ -3537,10 +3544,10 @@ dependencies = [
  "derive_more",
  "environmental 1.1.3",
  "itp-hashing",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "postcard",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sp-core",
 ]
@@ -3590,7 +3597,7 @@ dependencies = [
  "itp-time-utils",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
@@ -3635,7 +3642,7 @@ dependencies = [
  "itp-time-utils",
  "itp-types",
  "lazy_static",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
@@ -3652,7 +3659,7 @@ name = "itp-stf-state-observer"
 version = "0.9.0"
 dependencies = [
  "itp-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "thiserror 1.0.40",
@@ -3734,10 +3741,10 @@ dependencies = [
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "linked-hash-map 0.5.2",
  "linked-hash-map 0.5.6",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "parity-util-mem",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sgx_types",
  "sp-application-crypto",
@@ -3765,7 +3772,7 @@ dependencies = [
  "itp-utils",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
@@ -3781,14 +3788,14 @@ dependencies = [
 name = "itp-types"
 version = "0.9.0"
 dependencies = [
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "frame-system",
  "integritee-node-runtime",
  "itp-sgx-runtime-primitives",
  "pallet-balances",
  "parity-scale-codec",
  "primitive-types",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sp-core",
  "sp-runtime",
@@ -3824,7 +3831,7 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-state",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3844,7 +3851,7 @@ dependencies = [
  "itp-utils",
  "its-primitives",
  "its-test",
- "log 0.4.17",
+ "log 0.4.19",
  "sgx_tstd",
  "sp-consensus-slots",
  "sp-core",
@@ -3885,7 +3892,7 @@ dependencies = [
  "its-state",
  "its-test",
  "its-validateer-fetch",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
@@ -3914,7 +3921,7 @@ dependencies = [
  "its-primitives",
  "its-state",
  "its-test",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3941,7 +3948,7 @@ dependencies = [
  "its-primitives",
  "its-test",
  "lazy_static",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-consensus-slots",
@@ -3964,8 +3971,8 @@ dependencies = [
  "its-storage",
  "its-test",
  "jsonrpsee",
- "log 0.4.17",
- "serde 1.0.163",
+ "log 0.4.19",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "thiserror 1.0.40",
  "tokio",
@@ -3977,7 +3984,7 @@ version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -3996,7 +4003,7 @@ dependencies = [
  "its-primitives",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
@@ -4027,9 +4034,9 @@ dependencies = [
  "itp-sgx-externalities",
  "itp-storage",
  "its-primitives",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx_tstd",
  "sp-core",
  "sp-io 7.0.0",
@@ -4048,7 +4055,7 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-test",
- "log 0.4.17",
+ "log 0.4.19",
  "mockall",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -4099,9 +4106,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4115,9 +4122,9 @@ dependencies = [
  "futures 0.3.28",
  "futures-executor 0.3.28",
  "futures-util 0.3.28",
- "log 0.4.17",
- "serde 1.0.163",
- "serde_derive 1.0.163",
+ "log 0.4.19",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
  "serde_json 1.0.96",
 ]
 
@@ -4160,11 +4167,11 @@ dependencies = [
  "hyper-rustls",
  "jsonrpsee-types",
  "jsonrpsee-utils",
- "log 0.4.17",
- "serde 1.0.163",
+ "log 0.4.19",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4180,8 +4187,8 @@ dependencies = [
  "jsonrpsee-types",
  "jsonrpsee-utils",
  "lazy_static",
- "log 0.4.17",
- "serde 1.0.163",
+ "log 0.4.19",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "socket2",
  "thiserror 1.0.40",
@@ -4213,8 +4220,8 @@ dependencies = [
  "futures-channel 0.3.28",
  "futures-util 0.3.28",
  "hyper",
- "log 0.4.17",
- "serde 1.0.163",
+ "log 0.4.19",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "soketto",
  "thiserror 1.0.40",
@@ -4230,11 +4237,11 @@ dependencies = [
  "futures-util 0.3.28",
  "hyper",
  "jsonrpsee-types",
- "log 0.4.17",
+ "log 0.4.19",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "rustc-hash",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "thiserror 1.0.40",
 ]
@@ -4249,18 +4256,18 @@ dependencies = [
  "fnv 1.0.7",
  "futures 0.3.28",
  "jsonrpsee-types",
- "log 0.4.17",
+ "log 0.4.19",
  "pin-project",
  "rustls 0.19.1",
  "rustls-native-certs",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "soketto",
  "thiserror 1.0.40",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.6.10",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -4273,9 +4280,9 @@ dependencies = [
  "futures-util 0.3.28",
  "jsonrpsee-types",
  "jsonrpsee-utils",
- "log 0.4.17",
+ "log 0.4.19",
  "rustc-hash",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "soketto",
  "thiserror 1.0.40",
@@ -4332,9 +4339,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libloading"
@@ -4378,7 +4385,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sha2 0.9.9",
  "typenum 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4452,15 +4459,15 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg 1.1.0",
  "scopeguard",
@@ -4486,12 +4493,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "mach"
@@ -4548,7 +4552,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.37.19",
+ "rustix 0.37.20",
 ]
 
 [[package]]
@@ -4562,9 +4566,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -4663,23 +4667,22 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys",
  "libc",
- "log 0.4.17",
+ "log 0.4.19",
  "miow",
- "net2 0.2.38",
+ "net2 0.2.39",
  "slab 0.4.8",
  "winapi 0.2.8",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log 0.4.17",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4689,7 +4692,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.17",
+ "log 0.4.19",
  "mio 0.6.23",
  "slab 0.4.8",
 ]
@@ -4700,7 +4703,7 @@ version = "2.0.6"
 source = "git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b#963234bf55e44f9efff921938255126c48deef3a"
 dependencies = [
  "lazycell",
- "log 0.4.17",
+ "log 0.4.19",
  "mio 0.6.21",
  "mio 0.6.23",
  "sgx_tstd",
@@ -4715,7 +4718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
- "net2 0.2.38",
+ "net2 0.2.39",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -4758,7 +4761,7 @@ dependencies = [
  "futures-util 0.3.28",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.17",
+ "log 0.4.19",
  "memchr 2.5.0",
  "mime",
  "spin 0.9.8",
@@ -4825,7 +4828,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.17",
+ "log 0.4.19",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -4847,9 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -5004,7 +5007,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "itoa 1.0.6",
 ]
 
@@ -5127,9 +5130,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.30.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
 dependencies = [
  "memchr 2.5.0",
 ]
@@ -5153,9 +5156,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "opaque-debug"
@@ -5171,15 +5174,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -5192,7 +5195,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5203,9 +5206,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
 dependencies = [
  "cc",
  "libc",
@@ -5215,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "pallet-assets"
@@ -5272,7 +5275,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -5290,8 +5293,8 @@ dependencies = [
  "parity-scale-codec",
  "rustc-hex",
  "scale-info",
- "serde 1.0.163",
- "serde_derive 1.0.163",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
  "sp-std",
@@ -5307,13 +5310,13 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-contracts-primitives",
  "pallet-contracts-proc-macro",
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "smallvec 1.10.0",
  "sp-api",
  "sp-core",
@@ -5362,7 +5365,7 @@ dependencies = [
  "frame-system",
  "hex",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "rlp",
@@ -5381,7 +5384,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -5418,7 +5421,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -5433,10 +5436,10 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -5450,7 +5453,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -5481,7 +5484,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -5498,7 +5501,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -5518,12 +5521,12 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-teerex",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sidechain-primitives",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -5541,12 +5544,12 @@ dependencies = [
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-application-crypto",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -5575,7 +5578,7 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-teerex",
  "parity-scale-codec",
  "scale-info",
@@ -5594,11 +5597,11 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sgx-verify",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -5615,7 +5618,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -5634,7 +5637,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -5665,7 +5668,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-runtime",
  "sp-std",
 ]
@@ -5694,7 +5697,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -5712,11 +5715,11 @@ dependencies = [
  "byteorder 1.4.3",
  "data-encoding",
  "multihash",
- "percent-encoding 2.2.0",
- "serde 1.0.163",
+ "percent-encoding 2.3.0",
+ "serde 1.0.164",
  "static_assertions",
  "unsigned-varint 0.7.1",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -5725,13 +5728,13 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ddb756ca205bd108aee3c62c6d3c994e1df84a59b9d6d4a5ea42ee1fd5a9a28"
 dependencies = [
- "arrayvec 0.7.2",
+ "arrayvec 0.7.3",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.4.0",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -5794,7 +5797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.7",
+ "parking_lot_core 0.9.8",
 ]
 
 [[package]]
@@ -5813,15 +5816,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "smallvec 1.10.0",
- "windows-sys 0.45.0",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -5832,7 +5835,7 @@ checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
 dependencies = [
  "lazy_static",
  "num 0.2.1",
- "regex 1.8.1",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -5856,7 +5859,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5892,9 +5895,9 @@ source = "git+https://github.com/mesalock-linux/rust-url-sgx?tag=sgx_1.1.3#23832
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
@@ -5913,7 +5916,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -5951,7 +5954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
  "postcard-cobs",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -5982,7 +5985,7 @@ dependencies = [
  "itertools",
  "normalize-line-endings",
  "predicates-core",
- "regex 1.8.1",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -6021,7 +6024,7 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "toml_edit",
 ]
 
@@ -6063,9 +6066,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -6080,7 +6083,7 @@ dependencies = [
  "byteorder 1.4.3",
  "hex",
  "lazy_static",
- "rustix 0.36.13",
+ "rustix 0.36.14",
 ]
 
 [[package]]
@@ -6137,9 +6140,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -6254,7 +6257,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -6300,7 +6303,7 @@ version = "0.9.2"
 source = "git+https://github.com/integritee-network/rcgen#1852c8dbeb74de36a422d218254b659497daf717"
 dependencies = [
  "chrono 0.4.11",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "pem 0.8.2",
  "pem 1.1.1",
  "ring 0.16.19",
@@ -6343,7 +6346,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.9",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror 1.0.40",
 ]
@@ -6365,7 +6368,7 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -6379,13 +6382,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick 1.0.2",
  "memchr 2.5.0",
- "regex-syntax 0.7.1",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -6413,9 +6416,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rfc6979"
@@ -6447,7 +6450,7 @@ checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "spin 0.5.2",
  "untrusted",
  "web-sys",
@@ -6461,8 +6464,8 @@ source = "git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup#8b
 dependencies = [
  "cc",
  "libc",
- "log 0.4.17",
- "once_cell 1.17.1",
+ "log 0.4.19",
+ "once_cell 1.18.0",
  "rkyv",
  "spin 0.5.2",
  "untrusted",
@@ -6582,9 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.13"
+version = "0.36.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a38f9520be93aba504e8ca974197f46158de5dcaa9fa04b57c57cd6a679d658"
+checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
 dependencies = [
  "bitflags",
  "errno",
@@ -6596,15 +6599,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.7",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
 ]
 
@@ -6654,7 +6657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.1",
- "log 0.4.17",
+ "log 0.4.19",
  "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "sct 0.6.1",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6678,7 +6681,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -6710,9 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "safe_arch"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+checksum = "62a7484307bd40f8f7ccbacccac730108f2cae119a3b11c74485b48aa9ea650f"
 dependencies = [
  "bytemuck",
 ]
@@ -6752,7 +6755,7 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -6886,9 +6889,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2855b3715770894e67cbfa3df957790aa0c9edc3bf06efa1a84d77fa0839d1"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -6931,7 +6934,7 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -6959,11 +6962,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
- "serde_derive 1.0.163",
+ "serde_derive 1.0.164",
 ]
 
 [[package]]
@@ -6972,8 +6975,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b926cfbabfe8011609dda0350cb24d884955d294909ac71c0db7027366c77e3e"
 dependencies = [
- "serde 1.0.163",
- "serde_derive 1.0.163",
+ "serde 1.0.164",
+ "serde_derive 1.0.164",
 ]
 
 [[package]]
@@ -6997,13 +7000,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -7038,7 +7041,7 @@ dependencies = [
  "indexmap 1.9.3",
  "itoa 1.0.6",
  "ryu",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -7050,7 +7053,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.6",
  "ryu",
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
@@ -7059,7 +7062,7 @@ version = "0.1.4"
 source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.39#4239d3defa20c3fbd13966f62ce85e9a407bd7bf"
 dependencies = [
  "base64 0.13.1",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "der",
  "frame-support",
  "hex",
@@ -7067,7 +7070,7 @@ dependencies = [
  "parity-scale-codec",
  "ring 0.16.20 (git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup)",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
@@ -7080,12 +7083,12 @@ dependencies = [
 [[package]]
 name = "sgx_alloc"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 
 [[package]]
 name = "sgx_backtrace_sys"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "cc",
  "sgx_build_helper",
@@ -7095,21 +7098,21 @@ dependencies = [
 [[package]]
 name = "sgx_build_helper"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 
 [[package]]
 name = "sgx_crypto_helper"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "itertools",
  "libc",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde-big-array 0.1.5",
  "serde-big-array 0.3.0",
  "serde_derive 1.0.118",
- "serde_derive 1.0.163",
+ "serde_derive 1.0.164",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
@@ -7119,12 +7122,12 @@ dependencies = [
 [[package]]
 name = "sgx_demangle"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 
 [[package]]
 name = "sgx_libc"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "sgx_types",
 ]
@@ -7132,7 +7135,7 @@ dependencies = [
 [[package]]
 name = "sgx_rand"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "sgx_trts",
  "sgx_tstd",
@@ -7142,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "sgx_tcrypto"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "sgx_types",
 ]
@@ -7150,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "sgx_tprotected_fs"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "sgx_trts",
  "sgx_types",
@@ -7159,7 +7162,7 @@ dependencies = [
 [[package]]
 name = "sgx_trts"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "sgx_libc",
  "sgx_types",
@@ -7168,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "sgx_tse"
 version = "1.1.6"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "sgx_types",
 ]
@@ -7176,7 +7179,7 @@ dependencies = [
 [[package]]
 name = "sgx_tstd"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "hashbrown_tstd",
  "sgx_alloc",
@@ -7192,12 +7195,12 @@ dependencies = [
 [[package]]
 name = "sgx_types"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 
 [[package]]
 name = "sgx_ucrypto"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "libc",
  "rand_core 0.3.1",
@@ -7208,7 +7211,7 @@ dependencies = [
 [[package]]
 name = "sgx_unwind"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "sgx_build_helper",
 ]
@@ -7216,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "sgx_urts"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#780dc8999477244d8ff1e6f418321adbec51ee58"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "libc",
  "sgx_types",
@@ -7263,7 +7266,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7311,7 +7314,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.6",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7320,7 +7323,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -7346,7 +7349,7 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-runtime",
@@ -7368,7 +7371,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.6",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7436,7 +7439,7 @@ dependencies = [
  "bytes 1.4.0",
  "futures 0.3.28",
  "httparse 1.8.0",
- "log 0.4.17",
+ "log 0.4.19",
  "rand 0.8.5",
  "sha-1 0.9.8",
 ]
@@ -7447,7 +7450,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-api-proc-macro",
  "sp-core",
@@ -7478,7 +7481,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-std",
@@ -7493,7 +7496,7 @@ dependencies = [
  "num-traits 0.2.15",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-std",
  "static_assertions",
 ]
@@ -7517,7 +7520,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "async-trait",
  "futures 0.3.28",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-core",
  "sp-inherents",
@@ -7553,7 +7556,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-std",
  "sp-timestamp",
 ]
@@ -7576,18 +7579,18 @@ dependencies = [
  "impl-serde",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.17",
+ "log 0.4.19",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "primitive-types",
  "rand 0.8.5",
- "regex 1.8.1",
+ "regex 1.8.4",
  "scale-info",
  "schnorrkel",
  "secp256k1",
  "secrecy",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
@@ -7608,7 +7611,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "blake2",
  "byteorder 1.4.3",
- "digest 0.10.6",
+ "digest 0.10.7",
  "sha2 0.10.6",
  "sha3",
  "sp-std",
@@ -7653,10 +7656,10 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "finality-grandpa",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -7689,7 +7692,7 @@ dependencies = [
  "hash-db",
  "itp-sgx-externalities",
  "libsecp256k1",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sgx_tstd",
@@ -7713,7 +7716,7 @@ dependencies = [
  "ed25519-dalek",
  "futures 0.3.28",
  "libsecp256k1",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "secp256k1",
  "sp-core",
@@ -7750,7 +7753,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "schnorrkel",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-externalities",
  "thiserror 1.0.40",
@@ -7772,7 +7775,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-arithmetic",
  "sp-core",
  "sp-runtime",
@@ -7796,7 +7799,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "backtrace",
  "lazy_static",
- "regex 1.8.1",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -7807,12 +7810,12 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "paste",
  "rand 0.8.5",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
@@ -7883,7 +7886,7 @@ version = "0.13.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39#8c4b84520cee2d7de53cc33cb67605ce4efefba8"
 dependencies = [
  "hash-db",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -7910,7 +7913,7 @@ dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-debug-derive",
  "sp-std",
 ]
@@ -7922,7 +7925,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "async-trait",
  "futures-timer",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
@@ -7983,7 +7986,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core-hashing-proc-macro",
  "sp-runtime",
  "sp-std",
@@ -8009,7 +8012,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
  "sp-std",
  "wasmi 0.13.2",
@@ -8023,7 +8026,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.3
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "smallvec 1.10.0",
  "sp-arithmetic",
  "sp-core",
@@ -8063,7 +8066,7 @@ dependencies = [
  "num-format",
  "proc-macro2",
  "quote",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "unicode-xid",
 ]
@@ -8126,14 +8129,14 @@ dependencies = [
  "frame-metadata 15.1.0 (git+https://github.com/paritytech/frame-metadata)",
  "frame-support",
  "hex",
- "log 0.4.17",
+ "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
- "url 2.3.1",
+ "url 2.4.0",
  "ws",
 ]
 
@@ -8173,7 +8176,7 @@ source = "git+https://github.com/encointer/substrate-fixed?tag=v0.5.9#a4fb461aae
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "typenum 1.16.0 (git+https://github.com/encointer/typenum?tag=v1.16.0)",
 ]
 
@@ -8213,9 +8216,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8264,7 +8267,7 @@ dependencies = [
  "common-primitives",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.163",
+ "serde 1.0.164",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.39)",
  "sp-std",
@@ -8278,15 +8281,16 @@ checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.19",
- "windows-sys 0.45.0",
+ "rustix 0.37.20",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -8355,7 +8359,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -8365,7 +8369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if 1.0.0",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
 ]
 
 [[package]]
@@ -8387,7 +8391,7 @@ checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
 dependencies = [
  "anyhow",
  "hmac 0.12.1",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
@@ -8424,14 +8428,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.1"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
  "autocfg 1.1.0",
  "bytes 1.4.0",
  "libc",
- "mio 0.8.6",
+ "mio 0.8.8",
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
@@ -8449,7 +8453,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -8491,7 +8495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util 0.3.28",
- "log 0.4.17",
+ "log 0.4.19",
  "tokio",
  "tungstenite 0.18.0",
 ]
@@ -8506,7 +8510,7 @@ dependencies = [
  "futures-core 0.3.28",
  "futures-io 0.3.28",
  "futures-sink 0.3.28",
- "log 0.4.17",
+ "log 0.4.19",
  "pin-project-lite",
  "tokio",
 ]
@@ -8531,20 +8535,20 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap 1.9.3",
  "toml_datetime",
@@ -8564,7 +8568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.17",
+ "log 0.4.19",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8578,7 +8582,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -8587,7 +8591,7 @@ version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "valuable",
 ]
 
@@ -8598,7 +8602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
- "log 0.4.17",
+ "log 0.4.19",
  "tracing-core",
 ]
 
@@ -8608,7 +8612,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.163",
+ "serde 1.0.164",
  "tracing-core",
 ]
 
@@ -8619,11 +8623,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "ansi_term",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "lazy_static",
  "matchers",
- "regex 1.8.1",
- "serde 1.0.163",
+ "regex 1.8.4",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "sharded-slab",
  "smallvec 1.10.0",
@@ -8642,7 +8646,7 @@ checksum = "3390c0409daaa6027d6681393316f4ccd3ff82e1590a1e4725014e3ae2bf1920"
 dependencies = [
  "hash-db",
  "hashbrown 0.13.2",
- "log 0.4.17",
+ "log 0.4.19",
  "rustc-hex",
  "smallvec 1.10.0",
 ]
@@ -8711,12 +8715,12 @@ dependencies = [
  "bytes 1.4.0",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.17",
+ "log 0.4.19",
  "rand 0.8.5",
  "rustls 0.19.1",
  "sha-1 0.9.8",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
  "utf-8 0.7.6",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.21.1",
@@ -8733,11 +8737,11 @@ dependencies = [
  "bytes 1.4.0",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.17",
+ "log 0.4.19",
  "rand 0.8.5",
  "sha1 0.10.5",
  "thiserror 1.0.40",
- "url 2.3.1",
+ "url 2.4.0",
  "utf-8 0.7.6",
 ]
 
@@ -8747,8 +8751,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
- "digest 0.10.6",
+ "cfg-if 1.0.0",
+ "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -8826,9 +8830,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-normalization"
@@ -8890,13 +8894,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
- "percent-encoding 2.2.0",
+ "idna 0.4.0",
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
@@ -8949,11 +8953,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log 0.4.17",
  "try-lock",
 ]
 
@@ -8969,15 +8972,15 @@ dependencies = [
  "headers",
  "http 0.2.9",
  "hyper",
- "log 0.4.17",
+ "log 0.4.19",
  "mime",
  "mime_guess",
  "multer",
- "percent-encoding 2.2.0",
+ "percent-encoding 2.3.0",
  "pin-project",
  "rustls-pemfile",
  "scoped-tls",
- "serde 1.0.163",
+ "serde 1.0.164",
  "serde_json 1.0.96",
  "serde_urlencoded",
  "tokio",
@@ -9008,9 +9011,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -9018,24 +9021,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "log 0.4.17",
- "once_cell 1.17.1",
+ "log 0.4.19",
+ "once_cell 1.18.0",
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9043,22 +9046,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-instrument"
@@ -9107,7 +9110,7 @@ dependencies = [
  "cc",
  "cxx",
  "cxx-build",
- "regex 1.8.1",
+ "regex 1.8.4",
 ]
 
 [[package]]
@@ -9179,7 +9182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
 dependencies = [
  "indexmap 1.9.3",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -9202,12 +9205,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap 1.9.3",
  "libc",
- "log 0.4.17",
+ "log 0.4.19",
  "object 0.29.0",
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
  "paste",
  "psm",
- "serde 1.0.163",
+ "serde 1.0.164",
  "target-lexicon",
  "wasmparser",
  "wasmtime-environ",
@@ -9235,9 +9238,9 @@ dependencies = [
  "cranelift-entity",
  "gimli 0.26.2",
  "indexmap 1.9.3",
- "log 0.4.17",
+ "log 0.4.19",
  "object 0.29.0",
- "serde 1.0.163",
+ "serde 1.0.164",
  "target-lexicon",
  "thiserror 1.0.40",
  "wasmparser",
@@ -9256,10 +9259,10 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli 0.26.2",
- "log 0.4.17",
+ "log 0.4.19",
  "object 0.29.0",
  "rustc-demangle",
- "serde 1.0.163",
+ "serde 1.0.164",
  "target-lexicon",
  "wasmtime-environ",
  "wasmtime-jit-icache-coherence",
@@ -9273,7 +9276,7 @@ version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed41cbcbf74ce3ff6f1d07d1b707888166dc408d1a880f651268f4f7c9194b2"
 dependencies = [
- "once_cell 1.17.1",
+ "once_cell 1.18.0",
 ]
 
 [[package]]
@@ -9298,13 +9301,13 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap 1.9.3",
  "libc",
- "log 0.4.17",
+ "log 0.4.19",
  "mach",
  "memfd",
  "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
- "rustix 0.36.13",
+ "rustix 0.36.14",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -9318,16 +9321,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e5572c5727c1ee7e8f28717aaa8400e4d22dcbd714ea5457d85b5005206568"
 dependencies = [
  "cranelift-entity",
- "serde 1.0.163",
+ "serde 1.0.164",
  "thiserror 1.0.40",
  "wasmparser",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9392,9 +9395,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b689b6c49d6549434bf944e6b0f39238cf63693cb7a147e9d887507fffa3b223"
+checksum = "40018623e2dba2602a9790faba8d33f2ebdebf4b86561b83928db735f8784728"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -9601,9 +9604,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr 2.5.0",
 ]
@@ -9617,14 +9620,14 @@ dependencies = [
  "byteorder 1.4.3",
  "bytes 0.4.12",
  "httparse 1.8.0",
- "log 0.4.17",
+ "log 0.4.19",
  "mio 0.6.23",
  "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.2",
  "slab 0.4.8",
- "url 2.3.1",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -9660,20 +9663,20 @@ dependencies = [
 
 [[package]]
 name = "xous"
-version = "0.9.42"
+version = "0.9.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4126043d97e773d482d4be8bd45c007640ae09af3ebf40d3d9b5c9ab843abf0b"
+checksum = "30684dda3583f528d5b05bddc96527e1783255e867a5e81c10721d6abb9e169c"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.38"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d267ec4b8fb7bff386e448043b81f20a7eb15174973bd37b7b9af6e2d6bbe2e6"
+checksum = "fd6b15ea09891f09b02d763422dc99733c96e62d0f8ab476c6bc663c90b17e72"
 dependencies = [
- "log 0.4.17",
+ "log 0.4.19",
  "num-derive",
  "num-traits 0.2.15",
  "xous",
@@ -9682,11 +9685,11 @@ dependencies = [
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.40"
+version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f39025c4b19ebf704effb967afcea2e2576f7a55ed0d25dec01920bed6ac44"
+checksum = "7b470fbf177d58767fa001acfcb5294a88d3938d3935865ff6b8f1db40f1004e"
 dependencies = [
- "log 0.4.17",
+ "log 0.4.19",
  "num-derive",
  "num-traits 0.2.15",
  "rkyv",
@@ -9697,9 +9700,9 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.42"
+version = "0.9.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52f85ca63305a0ea9d31ade0ea8fca86515ce33550486e7c0c8edbe3a4d68f"
+checksum = "d520fe08642d55a56f700b6d30c7a556f38818e7c3e5d9a0856dde0b79ed4d67"
 dependencies = [
  "bitflags",
  "rkyv",
@@ -9730,7 +9733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
 dependencies = [
  "bit-vec",
- "chrono 0.4.24",
+ "chrono 0.4.26",
  "num-bigint 0.4.3",
 ]
 
@@ -9751,7 +9754,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.16",
+ "syn 2.0.18",
 ]
 
 [[package]]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.50"
 base58 = "0.2"
+base64 = { version = "0.13", features = ["alloc"] }
 clap = { version = "2.33", features = ["yaml"] }
 dirs = "3.0.2"
 env_logger = "0.9"

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -743,7 +743,7 @@ fn register_quotes_from_marblerun(
 			info!("Fetching events from Marblerun failed with: {:?}, continuing with 0 events.", e);
 		})
 		.unwrap_or_default();
-	let quotes: Vec<&[u8]> =
+	let quotes: Vec<Vec<u8>> =
 		events.iter().map(|event| event.get_quote_without_prepended_bytes()).collect();
 
 	for quote in quotes {

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -224,9 +224,13 @@ pub struct PrometheusMarblerunEvent {
 
 #[cfg(feature = "attesteer")]
 impl PrometheusMarblerunEvent {
-	pub fn get_quote_without_prepended_bytes(&self) -> &[u8] {
+	pub fn get_quote_without_prepended_bytes(&self) -> Vec<u8> {
+		let whole_quote_decoded = base64::decode(&self.activation.quote)
+			.expect("Marblerun code should not be malformed.");
 		let marblerun_magic_prepended_header_size = 16usize;
-		&self.activation.quote.as_bytes()[marblerun_magic_prepended_header_size..]
+		let quote_decoded = whole_quote_decoded[marblerun_magic_prepended_header_size..].to_vec();
+
+		quote_decoded
 	}
 }
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]


### PR DESCRIPTION
As the quote is in base64 encoded format, it should be decoded before the prepended bytes are cut off.

Needs: 

~~- [ ] https://github.com/integritee-network/pallets/pull/181~~
EDIT: Marblerun 1.2.0 supports the newer V3 TCB Info format, so no compatibility wrapper needed.