### PR TITLE
[GHA] bump integritee node to v1.1.3 and increase log levels

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -251,7 +251,7 @@ jobs:
           echo "PROJECT=${{ matrix.flavor_id }}-${{ matrix.demo_name }}" >> $GITHUB_ENV
           echo "VERSION=dev.$version" >> $GITHUB_ENV
           echo "WORKER_IMAGE_TAG=integritee-worker:dev.$version" >> $GITHUB_ENV
-          echo "INTEGRITEE_NODE=integritee-node-dev:1.1.0.$version" >> $GITHUB_ENV
+          echo "INTEGRITEE_NODE=integritee-node-dev:1.1.3.$version" >> $GITHUB_ENV
           echo "CLIENT_IMAGE_TAG=integritee-cli:dev.$version" >> $GITHUB_ENV
           if [[ ${{ matrix.sgx_mode }} == 'HW' ]]; then
              echo "SGX_PROVISION=/dev/sgx/provision" >> $GITHUB_ENV
@@ -296,8 +296,8 @@ jobs:
           fi
           docker tag integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }} ${{ env.WORKER_IMAGE_TAG }}
           docker tag integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }} ${{ env.CLIENT_IMAGE_TAG }}
-          docker pull integritee/integritee-node-dev:1.1.0
-          docker tag integritee/integritee-node-dev:1.1.0 ${{ env.INTEGRITEE_NODE }}
+          docker pull integritee/integritee-node-dev:1.1.3
+          docker tag integritee/integritee-node-dev:1.1.3 ${{ env.INTEGRITEE_NODE }}
           docker images --all
 
       ##

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -251,7 +251,7 @@ jobs:
           echo "PROJECT=${{ matrix.flavor_id }}-${{ matrix.demo_name }}" >> $GITHUB_ENV
           echo "VERSION=dev.$version" >> $GITHUB_ENV
           echo "WORKER_IMAGE_TAG=integritee-worker:dev.$version" >> $GITHUB_ENV
-          echo "INTEGRITEE_NODE=integritee-node-dev:1.1.3.$version" >> $GITHUB_ENV
+          echo "INTEGRITEE_NODE=integritee-node:1.1.3.$version" >> $GITHUB_ENV
           echo "CLIENT_IMAGE_TAG=integritee-cli:dev.$version" >> $GITHUB_ENV
           if [[ ${{ matrix.sgx_mode }} == 'HW' ]]; then
              echo "SGX_PROVISION=/dev/sgx/provision" >> $GITHUB_ENV
@@ -296,8 +296,8 @@ jobs:
           fi
           docker tag integritee-worker-${{ matrix.flavor_id }}-${{ github.sha }} ${{ env.WORKER_IMAGE_TAG }}
           docker tag integritee-cli-client-${{ matrix.flavor_id }}-${{ github.sha }} ${{ env.CLIENT_IMAGE_TAG }}
-          docker pull integritee/integritee-node-dev:1.1.3
-          docker tag integritee/integritee-node-dev:1.1.3 ${{ env.INTEGRITEE_NODE }}
+          docker pull integritee/integritee-node:1.1.3
+          docker tag integritee/integritee-node:1.1.3 ${{ env.INTEGRITEE_NODE }}
           docker images --all
 
       ##

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@
 
 * Make sure you have installed Docker (version >= `2.0.0`) with [Docker Compose](https://docs.docker.com/compose/install/). On Windows, this can be Docker Desktop with WSL 2 integration.
 * In case you also build the worker directly, without docker (e.g. on a dev machine, running `make`), you should run `make clean` before running the docker build. Otherwise, it can occasionally lead to build errors.
-* The node image version that is loaded in the `docker-compose.yml`, (e.g. `image: "integritee/integritee-node-dev:1.0.32"`) needs to be compatible with the worker you're trying to build.
+* The node image version that is loaded in the `docker-compose.yml`, (e.g. `image: "integritee/integritee-node:1.1.3"`) needs to be compatible with the worker you're trying to build.
 * Set export VERSION=dev
 * `envsubst` should be installed, it is needed to replace the $VERSION in yaml files as docker compose doesn't support variables on service names.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   "integritee-node-${VERSION}":
-    image: "${INTEGRITEE_NODE:-integritee/integritee-node-dev:1.1.0}"
+    image: "${INTEGRITEE_NODE:-integritee/integritee-node-dev:1.1.3}"
     hostname: integritee-node
     devices:
       - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 6
-    command: --dev --rpc-methods unsafe --ws-external --rpc-external --ws-port 9912
+    command: -lruntime=info -lteerex=debug --dev --rpc-methods unsafe --ws-external --rpc-external --ws-port 9912
     #logging:
     #driver: local
   "integritee-worker-1-${VERSION}":

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   "integritee-node-${VERSION}":
-    image: "${INTEGRITEE_NODE:-integritee/integritee-node-dev:1.1.3}"
+    image: "${INTEGRITEE_NODE:-integritee/integritee-node:1.1.3}"
     hostname: integritee-node
     devices:
       - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"


### PR DESCRIPTION
This was actually a necessary fix, as our builder machine suddenly became outdated and was rejected by our node. Hence, the enclave couldn't register and the integration tests failed. The new node accepts outdated enclaves, but marks the enclave as outdated in the registry. Additionally, I increased the log levels so that we can actually observe why the enclave was rejected.