### PR TITLE
[CI] refactor clippy tests and fix clippy CI OOM

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -126,7 +126,6 @@ jobs:
           docker images --all
 
   code-quality:
-    name: ${{ matrix.check }}
     runs-on: ubuntu-latest
     container: "integritee/integritee-dev:0.2.2"
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -140,10 +140,6 @@ jobs:
   strategy:
     fail-fast: false
     matrix:
-      # We need to compile `test-no-std` separately, otherwise we have std leaks from the build-deps.
-      #
-      # `test-no-std` is only meant to check if the `substrate-api-client` compiles to `no_std`, hence
-      # we omit clippy and test there.
       check: [
         # Worker
         cargo clippy -- -D warnings,
@@ -166,7 +162,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: init-rust-target
-        # enclave is not in the same workspace
+        # Enclave is not in the same workspace
         run: rustup show && cd enclave-runtime && rustup show
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -148,8 +148,8 @@ jobs:
           cd enclave-runtime && cargo clippy --features offchain-worker -- -D warnings,
 
           # Fmt
-          cargo fmt --all -- --check
-          cd enclave-runtime && cargo fmt --all -- --check
+          cargo fmt --all -- --check,
+          cd enclave-runtime && cargo fmt --all -- --check,
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -149,7 +149,7 @@ jobs:
 
           # Fmt
           cargo fmt --all -- --check
-            cd enclave-runtime && cargo fmt --all -- --check
+          cd enclave-runtime && cargo fmt --all -- --check
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -156,6 +156,14 @@ jobs:
         # Enclave is not in the same workspace
         run: rustup show && cd enclave-runtime && rustup show
 
+      - name: Free up disk space
+        if: startsWith(runner.name, 'GitHub Actions')
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          swap-storage: false
+          large-packages: false
+
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.check }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -125,40 +125,31 @@ jobs:
           fi
           docker images --all
 
-  clippy:
+  name: "Code Quality:" ${{ matrix.check }}
     runs-on: ubuntu-latest
     container: "integritee/integritee-dev:0.2.2"
-    steps:
-      - uses: actions/checkout@v3
-      - name: init rust
-        # enclave is not in the same workspace
-        run: rustup show && cd enclave-runtime && rustup show
+    strategy:
+      fail-fast: false
+      matrix:
+        check: [
+          # Worker
+          cargo clippy -- -D warnings,
+          cargo clippy --features evm -- -D warnings,
+          cargo clippy --features sidechain -- -D warnings,
+          cargo clippy --features teeracle -- -D warnings,
+          cargo clippy --features offchain-worker -- -D warnings,
 
-  name: "Code Quality:" ${{ matrix.check }}
-  runs-on: ubuntu-latest
-  container: "integritee/integritee-dev:0.2.2"
-  strategy:
-    fail-fast: false
-    matrix:
-      check: [
-        # Worker
-        cargo clippy -- -D warnings,
-        cargo clippy --features evm -- -D warnings,
-        cargo clippy --features sidechain -- -D warnings,
-        cargo clippy --features teeracle -- -D warnings,
-        cargo clippy --features offchain-worker -- -D warnings,
+          # Enclave
+          cd enclave-runtime && cargo clippy -- -D warnings,
+          cd enclave-runtime && cargo clippy --features evm -- -D warnings,
+          cd enclave-runtime && cargo clippy --features sidechain -- -D warnings,
+          cd enclave-runtime && cargo clippy --features teeracle -- -D warnings,
+          cd enclave-runtime && cargo clippy --features offchain-worker -- -D warnings,
 
-        # Enclave
-        cd enclave-runtime && cargo clippy -- -D warnings,
-        cd enclave-runtime && cargo clippy --features evm -- -D warnings,
-        cd enclave-runtime && cargo clippy --features sidechain -- -D warnings,
-        cd enclave-runtime && cargo clippy --features teeracle -- -D warnings,
-        cd enclave-runtime && cargo clippy --features offchain-worker -- -D warnings,
-
-        # Fmt
-        cargo fmt --all -- --check
-        cd enclave-runtime && cargo fmt --all -- --check
-      ]
+          # Fmt
+          cargo fmt --all -- --check
+            cd enclave-runtime && cargo fmt --all -- --check
+        ]
     steps:
       - uses: actions/checkout@v3
       - name: init-rust-target
@@ -366,7 +357,7 @@ jobs:
     runs-on: integritee-builder-sgx
     name: Release Build of teeracle
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-test, integration-tests]
+    needs: [ build-test, integration-tests ]
 
     strategy:
       fail-fast: false
@@ -440,8 +431,8 @@ jobs:
 
       - name: Save released teeracle
         run: |
-            docker image save integritee/${{ matrix.flavor_id }}:${{ github.ref_name }} | gzip > integritee-worker-${{ matrix.flavor_id }}-${{ github.ref_name }}.tar.gz
-            docker images --all
+          docker image save integritee/${{ matrix.flavor_id }}:${{ github.ref_name }} | gzip > integritee-worker-${{ matrix.flavor_id }}-${{ github.ref_name }}.tar.gz
+          docker images --all
 
       - name: Upload teeracle image
         uses: actions/upload-artifact@v3
@@ -451,16 +442,16 @@ jobs:
 
       - name: Delete images
         run: |
