### PR TITLE
[GHA] fix sccache install failure

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -43,7 +43,7 @@ ENV WORKHOME=/home/ubuntu/work
 ENV HOME=/home/ubuntu
 
 RUN rustup default stable 
-RUN cargo install sccache
+RUN cargo install sccache --locked
 
 ENV SCCACHE_CACHE_SIZE="20G"
 ENV SCCACHE_DIR=$HOME/.cache/sccache


### PR DESCRIPTION
Failed because the latest semver compatible clap version 4.4.0 doesn't compile on rustc-1.6.8 any more (needs rustc-1.7.0). I have just put a `--locked` here because this is anyhow good practice for stability.