### PR TITLE
[light-client] remove pending parentchain tx-inclusion check

### DIFF
--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -116,11 +116,10 @@ impl<
 		{
 			// Check if there are any extrinsics in the to-be-imported block that we sent and cached in the light-client before.
 			// If so, remove them now from the cache.
-			if let Err(e) = self.validator_accessor.execute_mut_on_validator(|v| {
-				v.check_xt_inclusion(&signed_block.block)?;
-
-				v.submit_block(&signed_block)
-			}) {
+			if let Err(e) = self
+				.validator_accessor
+				.execute_mut_on_validator(|v| v.submit_block(&signed_block))
+			{
 				error!("[{:?}] Header submission to light client failed: {:?}", id, e);
 				return Err(e.into())
 			}

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -114,8 +114,6 @@ impl<
 		for (signed_block, raw_events) in
 			blocks_to_import.into_iter().zip(events_to_import.into_iter())
 		{
-			// Check if there are any extrinsics in the to-be-imported block that we sent and cached in the light-client before.
-			// If so, remove them now from the cache.
 			if let Err(e) = self
 				.validator_accessor
 				.execute_mut_on_validator(|v| v.submit_block(&signed_block))

--- a/core/parentchain/light-client/src/io.rs
+++ b/core/parentchain/light-client/src/io.rs
@@ -358,7 +358,6 @@ pub mod sgx_tests {
 		.unwrap();
 
 		assert_eq!(validator.genesis_hash().unwrap(), parachain_params.genesis_header.hash());
-		assert_eq!(validator.num_xt_to_be_included().unwrap(), 0);
 		assert_eq!(validator.latest_finalized_header().unwrap(), parachain_params.genesis_header);
 		assert_eq!(
 			validator.penultimate_finalized_block_header().unwrap(),

--- a/core/parentchain/light-client/src/lib.rs
+++ b/core/parentchain/light-client/src/lib.rs
@@ -74,8 +74,6 @@ where
 {
 	fn submit_block(&mut self, signed_block: &SignedBlock<Block>) -> Result<(), Error>;
 
-	fn check_xt_inclusion(&mut self, block: &Block) -> Result<(), Error>;
-
 	fn get_state(&self) -> &LightValidationState<Block>;
 }
 
@@ -85,8 +83,6 @@ pub trait ExtrinsicSender {
 }
 
 pub trait LightClientState<Block: ParentchainBlockTrait> {
-	fn num_xt_to_be_included(&self) -> Result<usize, Error>;
-
 	fn genesis_hash(&self) -> Result<HashFor<Block>, Error>;
 
 	fn latest_finalized_header(&self) -> Result<Block::Header, Error>;

--- a/core/parentchain/light-client/src/light_validation.rs
+++ b/core/parentchain/light-client/src/light_validation.rs
@@ -114,7 +114,10 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 			}
 		}
 
-		// A valid grandpa proof proves finalization of all previous unjustified blocks.
+		// Todo: Justifying the headers here is actually wrong, but it prevents ever growing
+		// `unjustified_headers` queue  because in the parachain case we won't have justifications,
+		// and in solo chain setups we only get a justification upon an Grandpa authority change.
+		// Hence, we justify the headers here until we properly solve this in #1404.
 		relay.justify_headers();
 		relay.push_header_hash(header.hash());
 

--- a/core/parentchain/light-client/src/light_validation.rs
+++ b/core/parentchain/light-client/src/light_validation.rs
@@ -114,8 +114,8 @@ impl<Block: ParentchainBlockTrait, OcallApi: EnclaveOnChainOCallApi>
 			}
 		}
 
-		// Todo: Justifying the headers here is actually wrong, but it prevents ever growing
-		// `unjustified_headers` queue  because in the parachain case we won't have justifications,
+		// Todo: Justifying the headers here is actually wrong, but it prevents an ever-growing
+		// `unjustified_headers` queue because in the parachain case we won't have justifications,
 		// and in solo chain setups we only get a justification upon an Grandpa authority change.
 		// Hence, we justify the headers here until we properly solve this in #1404.
 		relay.justify_headers();

--- a/core/parentchain/light-client/src/light_validation_state.rs
+++ b/core/parentchain/light-client/src/light_validation_state.rs
@@ -52,11 +52,6 @@ impl<Block> LightClientState<Block> for LightValidationState<Block>
 where
 	Block: ParentchainBlockTrait,
 {
-	fn num_xt_to_be_included(&self) -> Result<usize, Error> {
-		let relay = self.get_relay();
-		Ok(relay.verify_tx_inclusion.len())
-	}
-
 	fn genesis_hash(&self) -> Result<HashFor<Block>, Error> {
 		Ok(self.get_relay().genesis_hash)
 	}

--- a/core/parentchain/light-client/src/mocks/validator_mock.rs
+++ b/core/parentchain/light-client/src/mocks/validator_mock.rs
@@ -49,10 +49,6 @@ impl Validator<Block> for ValidatorMock {
 		Ok(())
 	}
 
-	fn check_xt_inclusion(&mut self, _block: &Block) -> Result<()> {
-		Ok(())
-	}
-
 	fn get_state(&self) -> &LightValidationState<Block> {
 		&self.light_validation_state
 	}
@@ -65,10 +61,6 @@ impl ExtrinsicSender for ValidatorMock {
 }
 
 impl LightClientState<Block> for ValidatorMock {
-	fn num_xt_to_be_included(&self) -> Result<usize> {
-		todo!()
-	}
-
 	fn genesis_hash(&self) -> Result<HashFor<Block>> {
 		todo!()
 	}

--- a/core/parentchain/light-client/src/state.rs
+++ b/core/parentchain/light-client/src/state.rs
@@ -17,10 +17,7 @@
 
 use codec::{Decode, Encode};
 use sp_consensus_grandpa::{AuthorityList, SetId};
-use sp_runtime::{
-	traits::{Block as BlockT, Header as HeaderT},
-	OpaqueExtrinsic,
-};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 use std::{collections::VecDeque, fmt, vec::Vec};
 
 /// Defines the amount of parentchain headers to keep.
@@ -35,7 +32,6 @@ pub struct RelayState<Block: BlockT> {
 	pub current_validator_set_id: SetId,
 	header_hashes: VecDeque<Block::Hash>,
 	pub unjustified_headers: Vec<Block::Hash>, // Finalized headers without grandpa proof
-	pub verify_tx_inclusion: Vec<OpaqueExtrinsic>, // Transactions sent by the relay
 	pub scheduled_change: Option<ScheduledChangeAtBlock<Block::Header>>, // Scheduled Authorities change as indicated in the header's digest.
 }
 
@@ -79,7 +75,6 @@ impl<Block: BlockT> RelayState<Block> {
 			current_validator_set: validator_set,
 			current_validator_set_id: 0,
 			unjustified_headers: Vec::new(),
-			verify_tx_inclusion: Vec::new(),
 			scheduled_change: None,
 		}
 	}
@@ -95,11 +90,10 @@ impl<Block: BlockT> fmt::Debug for RelayState<Block> {
 		write!(
 			f,
 			"RelayInfo {{ last_finalized_block_header_number: {:?}, current_validator_set: {:?}, \
-        current_validator_set_id: {} amount of transaction in tx_inclusion_queue: {} }}",
+        current_validator_set_id: {} }}",
 			self.last_finalized_block_header.number(),
 			self.current_validator_set,
 			self.current_validator_set_id,
-			self.verify_tx_inclusion.len()
 		)
 	}
 }

--- a/core/parentchain/light-client/src/state.rs
+++ b/core/parentchain/light-client/src/state.rs
@@ -90,10 +90,11 @@ impl<Block: BlockT> fmt::Debug for RelayState<Block> {
 		write!(
 			f,
 			"RelayInfo {{ last_finalized_block_header_number: {:?}, current_validator_set: {:?}, \
-        current_validator_set_id: {} }}",
+        current_validator_set_id: {}, number of unjustified headers: {} }}",
 			self.last_finalized_block_header.number(),
 			self.current_validator_set,
 			self.current_validator_set_id,
+			self.unjustified_headers.len()
 		)
 	}
 }


### PR DESCRIPTION
This PR removes the parentchain tx-inclusion check, which didn't work. This led to an infinitely growing list of extrinsics with pending inclusion check in the light-client, which slowed down the block import tremendously. As the light-client was never the correct place to do that, I just removed the feature, and added a tracking issue for proper re-introduction: #1457.

* Closes #1454.