### PR TITLE
[its-consensus-slots] fix flaky tests, which are due to parallelism

### DIFF
--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -342,10 +342,8 @@ mod tests {
 
 	#[test]
 	fn yield_next_slot_returns_none_when_slot_equals_last_slot() {
-		let _lock = LastSlot::set_last_slot(slot_from_timestamp_and_duration(
-			duration_now(),
-			SLOT_DURATION,
-		));
+		let _lock =
+			LastSlot.set_last_slot(slot_from_timestamp_and_duration(duration_now(), SLOT_DURATION));
 		assert!(yield_next_slot::<_, ParentchainBlock>(
 			duration_now(),
 			SLOT_DURATION,
@@ -358,10 +356,8 @@ mod tests {
 
 	#[test]
 	fn yield_next_slot_returns_next_slot() {
-		let _lock = LastSlot::set_last_slot(slot_from_timestamp_and_duration(
-			duration_now(),
-			SLOT_DURATION,
-		));
+		let _lock =
+			LastSlot.set_last_slot(slot_from_timestamp_and_duration(duration_now(), SLOT_DURATION));
 		assert!(yield_next_slot::<_, ParentchainBlock>(
 			duration_now() + SLOT_DURATION,
 			SLOT_DURATION,

--- a/sidechain/consensus/slots/src/slots.rs
+++ b/sidechain/consensus/slots/src/slots.rs
@@ -342,6 +342,10 @@ mod tests {
 
 	#[test]
 	fn yield_next_slot_returns_none_when_slot_equals_last_slot() {
+		let _lock = LastSlot::set_last_slot(slot_from_timestamp_and_duration(
+			duration_now(),
+			SLOT_DURATION,
+		));
 		assert!(yield_next_slot::<_, ParentchainBlock>(
 			duration_now(),
 			SLOT_DURATION,
@@ -354,6 +358,10 @@ mod tests {
 
 	#[test]
 	fn yield_next_slot_returns_next_slot() {
+		let _lock = LastSlot::set_last_slot(slot_from_timestamp_and_duration(
+			duration_now(),
+			SLOT_DURATION,
+		));
 		assert!(yield_next_slot::<_, ParentchainBlock>(
 			duration_now() + SLOT_DURATION,
 			SLOT_DURATION,


### PR DESCRIPTION
I think I found out why we had a flaky yield next slot test, which was a combination of having a global `LastSlot` object, but parallel tests. Depending on the order of the tests, it could be a slot was yielded even though it shouldn't have. I ran the problematic test 15 times on my local machine, and it passed every time, and the CI was also green on the first try. Hence, I believe that it is fixed.

* Closes https://github.com/integritee-network/worker/issues/1343
