### PR TITLE
Fix OOM error in large parentchain syncs

### DIFF
--- a/core/parentchain/block-import-dispatcher/src/triggered_dispatcher.rs
+++ b/core/parentchain/block-import-dispatcher/src/triggered_dispatcher.rs
@@ -163,6 +163,7 @@ where
 		&self,
 		predicate: impl Fn(&BlockImporter::SignedBlockType) -> bool,
 	) -> Result<Option<BlockImporter::SignedBlockType>> {
+		trace!("Import of parentchain blocks and events has been triggered");
 		let blocks_to_import =
 			self.import_queue.pop_until(predicate).map_err(Error::ImportQueue)?;
 
@@ -174,7 +175,7 @@ where
 		let latest_imported_block = blocks_to_import.last().map(|b| (*b).clone());
 
 		trace!(
-			"Import of parentchain blocks and events has been triggered, importing {} blocks and {} events from queue",
+			"Importing {} blocks and {} events from queue",
 			blocks_to_import.len(),
 			events_to_import.len(),
 		);

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -146,7 +146,7 @@ fn bootstrap_funds_from_alice(
             "funding amount is too high: please change EXISTENTIAL_DEPOSIT_FACTOR_FOR_INIT_FUNDS ({:?})",
             funding_amount
         );
-		return Err(Error::ApplicationSetup)
+		return Err(Error::ApplicationSetup("Alice funds too low".into()))
 	}
 
 	let mut alice_signer_api = api.clone();

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -38,8 +38,8 @@ pub enum Error {
 	Serialization(#[from] serde_json::Error),
 	#[error("{0}")]
 	FromUtf8(#[from] std::string::FromUtf8Error),
-	#[error("Application setup error!")]
-	ApplicationSetup,
+	#[error("Application setup error: {0}")]
+	ApplicationSetup(String),
 	#[error("Failed to find any peer worker")]
 	NoPeerWorkerFound,
 	#[error("No worker for shard {0} found on parentchain")]

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
 	MissingGenesisHeader,
 	#[error("Could not find last finalized block of the parentchain")]
 	MissingLastFinalizedBlock,
+	#[error("Error during the block sync process: {0}")]
+	BlockSync(String),
 	#[error("{0}")]
 	Custom(Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -1024,7 +1024,7 @@ fn start_parentchain_header_subscription_thread<E: EnclaveBase + Sidechain>(
 	parentchain_handler: Arc<ParentchainHandler<ParentchainApi, E>>,
 	last_synced_header: Header,
 ) {
-	let parentchain_id = parentchain_handler.parentchain_id().clone();
+	let parentchain_id = *parentchain_handler.parentchain_id();
 	thread::Builder::new()
 		.name(format!("{:?}_parentchain_sync_loop", parentchain_id))
 		.spawn(move || {

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -387,9 +387,6 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 
 	let tokio_handle = tokio_handle_getter.get_handle();
 
-	#[cfg(feature = "teeracle")]
-	let teeracle_tokio_handle = tokio_handle.clone();
-
 	// ------------------------------------------------------------------------
 	// Get the public key of our TEE.
 	let tee_accountid = enclave_account(enclave.as_ref());
@@ -455,7 +452,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 			&config,
 			enclave.clone(),
 			sidechain_storage.clone(),
-			tokio_handle,
+			&tokio_handle,
 		);
 	}
 

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -554,7 +554,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 				&integritee_rpc_api,
 				run_config.teeracle_update_interval(),
 				enclave.as_ref(),
-				&tokio_handle.clone(),
+				&tokio_handle,
 			);
 		},
 		WorkerMode::OffChainWorker => {

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -151,14 +151,14 @@ where
 
 		if last_synced_header.number == curr_block_number {
 			println!(
-				"[{:?}] No sync necessary, we are already up to date with block {}",
+				"[{:?}] No sync necessary, we are already up to date with block #{}",
 				id, last_synced_header.number,
 			);
 			return Ok(last_synced_header)
 		}
 
 		println!(
-			"[{:?}] Syncing blocks from {} to {}",
+			"[{:?}] Syncing blocks from #{} to #{}",
 			id, last_synced_header.number, curr_block_number
 		);
 

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -171,10 +171,6 @@ where
 
 		let mut until_synced_header = last_synced_header;
 		loop {
-			if &until_synced_header.number >= &curr_block_number {
-				return Ok(until_synced_header)
-			}
-
 			until_synced_header = self.sync_blocks(
 				until_synced_header.number + 1,
 				min(until_synced_header.number + BLOCK_SYNC_BATCH_SIZE, curr_block_number),
@@ -184,6 +180,10 @@ where
 				"[{:?}] Synced {} out of {} finalized parentchain blocks",
 				id, until_synced_header.number, curr_block_number,
 			);
+
+			if &until_synced_header.number >= &curr_block_number {
+				return Ok(until_synced_header)
+			}
 		}
 	}
 

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -157,13 +157,6 @@ where
 			return Ok(last_synced_header)
 		}
 
-		if last_synced_header.number > curr_block_number {
-			return Err(Error::ApplicationSetup(format!(
-				"[{:?}] Bad config, last synced header {} is recent than current parentchain head {}",
-				id, last_synced_header.number, curr_block_number
-			)))
-		}
-
 		println!(
 			"[{:?}] Syncing blocks from {} to {}",
 			id, last_synced_header.number, curr_block_number
@@ -228,6 +221,13 @@ where
 {
 	fn sync_blocks(&self, from: u32, to: u32) -> ServiceResult<Header> {
 		let id = self.parentchain_id();
+
+		if from > to {
+			return Err(Error::ApplicationSetup(format!(
+				"[{:?}] from can't be bigger than to. {} > {}",
+				id, from, to
+			)))
+		}
 
 		let blocks = self.parentchain_api.get_blocks(from, to)?;
 		println!("[+] [{:?}] Found {} block(s) to sync", id, blocks.len());

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -227,7 +227,7 @@ where
 
 			// Tested above that last_synced_header.number < current_block_number (i.e. chunk_target).
 			last_synced_header = self.sync_blocks(last_synced_header.number + 1, chunk_target)?;
-			trace!("[{:?}] synced block number: #{}", id, last_synced_header.number);
+			println!("[{:?}] synced block number: #{}", id, last_synced_header.number);
 
 			// Verify and import blocks into the light client. This can't be done after the loop
 			// because the import is mandatory to remove them from RAM. When we register on
@@ -255,14 +255,14 @@ where
 		}
 
 		let blocks = self.parentchain_api.get_blocks(from, to)?;
-		println!("[+] [{:?}] Found {} block(s) to sync", id, blocks.len());
+		debug!("[+] [{:?}] Found {} block(s) to sync", id, blocks.len());
 
 		let events: Vec<Vec<u8>> = blocks
 			.iter()
 			.map(|block| self.parentchain_api.get_events_for_block(Some(block.block.header.hash())))
 			.collect::<Result<Vec<_>, _>>()?;
 
-		println!("[+] [{:?}] Found {} event vector(s) to sync", id, events.len());
+		debug!("[+] [{:?}] Found {} event vector(s) to sync", id, events.len());
 
 		let events_proofs: Vec<StorageProof> = blocks
 			.iter()

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -163,7 +163,7 @@ where
 		);
 
 		let mut synced_until = last_synced_header;
-		while synced_until.number() <= &curr_block_number {
+		while synced_until.number() < &curr_block_number {
 			synced_until = self.sync_blocks(
 				synced_until.number + 1,
 				// while statement tests that synced_until.number < curr_block_number
@@ -248,8 +248,8 @@ where
 		let id = self.parentchain_id();
 
 		if from > to {
-			return Err(Error::ApplicationSetup(format!(
-				"[{:?}] `from` can't be bigger than `to`. {} > {}",
+			return Err(Error::BlockSync(format!(
+				"[{:?}] Block range to import must be positive, i.e., `from` can't be bigger than `to`. {} > {}",
 				id, from, to
 			)))
 		}

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -199,7 +199,7 @@ where
 	) -> ServiceResult<Header> {
 		let id = self.parentchain_id();
 
-		trace!(
+		printl!(
 			"[{:?}] last synced block number: {}. synching until {}",
 			id,
 			last_synced_header.number,

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -242,8 +242,13 @@ where
 		while last_synced_header.number() < until_header.number() {
 			last_synced_header = self.sync_parentchain(last_synced_header)?;
 			trace!("[{:?}] synced block number: {}", id, last_synced_header.number);
+
+			// Verify and import blocks into the light client. This can't be done after the loop
+			// because the import is mandatory to remove them from RAM loop. When we register on
+			// a production system that has already many blocks this might lead to an OOM if we
+			// import them all at once after the loop, see #1462.
+			self.trigger_parentchain_block_import()?;
 		}
-		self.trigger_parentchain_block_import()?;
 
 		Ok(last_synced_header)
 	}

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -140,7 +140,7 @@ where
 			.init_parentchain_components(self.parentchain_init_params.clone())?)
 	}
 
-	fn sync_parentchain(&self, sync_until_header: Header) -> ServiceResult<Header> {
+	fn sync_parentchain(&self, last_synced_header: Header) -> ServiceResult<Header> {
 		let id = self.parentchain_id();
 		trace!("[{:?}] Getting current head", id);
 		let curr_block = self
@@ -149,28 +149,28 @@ where
 			.ok_or(Error::MissingLastFinalizedBlock)?;
 		let curr_block_number = curr_block.block.header().number();
 
-		if sync_until_header.number == curr_block_number {
+		if last_synced_header.number == curr_block_number {
 			println!(
 				"[{:?}] No sync necessary, we are already up to date with block {}",
-				id, sync_until_header.number,
+				id, last_synced_header.number,
 			);
-			return Ok(sync_until_header)
+			return Ok(last_synced_header)
 		}
 
-		if sync_until_header.number > curr_block_number {
+		if last_synced_header.number > curr_block_number {
 			return Err(Error::ApplicationSetup(format!(
 				"[{:?}] Bad config, last synced header {} is recent than current parentchain head {}",
-				id, sync_until_header.number, curr_block_number
+				id, last_synced_header.number, curr_block_number
 			)))
 		}
 
 		println!(
 			"[{:?}] Syncing blocks from {} to {}",
-			id, sync_until_header.number, curr_block_number
+			id, last_synced_header.number, curr_block_number
 		);
 
-		let sync_until = sync_until_header.number;
-		let mut until_synced_header = sync_until_header;
+		let sync_until = last_synced_header.number;
+		let mut until_synced_header = last_synced_header;
 		loop {
 			if &until_synced_header.number >= &sync_until {
 				return Ok(until_synced_header)

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -149,6 +149,21 @@ where
 			.ok_or(Error::MissingLastFinalizedBlock)?;
 		let curr_block_number = curr_block.block.header().number();
 
+		if last_synced_header.number == curr_block_number {
+			println!(
+				"[{:?}] No sync necessary, we are already up to date with block {}",
+				id, last_synced_header.number,
+			);
+			return Ok(last_synced_header)
+		}
+
+		if last_synced_header.number > curr_block_number {
+			return Err(Error::ApplicationSetup(format!(
+				"[{:?}] Bad config, last synced header {} is recent than current parentchain head {}",
+				id, last_synced_header.number, curr_block_number
+			)))
+		}
+
 		println!(
 			"[{:?}] Syncing blocks from {} to {}",
 			id, last_synced_header.number, curr_block_number

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -166,6 +166,7 @@ where
 		while synced_until.number() <= &curr_block_number {
 			synced_until = self.sync_blocks(
 				synced_until.number + 1,
+				// while statement tests that synced_until.number < curr_block_number
 				min(synced_until.number + BLOCK_SYNC_BATCH_SIZE, curr_block_number),
 			)?;
 

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -192,7 +192,7 @@ where
 		let id = self.parentchain_id();
 
 		println!(
-			"[{:?}] last synced block number: {}. syncing until {}",
+			"[{:?}] last synced block number: #{}. syncing until #{}",
 			id, last_synced_header.number, sync_target.number
 		);
 		let mut last_synced_header = last_synced_header.clone();
@@ -227,7 +227,7 @@ where
 
 			// Tested above that last_synced_header.number < current_block_number (i.e. chunk_target).
 			last_synced_header = self.sync_blocks(last_synced_header.number + 1, chunk_target)?;
-			trace!("[{:?}] synced block number: {}", id, last_synced_header.number);
+			trace!("[{:?}] synced block number: #{}", id, last_synced_header.number);
 
 			// Verify and import blocks into the light client. This can't be done after the loop
 			// because the import is mandatory to remove them from RAM. When we register on
@@ -249,7 +249,7 @@ where
 
 		if from > to {
 			return Err(Error::ApplicationSetup(format!(
-				"[{:?}] from can't be bigger than to. {} > {}",
+				"[{:?}] `from` can't be bigger than `to`. {} > {}",
 				id, from, to
 			)))
 		}

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -169,10 +169,9 @@ where
 			id, last_synced_header.number, curr_block_number
 		);
 
-		let sync_until = last_synced_header.number;
 		let mut until_synced_header = last_synced_header;
 		loop {
-			if &until_synced_header.number >= &sync_until {
+			if &until_synced_header.number >= &curr_block_number {
 				return Ok(until_synced_header)
 			}
 

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -176,7 +176,7 @@ where
 			);
 		}
 
-		return Ok(synced_until)
+		Ok(synced_until)
 	}
 
 	fn trigger_parentchain_block_import(&self) -> ServiceResult<()> {

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -162,22 +162,20 @@ where
 			id, last_synced_header.number, curr_block_number
 		);
 
-		let mut until_synced_header = last_synced_header;
-		loop {
-			until_synced_header = self.sync_blocks(
-				until_synced_header.number + 1,
-				min(until_synced_header.number + BLOCK_SYNC_BATCH_SIZE, curr_block_number),
+		let mut synced_until = last_synced_header;
+		while synced_until.number() <= &curr_block_number {
+			synced_until = self.sync_blocks(
+				synced_until.number + 1,
+				min(synced_until.number + BLOCK_SYNC_BATCH_SIZE, curr_block_number),
 			)?;
 
 			println!(
 				"[{:?}] Synced {} out of {} finalized parentchain blocks",
-				id, until_synced_header.number, curr_block_number,
+				id, synced_until.number, curr_block_number,
 			);
-
-			if &until_synced_header.number >= &curr_block_number {
-				return Ok(until_synced_header)
-			}
 		}
+
+		return Ok(synced_until)
 	}
 
 	fn trigger_parentchain_block_import(&self) -> ServiceResult<()> {

--- a/service/src/sidechain_setup.rs
+++ b/service/src/sidechain_setup.rs
@@ -40,7 +40,7 @@ pub(crate) fn sidechain_start_untrusted_rpc_server<Enclave, SidechainStorage>(
 	config: &Config,
 	enclave: Arc<Enclave>,
 	sidechain_storage: Arc<SidechainStorage>,
-	tokio_handle: Handle,
+	tokio_handle: &Handle,
 ) where
 	Enclave: DirectRequest + Clone,
 	SidechainStorage: BlockPruner + FetchBlocks<SignedSidechainBlock> + Sync + Send + 'static,


### PR DESCRIPTION
* The problem behind the OOM error was that we had synced the whole parentchain before we imported the blocks into the light client. This PR changes the behaviour to trigger the import of the parentchain blocks after each chunk in the `sync_parentchain_and_import_blocks` function. The behaviour of `sync_parentchain` has not been changed. This is because it is either used by non-primary workers, which have only small syncs, as they receive a light-client-db from the primary worker at startup, or it is used in the teeracle/offchain worker modes, which directly import the parentchain blocks when they are synced. Closes #1462.

* Another minor fix is included that fixes #1465