### PR TITLE
Ab/shield from shard vault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,6 +3221,7 @@ dependencies = [
  "itp-sgx-crypto",
  "itp-sgx-runtime-primitives",
  "itp-stf-executor",
+ "itp-stf-interface",
  "itp-stf-primitives",
  "itp-test",
  "itp-top-pool-author",

--- a/app-libs/parentchain-interface/src/integritee/event_filter.rs
+++ b/app-libs/parentchain-interface/src/integritee/event_filter.rs
@@ -74,12 +74,7 @@ impl FilterEvents for FilterableEvents {
 			.iter()
 			.flatten() // flatten filters out the nones
 			.filter_map(|ev| match ev.as_event::<BalanceTransfer>() {
-				Ok(maybe_event) => {
-					if maybe_event.is_none() {
-						log::warn!("Transfer event does not exist in parentchain metadata");
-					};
-					maybe_event
-				},
+				Ok(maybe_event) => maybe_event,
 				Err(e) => {
 					log::error!("Could not decode event: {:?}", e);
 					None

--- a/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -68,7 +68,7 @@ where
 				.iter()
 				.filter(|&event| event.to == *vault_account)
 				.try_for_each(|event| {
-					info!("transfer_event: {}", event);
+					info!("found transfer_event to vault account: {}", event);
 					//call = IndirectCall::ShieldFunds(ShieldFundsArgs{ })
 					Self::shield_funds(executor, &event.from, event.amount)
 				})

--- a/app-libs/parentchain-interface/src/integritee/event_handler.rs
+++ b/app-libs/parentchain-interface/src/integritee/event_handler.rs
@@ -22,16 +22,8 @@ use ita_stf::{Getter, TrustedCall, TrustedCallSigned};
 use itc_parentchain_indirect_calls_executor::error::Error;
 use itp_stf_primitives::{traits::IndirectExecutor, types::TrustedOperation};
 use itp_types::parentchain::{AccountId, FilterEvents, HandleParentchainEvents, ParentchainError};
+use itp_utils::hex::hex_encode;
 use log::*;
-
-type Seed = [u8; 32];
-
-const ALICE_ENCODED: Seed = [
-	212, 53, 147, 199, 21, 253, 211, 28, 97, 20, 26, 189, 4, 169, 159, 214, 130, 44, 133, 88, 133,
-	76, 205, 227, 154, 86, 132, 231, 165, 109, 162, 125,
-];
-
-const SHIELDING_ACCOUNT: AccountId = AccountId::new(ALICE_ENCODED);
 
 pub struct ParentchainEventHandler {}
 
@@ -61,13 +53,20 @@ impl<Executor> HandleParentchainEvents<Executor, TrustedCallSigned, Error>
 where
 	Executor: IndirectExecutor<TrustedCallSigned, Error>,
 {
-	fn handle_events(executor: &Executor, events: impl FilterEvents) -> Result<(), Error> {
+	fn handle_events(
+		executor: &Executor,
+		events: impl FilterEvents,
+		vault_account: &AccountId,
+	) -> Result<(), Error> {
 		let filter_events = events.get_transfer_events();
-
+		trace!(
+			"filtering transfer events to shard vault account: {}",
+			hex_encode(vault_account.encode().as_slice())
+		);
 		if let Ok(events) = filter_events {
 			events
 				.iter()
-				.filter(|&event| event.to == SHIELDING_ACCOUNT)
+				.filter(|&event| event.to == *vault_account)
 				.try_for_each(|event| {
 					info!("transfer_event: {}", event);
 					//call = IndirectCall::ShieldFunds(ShieldFundsArgs{ })

--- a/app-libs/parentchain-interface/src/target_a/event_handler.rs
+++ b/app-libs/parentchain-interface/src/target_a/event_handler.rs
@@ -20,7 +20,7 @@ pub use ita_sgx_runtime::{Balance, Index};
 use ita_stf::TrustedCallSigned;
 use itc_parentchain_indirect_calls_executor::error::Error;
 use itp_stf_primitives::traits::IndirectExecutor;
-use itp_types::parentchain::{FilterEvents, HandleParentchainEvents};
+use itp_types::parentchain::{AccountId, FilterEvents, HandleParentchainEvents};
 use log::*;
 
 pub struct ParentchainEventHandler {}
@@ -30,7 +30,11 @@ impl<Executor> HandleParentchainEvents<Executor, TrustedCallSigned, Error>
 where
 	Executor: IndirectExecutor<TrustedCallSigned, Error>,
 {
-	fn handle_events(_executor: &Executor, _events: impl FilterEvents) -> Result<(), Error> {
+	fn handle_events(
+		_executor: &Executor,
+		_events: impl FilterEvents,
+		_vault_account: &AccountId,
+	) -> Result<(), Error> {
 		debug!("not handling any events for target A");
 		Ok(())
 	}

--- a/app-libs/parentchain-interface/src/target_b/event_handler.rs
+++ b/app-libs/parentchain-interface/src/target_b/event_handler.rs
@@ -20,7 +20,7 @@ pub use ita_sgx_runtime::{Balance, Index};
 use ita_stf::TrustedCallSigned;
 use itc_parentchain_indirect_calls_executor::error::Error;
 use itp_stf_primitives::traits::IndirectExecutor;
-use itp_types::parentchain::{FilterEvents, HandleParentchainEvents};
+use itp_types::parentchain::{AccountId, FilterEvents, HandleParentchainEvents};
 use log::*;
 
 pub struct ParentchainEventHandler {}
@@ -30,7 +30,11 @@ impl<Executor> HandleParentchainEvents<Executor, TrustedCallSigned, Error>
 where
 	Executor: IndirectExecutor<TrustedCallSigned, Error>,
 {
-	fn handle_events(_executor: &Executor, _events: impl FilterEvents) -> Result<(), Error> {
+	fn handle_events(
+		_executor: &Executor,
+		_events: impl FilterEvents,
+		_vault_account: &AccountId,
+	) -> Result<(), Error> {
 		debug!("not handling any events for target B");
 		Ok(())
 	}

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -26,11 +26,15 @@ use itp_stf_interface::{
 	parentchain_pallet::ParentchainPalletInterface,
 	sudo_pallet::SudoPalletInterface,
 	system_pallet::{SystemPalletAccountInterface, SystemPalletEventInterface},
-	ExecuteCall, ExecuteGetter, InitState, StateCallInterface, StateGetterInterface, UpdateState,
+	ExecuteCall, ExecuteGetter, InitState, ShardVaultQuery, StateCallInterface,
+	StateGetterInterface, UpdateState, SHARD_VAULT_KEY,
 };
 use itp_stf_primitives::{error::StfError, traits::TrustedCallVerification};
 use itp_storage::storage_value_key;
-use itp_types::{parentchain::ParentchainId, OpaqueCall};
+use itp_types::{
+	parentchain::{AccountId, ParentchainId},
+	OpaqueCall,
+};
 use itp_utils::stringify::account_id_to_string;
 use log::*;
 use sp_runtime::traits::StaticLookup;
@@ -157,6 +161,17 @@ where
 {
 	fn execute_getter(state: &mut State, getter: G) -> Option<Vec<u8>> {
 		state.execute_with(|| getter.execute())
+	}
+}
+
+impl<TCS, G, State, Runtime> ShardVaultQuery<State> for Stf<TCS, G, State, Runtime>
+where
+	State: SgxExternalitiesTrait + Debug,
+{
+	fn get_vault(state: &mut State) -> Option<AccountId> {
+		state
+			.get(&SHARD_VAULT_KEY.as_bytes())
+			.and_then(|v| Decode::decode(&mut v.clone().as_slice()).ok())
 	}
 }
 

--- a/core-primitives/stf-executor/src/enclave_signer.rs
+++ b/core-primitives/stf-executor/src/enclave_signer.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	error::{Error, Result},
-	traits::StfEnclaveSigning,
+	traits::{StfEnclaveSigning, StfShardVaultQuery},
 	H256,
 };
 use codec::{Decode, Encode};
@@ -25,7 +25,7 @@ use core::{fmt::Debug, marker::PhantomData};
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_crypto::{ed25519_derivation::DeriveEd25519, key_repository::AccessKey};
 use itp_sgx_externalities::SgxExternalitiesTrait;
-use itp_stf_interface::system_pallet::SystemPalletAccountInterface;
+use itp_stf_interface::{system_pallet::SystemPalletAccountInterface, ShardVaultQuery};
 use itp_stf_primitives::{
 	traits::TrustedCallSigning,
 	types::{AccountId, KeyPair},
@@ -60,7 +60,8 @@ where
 	StateObserver::StateType: SgxExternalitiesTrait,
 	ShieldingKeyRepository: AccessKey,
 	<ShieldingKeyRepository as AccessKey>::KeyType: DeriveEd25519,
-	Stf: SystemPalletAccountInterface<StateObserver::StateType, AccountId>,
+	Stf: SystemPalletAccountInterface<StateObserver::StateType, AccountId>
+		+ ShardVaultQuery<StateObserver::StateType>,
 	Stf::Index: Into<Index>,
 	TopPoolAuthor: AuthorApi<H256, H256, TCS, G> + Send + Sync + 'static,
 	TCS: PartialEq + Encode + Decode + Debug + Send + Sync,
@@ -105,7 +106,8 @@ where
 	StateObserver::StateType: SgxExternalitiesTrait,
 	ShieldingKeyRepository: AccessKey,
 	<ShieldingKeyRepository as AccessKey>::KeyType: DeriveEd25519,
-	Stf: SystemPalletAccountInterface<StateObserver::StateType, AccountId>,
+	Stf: SystemPalletAccountInterface<StateObserver::StateType, AccountId>
+		+ ShardVaultQuery<StateObserver::StateType>,
 	Stf::Index: Into<Index>,
 	TopPoolAuthor: AuthorApi<H256, H256, TCS, G> + Send + Sync + 'static,
 	TCS: PartialEq + Encode + Decode + Debug + Send + Sync,
@@ -140,5 +142,27 @@ where
 			&mr_enclave.m,
 			shard,
 		))
+	}
+}
+
+impl<OCallApi, StateObserver, ShieldingKeyRepository, Stf, TopPoolAuthor, TCS, G> StfShardVaultQuery
+	for StfEnclaveSigner<OCallApi, StateObserver, ShieldingKeyRepository, Stf, TopPoolAuthor, TCS, G>
+where
+	OCallApi: EnclaveAttestationOCallApi,
+	StateObserver: ObserveState,
+	StateObserver::StateType: SgxExternalitiesTrait,
+	ShieldingKeyRepository: AccessKey,
+	<ShieldingKeyRepository as AccessKey>::KeyType: DeriveEd25519,
+	Stf: SystemPalletAccountInterface<StateObserver::StateType, AccountId>
+		+ ShardVaultQuery<StateObserver::StateType>,
+	Stf::Index: Into<Index>,
+	TopPoolAuthor: AuthorApi<H256, H256, TCS, G> + Send + Sync + 'static,
+	TCS: PartialEq + Encode + Decode + Debug + Send + Sync,
+	G: PartialEq + Encode + Decode + Debug + Send + Sync,
+{
+	fn get_shard_vault(&self, shard: &ShardIdentifier) -> Result<AccountId> {
+		let vault = self.state_observer.observe_state(shard, move |state| Stf::get_vault(state))?;
+
+		vault.ok_or_else(|| Error::Other("shard vault undefined".into()))
 	}
 }

--- a/core-primitives/stf-executor/src/traits.rs
+++ b/core-primitives/stf-executor/src/traits.rs
@@ -49,6 +49,10 @@ where
 	) -> Result<TCS>;
 }
 
+pub trait StfShardVaultQuery {
+	fn get_shard_vault(&self, shard: &ShardIdentifier) -> Result<AccountId>;
+}
+
 /// Proposes a state update to `Externalities`.
 pub trait StateUpdateProposer<TCS, G>
 where

--- a/core-primitives/stf-interface/src/lib.rs
+++ b/core-primitives/stf-interface/src/lib.rs
@@ -28,7 +28,10 @@ use core::fmt::Debug;
 use itp_node_api_metadata::NodeMetadataTrait;
 use itp_node_api_metadata_provider::AccessNodeMetadata;
 use itp_stf_primitives::traits::TrustedCallVerification;
-use itp_types::{parentchain::ParentchainId, OpaqueCall};
+use itp_types::{
+	parentchain::{AccountId, ParentchainId},
+	OpaqueCall,
+};
 
 #[cfg(feature = "mocks")]
 pub mod mocks;
@@ -42,6 +45,11 @@ pub const SHARD_VAULT_KEY: &str = "ShardVaultPubKey";
 pub trait InitState<State, AccountId> {
 	/// Initialize a new state for a given enclave account.
 	fn init_state(enclave_account: AccountId) -> State;
+}
+
+/// Interface to query shard vault account for shard
+pub trait ShardVaultQuery<S> {
+	fn get_vault(state: &mut S) -> Option<AccountId>;
 }
 
 /// Interface for all functions calls necessary to update an already

--- a/core-primitives/types/src/parentchain.rs
+++ b/core-primitives/types/src/parentchain.rs
@@ -129,6 +129,7 @@ where
 	fn handle_events(
 		executor: &Executor,
 		events: impl FilterEvents,
+		vault_account: &AccountId,
 	) -> core::result::Result<(), Error>;
 }
 

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -144,7 +144,7 @@ impl<
 				Ok(executed_shielding_calls) => {
 					calls.push(executed_shielding_calls);
 				},
-				Err(_) => error!("[{:?}] Error executing relevant extrinsics", id),
+				Err(e) => error!("[{:?}] Error executing relevant extrinsics: {:?}", id, e),
 			};
 
 			info!(

--- a/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -16,6 +16,7 @@ itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features 
 itp-sgx-crypto = { path = "../../../core-primitives/sgx/crypto", default-features = false }
 itp-sgx-runtime-primitives = { path = "../../../core-primitives/sgx-runtime-primitives", default-features = false }
 itp-stf-executor = { path = "../../../core-primitives/stf-executor", default-features = false }
+itp-stf-interface = { path = "../../../core-primitives/stf-interface", default-features = false }
 itp-stf-primitives = { path = "../../../core-primitives/stf-primitives", default-features = false }
 itp-test = { path = "../../../core-primitives/test", default-features = false }
 itp-top-pool-author = { path = "../../../core-primitives/top-pool-author", default-features = false }
@@ -59,6 +60,7 @@ std = [
     "itp-ocall-api/std",
     "itp-sgx-crypto/std",
     "itp-stf-executor/std",
+    "itp-stf-interface/std",
     "itp-top-pool-author/std",
     "itp-api-client-types/std",
     "itp-test/std",

--- a/core/parentchain/indirect-calls-executor/src/executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/executor.rs
@@ -167,8 +167,9 @@ impl<
 		trace!("xt_statuses:: {:?}", xt_statuses);
 
 		let shard = self.get_default_shard();
-		let vault = self.stf_enclave_signer.get_shard_vault(&shard)?;
-		ParentchainEventHandler::handle_events(self, events, &vault)?;
+		if let Ok(vault) = self.stf_enclave_signer.get_shard_vault(&shard) {
+			ParentchainEventHandler::handle_events(self, events, &vault)?;
+		}
 
 		// This would be catastrophic but should never happen
 		if xt_statuses.len() != block.extrinsics().len() {

--- a/core/parentchain/indirect-calls-executor/src/executor.rs
+++ b/core/parentchain/indirect-calls-executor/src/executor.rs
@@ -33,7 +33,7 @@ use itp_node_api::metadata::{
 	NodeMetadataTrait,
 };
 use itp_sgx_crypto::{key_repository::AccessKey, ShieldingCryptoDecrypt, ShieldingCryptoEncrypt};
-use itp_stf_executor::traits::StfEnclaveSigning;
+use itp_stf_executor::traits::{StfEnclaveSigning, StfShardVaultQuery};
 use itp_stf_primitives::{
 	traits::{IndirectExecutor, TrustedCallSigning, TrustedCallVerification},
 	types::AccountId,
@@ -129,7 +129,7 @@ impl<
 	ShieldingKeyRepository: AccessKey,
 	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt<Error = itp_sgx_crypto::Error>
 		+ ShieldingCryptoEncrypt<Error = itp_sgx_crypto::Error>,
-	StfEnclaveSigner: StfEnclaveSigning<TCS>,
+	StfEnclaveSigner: StfEnclaveSigning<TCS> + StfShardVaultQuery,
 	TopPoolAuthor: AuthorApi<H256, H256, TCS, G> + Send + Sync + 'static,
 	NodeMetadataProvider: AccessNodeMetadata,
 	FilterIndirectCalls: FilterIntoDataFrom<NodeMetadataProvider::MetadataType>,
@@ -166,7 +166,9 @@ impl<
 		})?;
 		trace!("xt_statuses:: {:?}", xt_statuses);
 
-		ParentchainEventHandler::handle_events(self, events)?;
+		let shard = self.get_default_shard();
+		let vault = self.stf_enclave_signer.get_shard_vault(&shard)?;
+		ParentchainEventHandler::handle_events(self, events, &vault)?;
 
 		// This would be catastrophic but should never happen
 		if xt_statuses.len() != block.extrinsics().len() {
@@ -253,7 +255,7 @@ impl<
 	ShieldingKeyRepository: AccessKey,
 	<ShieldingKeyRepository as AccessKey>::KeyType: ShieldingCryptoDecrypt<Error = itp_sgx_crypto::Error>
 		+ ShieldingCryptoEncrypt<Error = itp_sgx_crypto::Error>,
-	StfEnclaveSigner: StfEnclaveSigning<TCS>,
+	StfEnclaveSigner: StfEnclaveSigning<TCS> + StfShardVaultQuery,
 	TopPoolAuthor: AuthorApi<H256, H256, TCS, G> + Send + Sync + 'static,
 	TCS: PartialEq + Encode + Decode + Debug + Clone + Send + Sync + TrustedCallVerification,
 	G: PartialEq + Encode + Decode + Debug + Clone + Send + Sync,

--- a/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -187,6 +187,7 @@ where
 	fn handle_events(
 		_: &Executor,
 		_: impl itp_types::parentchain::FilterEvents,
+		_: &AccountId,
 	) -> core::result::Result<(), Error> {
 		Ok(())
 	}

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "itp-sgx-crypto",
  "itp-sgx-runtime-primitives",
  "itp-stf-executor",
+ "itp-stf-interface",
  "itp-stf-primitives",
  "itp-test",
  "itp-top-pool-author",


### PR DESCRIPTION
closes #1495 

# testing
run node on host:
```
./target/release/integritee-node --dev --tmp --unsafe-ws-external --rpc-cors all 
```

run sidechain 
```
SGX_MODE=SW WORKER_MODE=sidechain WORKER_FEATURES=dcap make
cd bin
export RUST_LOG=info,substrate_api_client=warn,ws=warn,mio=warn,its_consensus_common=info,sidechain=info,integritee_service=trace,enclave_runtime=trace,ac_node_api=warn,sp_io=warn,itc_parentchain_indirect_calls_executor=trace,itp_stf_executor=trace,itc_parentchain_light_client=trace,itc_parentchain_block_importer=trace,itp_stf_state_handler=trace,ita_stf=trace,itp-attestation-handler=debug,itc_parentchain_indirect_calls_executor=trace,itp_top_pool=debug,itc_offchain_worker_executor=debug,ita_parentchain_interface=trace
./integritee-service -c -u ws://172.17.0.1 run --skip-ra --dev &> worker.log 
```
once you see the ProxyAdded event in js/apps, remember the delegator account which is the vault.

Now, use js/apps to send funds from Bob to _Vault_

* worker log should show `shielding for` ....
* and `ita_stf::trusted_cal[....] balance_shield([...]`

check shielded balance for Bob (find mrenclave in worker log)
```
./integritee-cli -u ws://172.17.0.1 trusted --mrenclave 2MyXuroF4yiR8A6S8t334C4ZvY6qyKxVBKsd8SPnVW3y balance //Bob
```
should return the amount you sent
q.e.d.