-            if [[ "$(docker images -q integritee/${{ matrix.flavor_id }}:${{ github.ref_name }} 2> /dev/null)" != "" ]]; then
-                docker image rmi --force integritee/${{ matrix.flavor_id }}:${{ github.ref_name }} 2>/dev/null
-            fi
-            docker images --all
+          if [[ "$(docker images -q integritee/${{ matrix.flavor_id }}:${{ github.ref_name }} 2> /dev/null)" != "" ]]; then
+              docker image rmi --force integritee/${{ matrix.flavor_id }}:${{ github.ref_name }} 2>/dev/null
+          fi
+          docker images --all
 
   release:
     runs-on: ubuntu-latest
     name: Draft Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-test, integration-tests, release-build]
+    needs: [ build-test, integration-tests, release-build ]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -125,7 +125,8 @@ jobs:
           fi
           docker images --all
 
-  name: "Code Quality:" ${{ matrix.check }}
+  code-quality:
+    name: ${{ matrix.check }}
     runs-on: ubuntu-latest
     container: "integritee/integritee-dev:0.2.2"
     strategy:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -133,11 +133,12 @@ jobs:
       matrix:
         check: [
           # Worker
-          cargo clippy -- -D warnings,
-          cargo clippy --features evm -- -D warnings,
-          cargo clippy --features sidechain -- -D warnings,
-          cargo clippy --features teeracle -- -D warnings,
-          cargo clippy --features offchain-worker -- -D warnings,
+          # Use release mode as the CI runs out of disk space otherwise.
+          cargo clippy --release -- -D warnings,
+          cargo clippy --release --features evm -- -D warnings,
+          cargo clippy --release --features sidechain -- -D warnings,
+          cargo clippy --release --features teeracle -- -D warnings,
+          cargo clippy --release --features offchain-worker -- -D warnings,
 
           # Enclave
           cd enclave-runtime && cargo clippy -- -D warnings,

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -156,14 +156,6 @@ jobs:
         # Enclave is not in the same workspace
         run: rustup show && cd enclave-runtime && rustup show
 
-      - name: Free up disk space
-        if: startsWith(runner.name, 'GitHub Actions')
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          swap-storage: false
-          large-packages: false
-
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.check }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -134,46 +134,54 @@ jobs:
         # enclave is not in the same workspace
         run: rustup show && cd enclave-runtime && rustup show
 
-      - name: Clippy default features
-        run: cargo clippy -- -D warnings
-      - name: Enclave # Enclave is separate as it's not in the workspace
-        run: cd enclave-runtime && cargo clippy -- -D warnings
+  name: "Code Quality:" ${{ matrix.check }}
+  runs-on: ubuntu-latest
+  container: "integritee/integritee-dev:0.2.2"
+  strategy:
+    fail-fast: false
+    matrix:
+      # We need to compile `test-no-std` separately, otherwise we have std leaks from the build-deps.
+      #
+      # `test-no-std` is only meant to check if the `substrate-api-client` compiles to `no_std`, hence
+      # we omit clippy and test there.
+      check: [
+        # Worker
+        cargo clippy -- -D warnings,
+        cargo clippy --features evm -- -D warnings,
+        cargo clippy --features sidechain -- -D warnings,
+        cargo clippy --features teeracle -- -D warnings,
+        cargo clippy --features offchain-worker -- -D warnings,
 
-      - name: Clippy with EVM feature
-        run: |
-          cargo clippy --features evm -- -D warnings
-          cd enclave-runtime && cargo clippy --features evm -- -D warnings
+        # Enclave
+        cd enclave-runtime && cargo clippy -- -D warnings,
+        cd enclave-runtime && cargo clippy --features evm -- -D warnings,
+        cd enclave-runtime && cargo clippy --features sidechain -- -D warnings,
+        cd enclave-runtime && cargo clippy --features teeracle -- -D warnings,
+        cd enclave-runtime && cargo clippy --features offchain-worker -- -D warnings,
 
-      - name: Clippy with Sidechain feature
-        run: |
-          cargo clippy --features sidechain -- -D warnings
-          cd enclave-runtime && cargo clippy --features sidechain -- -D warnings
+        # Fmt
+        cargo fmt --all -- --check
+        cd enclave-runtime && cargo fmt --all -- --check
+      ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: init-rust-target
+        # enclave is not in the same workspace
+        run: rustup show && cd enclave-runtime && rustup show
 
-      - name: Clippy with Teeracle feature
-        run: |
-          cargo clippy --features teeracle -- -D warnings
-          cd enclave-runtime && cargo clippy --features teeracle -- -D warnings
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.check }}
 
-      - name: Clippy with Offchain-worker feature
-        run: |
-          cargo clippy --features offchain-worker -- -D warnings
-          cd enclave-runtime && cargo clippy --features offchain-worker -- -D warnings
+      - name: ${{ matrix.check }}
+        run: ${{ matrix.check }}
 
-      - name: Fail-fast; cancel other jobs
-        if: failure()
-        uses: andymckay/cancel-action@0.3
-
-  fmt:
+  toml-fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: init rust
         run: rustup show
-
-      - name: Worker & Client
-        run: cargo fmt --all -- --check
-      - name: Enclave # Enclave is separate as it's not in the workspace
-        run: cd enclave-runtime && cargo fmt --all -- --check
 
       - name: Install taplo
         run: cargo install taplo-cli --locked


### PR DESCRIPTION
Fixing it by putting the individual tests into a matrix that runs them in parallel on different machines. This also reduces the total time to run those clippy tests (less than linearly though, as the subsequent tests partly benefited from the cargo cache of the test before).

* Closes #1464 