### PR TITLE
unify clap dependencies to version v3.2.25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,22 +750,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
- "yaml-rust",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
@@ -776,9 +760,10 @@ dependencies = [
  "clap_lex",
  "indexmap 1.9.3",
  "once_cell 1.18.0",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2752,7 +2737,7 @@ dependencies = [
  "base58",
  "blake2-rfc",
  "chrono 0.4.26",
- "clap 3.2.25",
+ "clap",
  "enclave-bridge-primitives",
  "env_logger 0.9.3",
  "frame-system",
@@ -2845,7 +2830,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base58",
- "clap 2.34.0",
+ "clap",
  "dirs",
  "enclave-bridge-primitives",
  "env_logger 0.9.3",
@@ -8259,12 +8244,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -8483,15 +8462,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "textwrap"
@@ -9112,12 +9082,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -9897,9 +9861,12 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.3.5"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map 0.5.6",
+]
 
 [[package]]
 name = "yasna"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.50"
 base58 = "0.2"
-clap = { version = "2.33", features = ["yaml"] }
+clap = { version = "3.2.25", features = ["yaml"] }
 dirs = "3.0.2"
 env_logger = "0.9"
 futures = "0.3"


### PR DESCRIPTION
Note: we can't move to clap v4 in the service yet because the yaml support has been removed https://github.com/integritee-network/worker/issues/1220