### PR TITLE
Clean up cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#e4ed74b0fb6c2fd5585f55c2702b97b56d99c7f6"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#d31ce7684a60a55b943b3355b2dacc6d0edcc371"
 dependencies = [
  "ac-primitives",
  "log 0.4.19",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#e4ed74b0fb6c2fd5585f55c2702b97b56d99c7f6"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#d31ce7684a60a55b943b3355b2dacc6d0edcc371"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#e4ed74b0fb6c2fd5585f55c2702b97b56d99c7f6"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#d31ce7684a60a55b943b3355b2dacc6d0edcc371"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -8219,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#e4ed74b0fb6c2fd5585f55c2702b97b56d99c7f6"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#d31ce7684a60a55b943b3355b2dacc6d0edcc371"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -8257,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.9.1"
-source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#e4ed74b0fb6c2fd5585f55c2702b97b56d99c7f6"
+source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#d31ce7684a60a55b943b3355b2dacc6d0edcc371"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -8863,7 +8863,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,15 +226,6 @@ checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
@@ -444,16 +435,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2-rfc"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-dependencies = [
- "arrayvec 0.4.12",
- "constant_time_eq 0.1.5",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,17 +442,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.3",
- "constant_time_eq 0.2.6",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
-dependencies = [
- "arrayref",
- "byte-tools 0.2.0",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -481,7 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
- "byte-tools 0.3.1",
+ "byte-tools",
  "byteorder 1.4.3",
  "generic-array 0.12.4",
 ]
@@ -510,7 +481,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
- "byte-tools 0.3.1",
+ "byte-tools",
 ]
 
 [[package]]
@@ -561,12 +532,6 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "byte-tools"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 
 [[package]]
 name = "byte-tools"
@@ -858,12 +823,6 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -1202,15 +1161,6 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-dependencies = [
- "generic-array 0.9.1",
-]
 
 [[package]]
 name = "digest"
@@ -2165,15 +2115,6 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d00328cedcac5e81c683e5620ca6a30756fc23027ebf9bff405c0e8da1fbb7e"
-dependencies = [
- "typenum 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
@@ -2767,12 +2708,10 @@ version = "0.12.0"
 dependencies = [
  "array-bytes 6.1.0",
  "base58",
- "blake2-rfc",
  "chrono 0.4.26",
  "clap 3.2.25",
  "enclave-bridge-primitives",
  "env_logger",
- "frame-system",
  "hdrhistogram",
  "hex",
  "integritee-node-runtime",
@@ -2791,12 +2730,10 @@ dependencies = [
  "pallet-evm",
  "pallet-teerex",
  "parity-scale-codec",
- "primitive-types",
  "rand 0.8.5",
  "rayon",
  "regex 1.9.5",
  "reqwest",
- "sc-keystore",
  "serde 1.0.188",
  "serde_json 1.0.106",
  "sgx_crypto_helper",
@@ -2809,7 +2746,6 @@ dependencies = [
  "substrate-client-keystore",
  "thiserror 1.0.40",
  "urlencoding",
- "ws",
 ]
 
 [[package]]
@@ -2870,7 +2806,6 @@ dependencies = [
  "enclave-bridge-primitives",
  "env_logger",
  "frame-support",
- "frame-system",
  "futures 0.3.28",
  "hex",
  "integritee-node-runtime",
@@ -2911,7 +2846,6 @@ dependencies = [
  "sgx-verify",
  "sgx_crypto_helper",
  "sgx_types",
- "sha2 0.7.1",
  "sp-consensus-grandpa",
  "sp-core",
  "sp-keyring",
@@ -2993,7 +2927,6 @@ dependencies = [
  "log 0.4.19",
  "parity-scale-codec",
  "serde 1.0.188",
- "serde_json 1.0.106",
  "sgx_tstd",
  "substrate-fixed",
  "thiserror 1.0.40",
@@ -3006,21 +2939,15 @@ dependencies = [
 name = "ita-parentchain-interface"
 version = "0.9.0"
 dependencies = [
- "binary-merkle-tree",
  "bs58",
  "env_logger",
- "frame-support",
- "futures 0.3.28",
- "futures 0.3.8",
  "ita-sgx-runtime",
  "ita-stf",
  "itc-parentchain-indirect-calls-executor",
  "itc-parentchain-test",
  "itp-api-client-types",
  "itp-node-api",
- "itp-ocall-api",
  "itp-sgx-crypto",
- "itp-sgx-runtime-primitives",
  "itp-stf-executor",
  "itp-stf-primitives",
  "itp-test",
@@ -3030,11 +2957,8 @@ dependencies = [
  "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.40",
- "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -3047,7 +2971,6 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "hex-literal",
  "itp-sgx-runtime-primitives",
  "pallet-aura",
  "pallet-balances",
@@ -3061,7 +2984,6 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
  "sp-api",
  "sp-block-builder",
  "sp-consensus-aura",
@@ -3079,17 +3001,12 @@ dependencies = [
 name = "ita-stf"
 version = "0.9.0"
 dependencies = [
- "derive_more",
  "frame-support",
  "frame-system",
- "hex",
- "integritee-node-runtime",
  "ita-sgx-runtime",
- "itc-parentchain-indirect-calls-executor",
  "itp-hashing",
  "itp-node-api",
  "itp-node-api-metadata",
- "itp-node-api-metadata-provider",
  "itp-sgx-externalities",
  "itp-stf-interface",
  "itp-stf-primitives",
@@ -3104,7 +3021,6 @@ dependencies = [
  "rlp",
  "sgx_tstd",
  "sha3",
- "sp-application-crypto",
  "sp-core",
  "sp-io 7.0.0",
  "sp-keyring",
@@ -3126,7 +3042,6 @@ dependencies = [
  "parity-scale-codec",
  "serde_json 1.0.106",
  "sgx_tstd",
- "sgx_types",
  "sp-runtime",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
@@ -3149,8 +3064,6 @@ dependencies = [
  "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
- "sgx_types",
- "sp-core",
  "sp-io 7.0.0",
  "sp-runtime",
  "thiserror 1.0.40",
@@ -3180,7 +3093,6 @@ dependencies = [
  "log 0.4.19",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
 ]
@@ -3193,7 +3105,6 @@ dependencies = [
  "itc-parentchain-indirect-calls-executor",
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
- "itp-settings",
  "itp-stf-executor",
  "itp-types",
  "log 0.4.19",
@@ -3217,16 +3128,13 @@ dependencies = [
  "itc-parentchain-test",
  "itp-api-client-types",
  "itp-node-api",
- "itp-ocall-api",
  "itp-sgx-crypto",
  "itp-sgx-runtime-primitives",
  "itp-stf-executor",
- "itp-stf-interface",
  "itp-stf-primitives",
  "itp-test",
  "itp-top-pool-author",
  "itp-types",
- "itp-utils",
  "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
@@ -3241,10 +3149,7 @@ dependencies = [
 name = "itc-parentchain-light-client"
 version = "0.9.0"
 dependencies = [
- "derive_more",
  "finality-grandpa",
- "frame-system",
- "hash-db 0.15.2",
  "itc-parentchain-test",
  "itp-ocall-api",
  "itp-sgx-io",
@@ -3252,17 +3157,12 @@ dependencies = [
  "itp-storage",
  "itp-test",
  "itp-types",
- "lazy_static",
  "log 0.4.19",
- "num-traits 0.2.15",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto",
  "sp-consensus-grandpa",
- "sp-core",
  "sp-runtime",
- "sp-trie",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
 ]
@@ -3271,17 +3171,8 @@ dependencies = [
 name = "itc-parentchain-test"
 version = "0.9.0"
 dependencies = [
- "frame-support",
- "frame-system",
  "itp-types",
- "log 0.4.19",
- "parity-scale-codec",
- "scale-info",
- "serde 1.0.188",
- "sp-core",
- "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -3297,7 +3188,6 @@ dependencies = [
  "serde 1.0.188",
  "serde_json 1.0.106",
  "sgx_tstd",
- "sgx_types",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
@@ -3321,7 +3211,6 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rustls 0.19.1",
- "serde_derive 1.0.188",
  "serde_json 1.0.106",
  "sgx_crypto_helper",
  "thiserror 1.0.40",
@@ -3346,7 +3235,6 @@ dependencies = [
  "jsonrpsee",
  "log 0.4.19",
  "parity-scale-codec",
- "serde_json 1.0.106",
  "sp-core",
  "tokio",
 ]
@@ -3365,9 +3253,7 @@ dependencies = [
  "rcgen",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
  "rustls 0.19.1",
- "sgx_crypto_helper",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
@@ -3410,12 +3296,9 @@ dependencies = [
  "itp-api-client-types",
  "itp-types",
  "log 0.4.19",
- "parity-scale-codec",
  "sp-consensus-grandpa",
- "sp-core",
  "sp-runtime",
  "substrate-api-client",
- "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -3424,7 +3307,6 @@ version = "0.9.0"
 dependencies = [
  "integritee-node-runtime",
  "itp-types",
- "sp-core",
  "sp-runtime",
  "substrate-api-client",
 ]
@@ -3447,7 +3329,6 @@ dependencies = [
  "itp-sgx-crypto",
  "itp-sgx-io",
  "itp-time-utils",
- "itp-types",
  "log 0.4.19",
  "num-bigint 0.2.5",
  "parity-scale-codec",
@@ -3461,7 +3342,6 @@ dependencies = [
  "sgx_tstd",
  "sgx_types",
  "sp-core",
- "sp-runtime",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3496,7 +3376,6 @@ dependencies = [
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
- "sp-consensus-grandpa",
  "sp-core",
  "sp-runtime",
  "teerex-primitives",
@@ -3515,7 +3394,6 @@ name = "itp-enclave-bridge-storage"
 version = "0.9.0"
 dependencies = [
  "itp-storage",
- "itp-types",
  "parity-scale-codec",
  "sp-std",
 ]
@@ -3536,7 +3414,6 @@ dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
  "itp-types",
- "log 0.4.19",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
@@ -3615,7 +3492,6 @@ dependencies = [
 name = "itp-nonce-cache"
 version = "0.8.0"
 dependencies = [
- "lazy_static",
  "sgx_tstd",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
@@ -3666,14 +3542,11 @@ version = "0.9.0"
 dependencies = [
  "aes",
  "derive_more",
- "itp-settings",
  "itp-sgx-io",
  "itp-sgx-temp-dir",
  "log 0.4.19",
  "ofb",
  "parity-scale-codec",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
- "serde 1.0.188",
  "serde_json 1.0.106",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx_crypto_helper",
@@ -3738,7 +3611,6 @@ dependencies = [
  "itp-stf-primitives",
  "itp-stf-state-handler",
  "itp-stf-state-observer",
- "itp-storage",
  "itp-test",
  "itp-time-utils",
  "itp-top-pool",
@@ -3746,7 +3618,6 @@ dependencies = [
  "itp-types",
  "log 0.4.19",
  "parity-scale-codec",
- "sgx_crypto_helper",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
@@ -3771,7 +3642,6 @@ name = "itp-stf-primitives"
 version = "0.9.0"
 dependencies = [
  "derive_more",
- "itp-hashing",
  "itp-sgx-runtime-primitives",
  "parity-scale-codec",
  "sp-core",
@@ -3793,12 +3663,10 @@ dependencies = [
  "itp-stf-state-observer",
  "itp-time-utils",
  "itp-types",
- "lazy_static",
  "log 0.4.19",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
- "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
@@ -3812,7 +3680,6 @@ version = "0.9.0"
 dependencies = [
  "itp-types",
  "log 0.4.19",
- "parity-scale-codec",
  "sgx_tstd",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
@@ -3851,7 +3718,6 @@ dependencies = [
 name = "itp-test"
 version = "0.9.0"
 dependencies = [
- "derive_more",
  "itp-enclave-bridge-storage",
  "itp-node-api",
  "itp-node-api-metadata-provider",
@@ -3890,7 +3756,6 @@ dependencies = [
  "byteorder 1.4.3",
  "derive_more",
  "itc-direct-rpc-server",
- "itp-sgx-runtime-primitives",
  "itp-stf-primitives",
  "itp-test",
  "itp-types",
@@ -3904,12 +3769,9 @@ dependencies = [
  "parity-util-mem",
  "serde 1.0.188",
  "sgx_tstd",
- "sgx_types",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.40",
- "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -3926,37 +3788,28 @@ dependencies = [
  "itp-test",
  "itp-top-pool",
  "itp-types",
- "itp-utils",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "log 0.4.19",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "thiserror 1.0.40",
- "thiserror 1.0.9",
 ]
 
 [[package]]
 name = "itp-types"
 version = "0.9.0"
 dependencies = [
- "chrono 0.4.26",
  "enclave-bridge-primitives",
  "frame-system",
- "integritee-node-runtime",
  "itp-sgx-runtime-primitives",
  "itp-stf-primitives",
  "itp-utils",
  "pallet-balances",
  "parity-scale-codec",
- "primitive-types",
- "serde 1.0.188",
- "serde_json 1.0.106",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -3976,13 +3829,11 @@ dependencies = [
 name = "its-block-composer"
 version = "0.9.0"
 dependencies = [
- "ita-stf",
  "itp-node-api",
  "itp-settings",
  "itp-sgx-crypto",
  "itp-sgx-externalities",
  "itp-stf-executor",
- "itp-stf-interface",
  "itp-stf-primitives",
  "itp-time-utils",
  "itp-top-pool-author",
@@ -4025,7 +3876,6 @@ version = "0.9.0"
 dependencies = [
  "env_logger",
  "finality-grandpa",
- "frame-support",
  "ita-stf",
  "itc-parentchain-block-import-dispatcher",
  "itc-parentchain-test",
@@ -4042,7 +3892,6 @@ dependencies = [
  "itp-time-utils",
  "itp-top-pool-author",
  "itp-types",
- "itp-utils",
  "its-block-composer",
  "its-block-verification",
  "its-consensus-common",
@@ -4095,11 +3944,9 @@ name = "its-consensus-slots"
 version = "0.9.0"
 dependencies = [
  "derive_more",
- "futures 0.3.28",
  "futures-timer",
  "itc-parentchain-test",
  "itp-settings",
- "itp-sgx-io",
  "itp-time-utils",
  "itp-types",
  "its-block-verification",
@@ -4146,7 +3993,6 @@ dependencies = [
  "scale-info",
  "serde 1.0.188",
  "sp-core",
- "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
  "sp-std",
 ]
@@ -4168,7 +4014,6 @@ dependencies = [
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
 ]
 
@@ -4196,12 +4041,10 @@ dependencies = [
  "its-primitives",
  "log 0.4.19",
  "parity-scale-codec",
- "serde 1.0.188",
  "sgx_tstd",
  "sp-core",
  "sp-io 7.0.0",
  "sp-runtime",
- "sp-std",
  "thiserror 1.0.40",
  "thiserror 1.0.9",
 ]
@@ -4231,7 +4074,6 @@ version = "0.9.0"
 dependencies = [
  "itp-types",
  "its-primitives",
- "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
 ]
@@ -4241,12 +4083,9 @@ name = "its-validateer-fetch"
 version = "0.9.0"
 dependencies = [
  "derive_more",
- "frame-support",
  "itc-parentchain-test",
  "itp-enclave-bridge-storage",
  "itp-ocall-api",
- "itp-storage",
- "itp-teerex-storage",
  "itp-test",
  "itp-types",
  "its-primitives",
@@ -4255,7 +4094,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -4298,7 +4136,7 @@ source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#0faf53c491c3222b9
 dependencies = [
  "futures 0.3.8",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
 ]
@@ -5057,12 +4895,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nohash-hasher"
@@ -7220,14 +7052,6 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 [[package]]
 name = "serde"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
-dependencies = [
- "sgx_tstd",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.118"
 source = "git+https://github.com/mesalock-linux/serde-sgx#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "serde_derive 1.0.118",
@@ -7258,7 +7082,7 @@ name = "serde-big-array"
 version = "0.3.0"
 source = "git+https://github.com/mesalock-linux/serde-big-array-sgx#94122c5167aee38b39b09a620a60db2c28cf7428"
 dependencies = [
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "serde_derive 1.0.118",
 ]
 
@@ -7291,7 +7115,7 @@ dependencies = [
  "indexmap 1.6.1",
  "itoa 0.4.5",
  "ryu",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "sgx_tstd",
 ]
 
@@ -7302,7 +7126,7 @@ source = "git+https://github.com/mesalock-linux/serde-json-sgx#380893814ad2a0577
 dependencies = [
  "itoa 0.4.5",
  "ryu",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "sgx_tstd",
 ]
 
@@ -7391,7 +7215,7 @@ source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master
 dependencies = [
  "itertools",
  "libc",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "serde 1.0.188",
  "serde-big-array 0.1.5",
  "serde-big-array 0.3.0",
@@ -7551,18 +7375,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
-dependencies = [
- "block-buffer 0.3.3",
- "byte-tools 0.2.0",
- "digest 0.7.6",
- "fake-simd",
 ]
 
 [[package]]
@@ -7979,23 +7791,12 @@ dependencies = [
 name = "sp-io"
 version = "7.0.0"
 dependencies = [
- "environmental 1.1.3",
- "futures 0.3.28",
- "hash-db 0.15.2",
  "itp-sgx-externalities",
  "libsecp256k1",
  "log 0.4.19",
  "parity-scale-codec",
- "parking_lot 0.12.1",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
- "sp-runtime-interface",
- "sp-std",
- "sp-tracing",
- "sp-wasm-interface",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,24 @@ sgx_tstd = { version = "1.1.6", git = "https://github.com/apache/incubator-teacl
 sgx_types = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_ucrypto = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_urts = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
+
+#[patch."https://github.com/integritee-network/integritee-node"]
+#my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network//integritee-node", branch = "ab/integrate-pallet-teerex-refactoring" }
+
+#[patch."https://github.com/scs/substrate-api-client"]
+#substrate-api-client = { path = "../../scs/substrate-api-client" }
+#substrate-client-keystore = { path = "../../scs/substrate-api-client/client-keystore" }
+
+#[patch."https://github.com/integritee-network/pallets.git"]
+#pallet-claims = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#pallet-enclave-bridge = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#pallet-teerex = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#pallet-sidechain = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#sgx-verify = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#pallet-teeracle = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#test-utils = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#claims-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#enclave-bridge-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#teerex-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#teeracle-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
+#common-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,32 +82,3 @@ sgx_tstd = { version = "1.1.6", git = "https://github.com/apache/incubator-teacl
 sgx_types = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_ucrypto = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_urts = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
-
-#[patch."https://github.com/integritee-network/sgx-runtime"]
-#sgx-runtime = { path = "../sgx-runtime/runtime"}
-#sp-io = { path = "../sgx-runtime/substrate-sgx/sp-io"}
-#sgx-externalities = { path = "../sgx-runtime/substrate-sgx/externalities"}
-
-#[patch."https://github.com/integritee-network/integritee-node"]
-#my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network//integritee-node", branch = "ab/integrate-pallet-teerex-refactoring" }
-
-#[patch."https://github.com/scs/substrate-api-client"]
-#substrate-api-client = { path = "../../scs/substrate-api-client" }
-#substrate-client-keystore = { path = "../../scs/substrate-api-client/client-keystore" }
-
-#[patch."https://github.com/integritee-network/pallets.git"]
-#pallet-claims = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#pallet-enclave-bridge = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#pallet-teerex = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#pallet-sidechain = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#sgx-verify = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#pallet-teeracle = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#test-utils = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#claims-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#enclave-bridge-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#teerex-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#teeracle-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-#common-primitives = { git = "https://github.com/integritee-network//pallets", branch = "ab/shard-config-upgradability-2" }
-
-#[patch."https://github.com/integritee-network/http_req"]
-#http_req = {path = '..//http_req' }

--- a/app-libs/oracle/Cargo.toml
+++ b/app-libs/oracle/Cargo.toml
@@ -20,7 +20,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 log = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 substrate-fixed = { default-features = false, git = "https://github.com/encointer/substrate-fixed", tag = "v0.5.9" }
 
 # internal dependencies
@@ -36,7 +35,6 @@ std = [
     "itp-ocall-api/std",
     "log/std",
     "serde/std",
-    "serde_json/std",
     "substrate-fixed/std",
     "thiserror",
     "url",

--- a/app-libs/parentchain-interface/Cargo.toml
+++ b/app-libs/parentchain-interface/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local dependencies
 ita-sgx-runtime = { path = "../sgx-runtime", default-features = false }
@@ -15,31 +14,14 @@ ita-stf = { path = "../stf", default-features = false }
 itc-parentchain-indirect-calls-executor = { path = "../../core/parentchain/indirect-calls-executor", default-features = false }
 itp-api-client-types = { path = "../../core-primitives/node-api/api-client-types", default-features = false }
 itp-node-api = { path = "../../core-primitives/node-api", default-features = false }
-itp-ocall-api = { path = "../../core-primitives/ocall-api", default-features = false }
-itp-sgx-crypto = { path = "../../core-primitives/sgx/crypto", default-features = false }
-itp-sgx-runtime-primitives = { path = "../../core-primitives/sgx-runtime-primitives", default-features = false }
-itp-stf-executor = { path = "../../core-primitives/stf-executor", default-features = false }
 itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-features = false }
-itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-features = false }
 itp-types = { path = "../../core-primitives/types", default-features = false }
 itp-utils = { path = "../../core-primitives/utils", default-features = false }
-
-# sgx enabled external libraries
-futures_sgx = { package = "futures", git = "https://github.com/mesalock-linux/futures-rs-sgx", optional = true }
-thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
-
-# std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
-futures = { version = "0.3.8", optional = true }
-thiserror = { version = "1.0", optional = true }
 
 # no-std compatible libraries
 bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
-
-# substrate dep
-binary-merkle-tree = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
@@ -58,15 +40,12 @@ default = ["std"]
 std = [
     "bs58/std",
     "codec/std",
-    "futures",
     "ita-sgx-runtime/std",
     "ita-stf/std",
     "itc-parentchain-indirect-calls-executor/std",
     "itp-api-client-types/std",
     "itp-node-api/std",
-    "itp-ocall-api/std",
     "itp-sgx-crypto/std",
-    "itp-sgx-runtime-primitives/std",
     "itp-stf-executor/std",
     "itp-stf-primitives/std",
     "itp-top-pool-author/std",
@@ -74,20 +53,15 @@ std = [
     "itp-utils/std",
     "log/std",
     #substrate
-    "binary-merkle-tree/std",
     "sp-core/std",
     "sp-runtime/std",
-    "frame-support/std",
-    "thiserror",
 ]
 sgx = [
     "sgx_tstd",
-    "futures_sgx",
     "ita-stf/sgx",
     "itc-parentchain-indirect-calls-executor/sgx",
     "itp-node-api/sgx",
     "itp-sgx-crypto/sgx",
     "itp-stf-executor/sgx",
     "itp-top-pool-author/sgx",
-    "thiserror_sgx",
 ]

--- a/app-libs/parentchain-interface/Cargo.toml
+++ b/app-libs/parentchain-interface/Cargo.toml
@@ -22,6 +22,8 @@ itp-utils = { path = "../../core-primitives/utils", default-features = false }
 bs58 = { version = "0.4.0", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
+
+# substrate dep
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 

--- a/app-libs/sgx-runtime/Cargo.toml
+++ b/app-libs/sgx-runtime/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-hex-literal = { version = "0.3.4", optional = true }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-# alias "parity-scale-code" to "codec"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
 
@@ -59,7 +56,6 @@ evm_std = [
     "pallet-evm/std",
 ]
 runtime-benchmarks = [
-    "hex-literal",
     "frame-benchmarking",
     "frame-support/runtime-benchmarks",
     "frame-system-benchmarking",
@@ -71,7 +67,6 @@ runtime-benchmarks = [
 std = [
     "codec/std",
     "scale-info/std",
-    "serde",
     "itp-sgx-runtime-primitives/std",
     "frame-executive/std",
     "frame-support/std",

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -31,11 +31,11 @@ sp-io = { default-features = false, features = ["disable_oom", "disable_panic_ha
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 
 
 [dev-dependencies]

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 [dependencies]
 # crates.io
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
-derive_more = { version = "0.99.5" }
-hex = { version = "0.4", default-features = false }
 log = { version = "0.4", default-features = false }
 rlp = { version = "0.5", default-features = false }
 sha3 = { version = "0.10", default-features = false }
@@ -18,11 +16,9 @@ sgx_tstd = { branch = "master", features = ["untrusted_fs", "net", "backtrace"],
 
 # local crates
 ita-sgx-runtime = { default-features = false, path = "../sgx-runtime" }
-itc-parentchain-indirect-calls-executor = { path = "../../core/parentchain/indirect-calls-executor", default-features = false }
 itp-hashing = { default-features = false, path = "../../core-primitives/hashing" }
 itp-node-api = { default-features = false, path = "../../core-primitives/node-api" }
 itp-node-api-metadata = { default-features = false, path = "../../core-primitives/node-api/metadata" }
-itp-node-api-metadata-provider = { default-features = false, path = "../../core-primitives/node-api/metadata-provider" }
 itp-sgx-externalities = { default-features = false, path = "../../core-primitives/substrate-sgx/externalities" }
 itp-stf-interface = { default-features = false, path = "../../core-primitives/stf-interface" }
 itp-stf-primitives = { default-features = false, path = "../../core-primitives/stf-primitives" }
@@ -36,13 +32,9 @@ frame-support = { default-features = false, git = "https://github.com/paritytech
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-application-crypto = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-
-# scs / integritee
-my-node-runtime = { package = "integritee-node-runtime", optional = true, git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 
 
@@ -58,7 +50,6 @@ sgx = [
     "itp-sgx-externalities/sgx",
     "sp-io/sgx",
     "itp-node-api/sgx",
-    "itp-node-api-metadata-provider/sgx",
 ]
 std = [
     # crates.io
@@ -67,7 +58,6 @@ std = [
     "rlp/std",
     # local
     "ita-sgx-runtime/std",
-    "itc-parentchain-indirect-calls-executor/std",
     "itp-hashing/std",
     "itp-sgx-externalities/std",
     "itp-stf-interface/std",
@@ -75,17 +65,14 @@ std = [
     "itp-types/std",
     "itp-node-api/std",
     "itp-node-api-metadata/std",
-    "itp-node-api-metadata-provider/std",
     # substrate
     "sp-core/std",
     "pallet-balances/std",
     "pallet-sudo/std",
     "frame-system/std",
     "frame-support/std",
-    "sp-application-crypto/std",
     "sp-runtime/std",
     # scs/integritee
-    "my-node-runtime",
     "pallet-parentchain/std",
     "sp-io/std",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,14 +32,14 @@ pallet-teerex = { git = "https://github.com/integritee-network/pallets.git", bra
 # `default-features = false` to remove the jsonrpsee dependency.
 enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 # disable unsupported jsonrpcsee
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
 
 # local dependencies
 ita-stf = { path = "../app-libs/stf" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,14 +32,16 @@ pallet-teerex = { git = "https://github.com/integritee-network/pallets.git", bra
 # `default-features = false` to remove the jsonrpsee dependency.
 enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 # disable unsupported jsonrpcsee
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
+substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
+
+# substrate dependencies
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
-substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
 
 # local dependencies
 ita-stf = { path = "../app-libs/stf" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 array-bytes = { version = "6.0.0" }
 base58 = "0.2"
-blake2-rfc = { version = "0.2.18" }
 chrono = "*"
 clap = { version = "3.1.6", features = ["derive"] }
 codec = { version = "3.0.0", package = "parity-scale-codec", features = ["derive"] }
@@ -15,7 +14,6 @@ env_logger = "0.9"
 hdrhistogram = "7.5.0"
 hex = "0.4.2"
 log = "0.4"
-primitive-types = { version = "0.12.1", features = ["codec"] }
 rand = "0.8.5"
 rayon = "1.5.1"
 regex = "1.9.5"
@@ -25,7 +23,6 @@ serde_json = "1.0"
 sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 thiserror = "1.0"
 urlencoding = "2.1.3"
-ws = { version = "0.9.1", features = ["ssl"] }
 
 # scs / integritee
 my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
@@ -37,11 +34,7 @@ enclave-bridge-primitives = { git = "https://github.com/integritee-network/palle
 # disable unsupported jsonrpcsee
 substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
-
-# substrate dependencies
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sc-keystore = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/core-primitives/attestation-handler/Cargo.toml
+++ b/core-primitives/attestation-handler/Cargo.toml
@@ -45,14 +45,12 @@ itp-settings = { path = "../settings" }
 itp-sgx-crypto = { path = "../sgx/crypto", default-features = false }
 itp-sgx-io = { path = "../sgx/io", default-features = false }
 itp-time-utils = { path = "../time-utils", default-features = false }
-itp-types = { path = "../types", default-features = false }
 
 # integritee
 httparse = { default-features = false, git = "https://github.com/integritee-network/httparse-sgx", branch = "sgx-experimental" }
 
 # substrate deps
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [features]
 default = ["std"]
@@ -74,10 +72,8 @@ std = [
     "itp-ocall-api/std",
     "itp-sgx-io/std",
     "itp-sgx-crypto/std",
-    "itp-types/std",
     # substrate
     "sp-core/std",
-    "sp-runtime/std",
     # integritee
     "httparse/std",
 ]

--- a/core-primitives/enclave-api/Cargo.toml
+++ b/core-primitives/enclave-api/Cargo.toml
@@ -16,7 +16,6 @@ sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-s
 sgx_urts = { optional = true, branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-consensus-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 

--- a/core-primitives/enclave-bridge-storage/Cargo.toml
+++ b/core-primitives/enclave-bridge-storage/Cargo.toml
@@ -10,12 +10,11 @@ sp-std = { default-features = false, git = "https://github.com/paritytech/substr
 
 #local deps
 itp-storage = { path = "../storage", default-features = false }
-itp-types = { path = "../types", default-features = false }
 
 [features]
 default = ["std"]
 std = [
+    "codec/std",
     "sp-std/std",
     "itp-storage/std",
-    "itp-types/std",
 ]

--- a/core-primitives/extrinsics-factory/Cargo.toml
+++ b/core-primitives/extrinsics-factory/Cargo.toml
@@ -23,7 +23,6 @@ thiserror = { version = "1.0", optional = true }
 
 # no-std dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-log = { version = "0.4", default-features = false }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
@@ -33,7 +32,6 @@ std = [
     "itp-node-api/std",
     "itp-nonce-cache/std",
     "itp-types/std",
-    "log/std",
     "substrate-api-client/std",
     "thiserror",
 ]

--- a/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -5,14 +5,10 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 
 [dependencies]
-# crates.io
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"] }
 log = { version = "0.4" }
-thiserror = { version = "1.0" }
 
 # substrate
 sp-consensus-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # scs

--- a/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/core-primitives/node-api/api-client-types/Cargo.toml
@@ -9,8 +9,10 @@ edition = "2021"
 my-node-runtime = { package = "integritee-node-runtime", optional = true, git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 
 # scs
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
+
+# substrate
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # local
 itp-types = { default-features = false, path = "../../types" }

--- a/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/core-primitives/node-api/api-client-types/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 my-node-runtime = { package = "integritee-node-runtime", optional = true, git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 
 # scs
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
 
 # local
 itp-types = { default-features = false, path = "../../types" }

--- a/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/core-primitives/node-api/api-client-types/Cargo.toml
@@ -10,9 +10,6 @@ my-node-runtime = { package = "integritee-node-runtime", optional = true, git = 
 
 # scs
 substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
-
-# substrate
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # local
@@ -25,7 +22,6 @@ std = [
     "itp-types/std",
     "substrate-api-client/std",
     "substrate-api-client/tungstenite-client",
-    "sp-core/std",
     "sp-runtime/std",
     "my-node-runtime",
 ]

--- a/core-primitives/nonce-cache/Cargo.toml
+++ b/core-primitives/nonce-cache/Cargo.toml
@@ -16,9 +16,6 @@ thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linu
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
 thiserror = { version = "1.0", optional = true }
 
-# no-std dependencies
-lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
-
 [features]
 default = ["std"]
 std = [

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -11,11 +11,9 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 derive_more = { version = "0.99.5" }
 log = { version = "0.4", default-features = false }
 ofb = { version = "0.4.0" }
-serde = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"], optional = true }
 
 # sgx deps
-serde-sgx = { package = "serde", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx", optional = true }
 serde_json-sgx = { package = "serde_json", tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx", optional = true }
 sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false }
 sgx_rand = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
@@ -24,9 +22,6 @@ sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-s
 
 # substrate deps
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-
-# local deps
-itp-settings = { path = "../../settings" }
 itp-sgx-io = { path = "../io", default-features = false }
 
 # test sgx deps
@@ -39,7 +34,6 @@ std = [
     "log/std",
     "itp-sgx-io/std",
     "sp-core/std",
-    "serde/std",
     "serde_json/std",
     "sgx-crypto-helper/default",
 ]
@@ -49,7 +43,6 @@ sgx = [
     "sgx_rand",
     "itp-sgx-io/sgx",
     "serde_json-sgx",
-    "serde-sgx",
 ]
 mocks = []
 test = [

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -21,8 +21,8 @@ sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sd
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # substrate deps
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 itp-sgx-io = { path = "../io", default-features = false }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # test sgx deps
 itp-sgx-temp-dir = { default-features = false, optional = true, path = "../temp-dir" }

--- a/core-primitives/sgx/crypto/Cargo.toml
+++ b/core-primitives/sgx/crypto/Cargo.toml
@@ -20,9 +20,11 @@ sgx_rand = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sd
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
-# substrate deps
-itp-sgx-io = { path = "../io", default-features = false }
+# substrate 
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
+# local deps
+itp-sgx-io = { path = "../io", default-features = false }
 
 # test sgx deps
 itp-sgx-temp-dir = { default-features = false, optional = true, path = "../temp-dir" }

--- a/core-primitives/sgx/crypto/src/lib.rs
+++ b/core-primitives/sgx/crypto/src/lib.rs
@@ -30,7 +30,6 @@ extern crate sgx_tstd as std;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 pub mod sgx_reexport_prelude {
 	pub use serde_json_sgx as serde_json;
-	pub use serde_sgx as serde;
 }
 
 pub mod aes;

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2021"
 
 [dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-
-# sgx dependencies
-sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
@@ -21,7 +18,6 @@ itp-stf-interface = { path = "../stf-interface", default-features = false }
 itp-stf-primitives = { path = "../stf-primitives", default-features = false }
 itp-stf-state-handler = { path = "../stf-state-handler", default-features = false }
 itp-stf-state-observer = { path = "../stf-state-observer", default-features = false }
-itp-storage = { path = "../storage", default-features = false }
 itp-time-utils = { path = "../time-utils", default-features = false }
 itp-top-pool-author = { path = "../top-pool-author", default-features = false }
 itp-types = { path = "../types", default-features = false }
@@ -62,7 +58,6 @@ std = [
     "itp-stf-state-handler/std",
     "itp-stf-state-observer/std",
     "itp-top-pool-author/std",
-    "itp-storage/std",
     "itp-types/std",
     "itp-time-utils/std",
     # crates.io
@@ -81,7 +76,6 @@ sgx = [
     "itp-stf-state-handler/sgx",
     "itp-stf-state-observer/sgx",
     "itp-top-pool-author/sgx",
-    "itp-storage/sgx",
     "itp-time-utils/sgx",
     "thiserror_sgx",
 ]
@@ -89,6 +83,5 @@ test = [
     "itc-parentchain-test",
     "itp-node-api/mocks",
     "itp-test",
-    "sgx-crypto-helper",
 ]
 mocks = []

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 
 [dependencies]
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+
+# sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 

--- a/core-primitives/stf-primitives/Cargo.toml
+++ b/core-primitives/stf-primitives/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2021"
 # crates.io
 codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 derive_more = { version = "0.99.5" }
-
-# Substrate dependencies
-itp-hashing = { default-features = false, path = "../../core-primitives/hashing" }
 itp-sgx-runtime-primitives = { path = "../../core-primitives/sgx-runtime-primitives", default-features = false }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 
 [dependencies]
-# sgx dependencies
-sgx_tcrypto = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
@@ -34,7 +32,6 @@ thiserror = { version = "1.0", optional = true }
 
 # no-std dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 log = { version = "0.4", default-features = false }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
@@ -59,7 +56,6 @@ std = [
 ]
 sgx = [
     "sgx_tstd",
-    "sgx_tcrypto",
     "rust-base58_sgx",
     "itp-sgx-crypto/sgx",
     "itp-sgx-externalities/sgx",

--- a/core-primitives/stf-state-observer/Cargo.toml
+++ b/core-primitives/stf-state-observer/Cargo.toml
@@ -14,8 +14,8 @@ itp-types = { default-features = false, path = "../types" }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
-thiserror = { version = "1.0", optional = true }
 log = { version = "0.4", default-features = false }
+thiserror = { version = "1.0", optional = true }
 
 [features]
 default = ["std"]

--- a/core-primitives/stf-state-observer/Cargo.toml
+++ b/core-primitives/stf-state-observer/Cargo.toml
@@ -15,15 +15,11 @@ thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linu
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
 thiserror = { version = "1.0", optional = true }
-
-# no-std dependencies
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 log = { version = "0.4", default-features = false }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
     "itp-types/std",
     "log/std",
     "thiserror",

--- a/core-primitives/substrate-sgx/sp-io/Cargo.toml
+++ b/core-primitives/substrate-sgx/sp-io/Cargo.toml
@@ -7,27 +7,14 @@ license = "Apache-2.0"
 
 [dependencies]
 codec = { version = "3.0.0", package = "parity-scale-codec", default-features = false }
-futures = { version = "0.3.1", optional = true, features = ["thread-pool"] }
-hash-db = { version = "0.15.2", default-features = false }
 libsecp256k1 = { version = "0.7.0", default-features = false, features = ["static-context"] }
 log = { version = "0.4", default-features = false }
-parking_lot = { version = "0.12.0", optional = true }
-tracing = { version = "0.1.25", default-features = false }
-tracing-core = { version = "0.1.17", default-features = false }
 
 itp-sgx-externalities = { default-features = false, path = "../externalities" }
 sgx_tstd = { optional = true, features = ["untrusted_fs", "net", "backtrace"], git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "master" }
-sgx_types = { optional = true, git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "master" }
 
 # Substrate dependencies
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-runtime-interface = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-tracing = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-wasm-interface = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-
-# local
-environmental = { path = "../environmental", default-features = false }
 
 [features]
 default = ["std"]
@@ -35,24 +22,12 @@ std = [
     "log/std",
     "sp-core/std",
     "codec/std",
-    "sp-std/std",
-    "hash-db/std",
     "libsecp256k1/std",
-    "sp-runtime-interface/std",
-    "sp-wasm-interface/std",
-    "futures",
-    "parking_lot",
     "itp-sgx-externalities/std",
-    # local
-    "environmental/std",
 ]
 sgx = [
     "sgx_tstd",
-    "sgx_types",
     "itp-sgx-externalities/sgx",
-    "sp-runtime-interface/disable_target_static_assertions",
-    #local
-    "environmental/sgx",
 ]
 
 # These two features are used for `no_std` builds for the environments which already provides

--- a/core-primitives/test/Cargo.toml
+++ b/core-primitives/test/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-derive_more = { version = "0.99.5" }
 log = { version = "0.4", default-features = false }
 sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false }
 

--- a/core-primitives/top-pool-author/Cargo.toml
+++ b/core-primitives/top-pool-author/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local dependencies
 itp-enclave-metrics = { path = "../enclave-metrics", default-features = false }
@@ -18,15 +17,12 @@ itp-stf-state-handler = { path = "../stf-state-handler", default-features = fals
 itp-test = { path = "../test", default-features = false, optional = true }
 itp-top-pool = { path = "../top-pool", default-features = false }
 itp-types = { path = "../types", default-features = false }
-itp-utils = { path = "../utils", default-features = false }
 
 # sgx enabled external libraries
 jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
-thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
 jsonrpc-core = { version = "18", optional = true }
-thiserror = { version = "1.0", optional = true }
 
 # no-std compatible libraries
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -54,7 +50,6 @@ std = [
     "itp-types/std",
     "jsonrpc-core",
     "log/std",
-    "thiserror",
 ]
 sgx = [
     "sgx_tstd",
@@ -63,7 +58,6 @@ sgx = [
     "itp-sgx-crypto/sgx",
     "itp-stf-state-handler/sgx",
     "itp-top-pool/sgx",
-    "thiserror_sgx",
 ]
 test = ["itp-test/sgx", "itp-top-pool/mocks"]
 mocks = []

--- a/core-primitives/top-pool-author/src/lib.rs
+++ b/core-primitives/top-pool-author/src/lib.rs
@@ -29,7 +29,6 @@ extern crate sgx_tstd as std;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 pub mod sgx_reexport_prelude {
 	pub use jsonrpc_core_sgx as jsonrpc_core;
-	pub use thiserror_sgx as thiserror;
 }
 
 pub mod api;

--- a/core-primitives/top-pool/Cargo.toml
+++ b/core-primitives/top-pool/Cargo.toml
@@ -7,11 +7,9 @@ edition = "2021"
 [dependencies]
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread", "untrusted_time"] }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
 itc-direct-rpc-server = { path = "../../core/direct-rpc-server", default-features = false }
-itp-sgx-runtime-primitives = { path = "../../core-primitives/sgx-runtime-primitives", default-features = false }
 itp-stf-primitives = { path = "../stf-primitives", default-features = false }
 itp-types = { path = "../types", default-features = false }
 its-primitives = { path = "../../sidechain/primitives", default-features = false }
@@ -19,12 +17,10 @@ its-primitives = { path = "../../sidechain/primitives", default-features = false
 # sgx enabled external libraries
 jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 linked-hash-map_sgx = { package = "linked-hash-map", git = "https://github.com/mesalock-linux/linked-hash-map-sgx", optional = true }
-thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 
 # std compatible external libraries (make sure these versions match with the sgx-enabled ones above)
 jsonrpc-core = { version = "18", optional = true }
 linked-hash-map = { version = "0.5.2", optional = true }
-thiserror = { version = "1.0", optional = true }
 
 # no-std compatible libraries
 byteorder = { version = "1.4.2", default-features = false }
@@ -45,11 +41,9 @@ itp-test = { path = "../test", default-features = false }
 default = ["std"]
 sgx = [
     "sgx_tstd",
-    "sgx_types",
     "itc-direct-rpc-server/sgx",
     "jsonrpc-core_sgx",
     "linked-hash-map_sgx",
-    "thiserror_sgx",
 ]
 std = [
     "itc-direct-rpc-server/std",
@@ -62,6 +56,5 @@ std = [
     "sp-core/std",
     "sp-runtime/std",
     "sp-application-crypto/std",
-    "thiserror",
 ]
 mocks = []

--- a/core-primitives/top-pool/src/lib.rs
+++ b/core-primitives/top-pool/src/lib.rs
@@ -28,7 +28,6 @@ extern crate sgx_tstd as std;
 pub mod sgx_reexport_prelude {
 	pub use jsonrpc_core_sgx as jsonrpc_core;
 	pub use linked_hash_map_sgx as linked_hash_map;
-	pub use thiserror_sgx as thiserror;
 }
 
 pub mod base_pool;

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -8,11 +8,7 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "0.4.19", default-features = false, features = ["alloc"] }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-primitive-types = { version = "0.12.1", default-features = false, features = ["codec"] }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 # local dependencies
 itp-sgx-runtime-primitives = { path = "../../core-primitives/sgx-runtime-primitives", default-features = false }
@@ -31,7 +27,6 @@ sp-std = { default-features = false, git = "https://github.com/paritytech/substr
 
 # integritee-node
 enclave-bridge-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
-my-node-runtime = { package = "integritee-node-runtime", optional = true, git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 teerex-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
 
 
@@ -39,11 +34,6 @@ teerex-primitives = { default-features = false, git = "https://github.com/integr
 default = ["std"]
 std = [
     "codec/std",
-    "chrono/std",
-    "my-node-runtime",
-    "serde/std",
-    "serde_json/std",
-    "primitive-types/std",
     "itp-sgx-runtime-primitives/std",
     "itp-stf-primitives/std",
     "itp-utils/std",

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # no-std dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -51,7 +50,6 @@ sgx = [
     "itp-rpc/sgx",
     "jsonrpc-core_sgx",
     "sgx_tstd",
-    "sgx_types",
     "thiserror_sgx",
 ]
 mocks = []

--- a/core/offchain-worker-executor/Cargo.toml
+++ b/core/offchain-worker-executor/Cargo.toml
@@ -26,6 +26,8 @@ itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-fe
 itp-stf-state-handler = { path = "../../core-primitives/stf-state-handler", default-features = false }
 itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-features = false }
 itp-types = { path = "../../core-primitives/types", default-features = false }
+
+# Substrate dependencies
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # no-std compatible libraries

--- a/core/offchain-worker-executor/Cargo.toml
+++ b/core/offchain-worker-executor/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2021"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
@@ -27,9 +26,6 @@ itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-fe
 itp-stf-state-handler = { path = "../../core-primitives/stf-state-handler", default-features = false }
 itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-features = false }
 itp-types = { path = "../../core-primitives/types", default-features = false }
-
-# Substrate dependencies
-sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # no-std compatible libraries
@@ -58,7 +54,6 @@ std = [
     "itp-stf-state-handler/std",
     "itp-top-pool-author/std",
     "itp-types/std",
-    "sp-core/std",
     "sp-runtime/std",
     "thiserror",
 ]

--- a/core/parentchain/block-import-dispatcher/Cargo.toml
+++ b/core/parentchain/block-import-dispatcher/Cargo.toml
@@ -21,7 +21,6 @@ thiserror = { version = "1.0", optional = true }
 
 # crates.io no-std compatible libraries
 log = { version = "0.4", default-features = false }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
 itc-parentchain-block-importer = { path = "../block-importer", features = ["mocks"] }
@@ -35,7 +34,6 @@ std = [
     "itp-import-queue/std",
     # no-std compatible libraries
     "log/std",
-    "sp-runtime/std",
     # std-only compatible libraries
     "thiserror",
 ]

--- a/core/parentchain/block-importer/Cargo.toml
+++ b/core/parentchain/block-importer/Cargo.toml
@@ -14,7 +14,6 @@ ita-stf = { path = "../../../app-libs/stf", default-features = false }
 itc-parentchain-indirect-calls-executor = { path = "../indirect-calls-executor", default-features = false }
 itc-parentchain-light-client = { path = "../light-client", default-features = false }
 itp-extrinsics-factory = { path = "../../../core-primitives/extrinsics-factory", default-features = false }
-itp-settings = { path = "../../../core-primitives/settings" }
 itp-stf-executor = { path = "../../../core-primitives/stf-executor", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
 

--- a/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -12,16 +12,13 @@ sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-s
 # local dependencies
 itp-api-client-types = { path = "../../../core-primitives/node-api/api-client-types", default-features = false }
 itp-node-api = { path = "../../../core-primitives/node-api", default-features = false }
-itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features = false }
 itp-sgx-crypto = { path = "../../../core-primitives/sgx/crypto", default-features = false }
 itp-sgx-runtime-primitives = { path = "../../../core-primitives/sgx-runtime-primitives", default-features = false }
 itp-stf-executor = { path = "../../../core-primitives/stf-executor", default-features = false }
-itp-stf-interface = { path = "../../../core-primitives/stf-interface", default-features = false }
 itp-stf-primitives = { path = "../../../core-primitives/stf-primitives", default-features = false }
 itp-test = { path = "../../../core-primitives/test", default-features = false }
 itp-top-pool-author = { path = "../../../core-primitives/top-pool-author", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
-itp-utils = { path = "../../../core-primitives/utils", default-features = false }
 
 # sgx enabled external libraries
 futures_sgx = { package = "futures", git = "https://github.com/mesalock-linux/futures-rs-sgx", optional = true }
@@ -57,10 +54,8 @@ std = [
     "codec/std",
     "futures",
     "itp-node-api/std",
-    "itp-ocall-api/std",
     "itp-sgx-crypto/std",
     "itp-stf-executor/std",
-    "itp-stf-interface/std",
     "itp-top-pool-author/std",
     "itp-api-client-types/std",
     "itp-test/std",

--- a/core/parentchain/light-client/Cargo.toml
+++ b/core/parentchain/light-client/Cargo.toml
@@ -20,6 +20,8 @@ itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features 
 itp-sgx-io = { path = "../../../core-primitives/sgx/io", default-features = false }
 itp-storage = { path = "../../../core-primitives/storage", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
+
+# substrate deps
 sp-consensus-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 

--- a/core/parentchain/light-client/Cargo.toml
+++ b/core/parentchain/light-client/Cargo.toml
@@ -6,12 +6,8 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
-derive_more = { version = "0.99.5" }
 finality-grandpa = { version = "0.16.0", default-features = false, features = ["derive-codec"] }
-hash-db = { version = "0.15.2", default-features = false }
-lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 log = { version = "0.4", default-features = false }
-num = { package = "num-traits", version = "0.2", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
 
 # sgx-deps
@@ -24,14 +20,8 @@ itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features 
 itp-sgx-io = { path = "../../../core-primitives/sgx/io", default-features = false }
 itp-storage = { path = "../../../core-primitives/storage", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
-
-# substrate deps
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-application-crypto = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-consensus-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-trie = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # test & mock dependencies
 itc-parentchain-test = { optional = true, default-features = false, path = "../../../core/parentchain/test" }
@@ -48,19 +38,13 @@ itp-sgx-temp-dir = { version = "0.1", path = "../../../core-primitives/sgx/temp-
 default = ["std"]
 std = [
     "codec/std",
-    "hash-db/std",
-    "num/std",
     "log/std",
     "finality-grandpa/std",
     "thiserror",
 
     # substrate deps
-    "frame-system/std",
-    "sp-core/std",
-    "sp-application-crypto/std",
     "sp-consensus-grandpa/std",
     "sp-runtime/std",
-    "sp-trie/std",
 
     # local deps
     "itp-ocall-api/std",

--- a/core/parentchain/test/Cargo.toml
+++ b/core/parentchain/test/Cargo.toml
@@ -8,33 +8,12 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
-log = { version = "0.4.14", default-features = false }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
-serde = { version = "1.0.13", features = ["derive"], optional = true }
-
-# substrate dependencies
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { default-features = false, package = "frame-system", git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
-    "log/std",
-    "scale-info/std",
-    "serde",
     "itp-types/std",
-    # substrate dependencies
-    "frame-support/std",
-    "frame-system/std",
-    "sp-core/std",
-    "sp-io/std",
     "sp-runtime/std",
-    "sp-std/std",
 ]

--- a/core/rest-client/Cargo.toml
+++ b/core/rest-client/Cargo.toml
@@ -15,7 +15,6 @@ url = { version = "2.0.0", optional = true }
 http-sgx = { package = "http", git = "https://github.com/integritee-network/http-sgx.git", branch = "sgx-experimental", optional = true }
 http_req-sgx = { optional = true, default-features = false, features = ["rust-tls", "sgx"], package = "http_req", git = "https://github.com/integritee-network/http_req" }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["net", "thread"] }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }
 url_sgx = { package = "url", git = "https://github.com/mesalock-linux/rust-url-sgx", tag = "sgx_1.1.3", optional = true }
 
@@ -42,7 +41,6 @@ std = [
 sgx = [
     "http-sgx",
     "http_req-sgx",
-    "sgx_types",
     "sgx_tstd",
     "thiserror_sgx",
     "url_sgx",

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -10,7 +10,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive
 log = "0.4"
 openssl = { version = "0.10" }
 parking_lot = "0.12.1"
-serde_derive = "1.0"
 serde_json = "1.0"
 sgx_crypto_helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 thiserror = { version = "1.0" }

--- a/core/rpc-server/Cargo.toml
+++ b/core/rpc-server/Cargo.toml
@@ -9,7 +9,6 @@ anyhow = "1.0.40"
 jsonrpsee = { version = "0.2.0-alpha.7", features = ["full"] }
 log = "0.4"
 parity-scale-codec = "3.0.0"
-serde_json = "1.0.64"
 tokio = { version = "1.6.1", features = ["full"] }
 
 # local

--- a/core/tls-websocket-server/Cargo.toml
+++ b/core/tls-websocket-server/Cargo.toml
@@ -11,9 +11,6 @@ rcgen = { package = "rcgen", default-features = false, git = "https://github.com
 
 # sgx dependencies
 sgx_tstd = { optional = true, features = ["net", "thread"], git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "master" }
-sgx_types = { optional = true, git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "master" }
-# Todo: should not be needed here: #848
-sgx_crypto_helper = { default-features = false, optional = true, features = ["mesalock_sgx"], version = "1.1.6", git = "https://github.com/apache/teaclave-sgx-sdk.git", branch = "master" }
 
 # sgx enabled external libraries
 mio-extras = { optional = true, default-features = false, git = "https://github.com/integritee-network/mio-extras-sgx", rev = "963234b" }
@@ -53,8 +50,6 @@ sgx = [
     "rcgen/pem_sgx",
     "rustls_sgx",
     "sgx_tstd",
-    "sgx_types",
-    "sgx_crypto_helper",
     "thiserror_sgx",
     "tungstenite_sgx",
     "webpki_sgx",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -794,7 +794,6 @@ dependencies = [
  "itp-attestation-handler",
  "itp-component-container",
  "itp-extrinsics-factory",
- "itp-hashing",
  "itp-import-queue",
  "itp-node-api",
  "itp-node-api-metadata",
@@ -805,7 +804,6 @@ dependencies = [
  "itp-settings",
  "itp-sgx-crypto",
  "itp-sgx-externalities",
- "itp-sgx-io",
  "itp-sgx-temp-dir",
  "itp-stf-executor",
  "itp-stf-interface",
@@ -813,7 +811,6 @@ dependencies = [
  "itp-stf-state-handler",
  "itp-stf-state-observer",
  "itp-storage",
- "itp-teerex-storage",
  "itp-test",
  "itp-time-utils",
  "itp-top-pool",
@@ -832,8 +829,6 @@ dependencies = [
  "primitive-types",
  "rust-base58",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3)",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
- "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx_rand",
  "sgx_serialize",
@@ -848,7 +843,6 @@ dependencies = [
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "sp-std",
  "teerex-primitives",
  "webpki",
 ]
@@ -1654,10 +1648,9 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "serde 1.0.188",
- "serde_json 1.0.96",
  "sgx_tstd",
  "substrate-fixed",
- "thiserror 1.0.9",
+ "thiserror",
  "url",
 ]
 
@@ -1665,30 +1658,20 @@ dependencies = [
 name = "ita-parentchain-interface"
 version = "0.9.0"
 dependencies = [
- "binary-merkle-tree",
  "bs58",
- "frame-support",
- "futures 0.3.8",
  "ita-sgx-runtime",
  "ita-stf",
  "itc-parentchain-indirect-calls-executor",
  "itp-api-client-types",
  "itp-node-api",
- "itp-ocall-api",
- "itp-sgx-crypto",
- "itp-sgx-runtime-primitives",
- "itp-stf-executor",
  "itp-stf-primitives",
- "itp-top-pool-author",
  "itp-types",
  "itp-utils",
  "log",
  "parity-scale-codec",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -1729,16 +1712,12 @@ dependencies = [
 name = "ita-stf"
 version = "0.9.0"
 dependencies = [
- "derive_more",
  "frame-support",
  "frame-system",
- "hex",
  "ita-sgx-runtime",
- "itc-parentchain-indirect-calls-executor",
  "itp-hashing",
  "itp-node-api",
  "itp-node-api-metadata",
- "itp-node-api-metadata-provider",
  "itp-sgx-externalities",
  "itp-stf-interface",
  "itp-stf-primitives",
@@ -1753,7 +1732,6 @@ dependencies = [
  "rlp",
  "sgx_tstd",
  "sha3 0.10.8",
- "sp-application-crypto",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -1773,9 +1751,8 @@ dependencies = [
  "parity-scale-codec",
  "serde_json 1.0.96",
  "sgx_tstd",
- "sgx_types",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -1793,10 +1770,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "sgx_tstd",
- "sgx_types",
- "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -1821,8 +1796,7 @@ dependencies = [
  "log",
  "sgx_tstd",
  "sgx_types",
- "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -1833,7 +1807,6 @@ dependencies = [
  "itc-parentchain-indirect-calls-executor",
  "itc-parentchain-light-client",
  "itp-extrinsics-factory",
- "itp-settings",
  "itp-stf-executor",
  "itp-types",
  "log",
@@ -1841,7 +1814,7 @@ dependencies = [
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -1853,33 +1826,27 @@ dependencies = [
  "futures 0.3.8",
  "itp-api-client-types",
  "itp-node-api",
- "itp-ocall-api",
  "itp-sgx-crypto",
  "itp-sgx-runtime-primitives",
  "itp-stf-executor",
- "itp-stf-interface",
  "itp-stf-primitives",
  "itp-test",
  "itp-top-pool-author",
  "itp-types",
- "itp-utils",
  "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
 name = "itc-parentchain-light-client"
 version = "0.9.0"
 dependencies = [
- "derive_more",
  "finality-grandpa",
- "frame-system",
- "hash-db 0.15.2",
  "itc-parentchain-test",
  "itp-ocall-api",
  "itp-sgx-io",
@@ -1887,34 +1854,21 @@ dependencies = [
  "itp-storage",
  "itp-test",
  "itp-types",
- "lazy_static",
  "log",
- "num-traits 0.2.15",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
- "sp-application-crypto",
  "sp-consensus-grandpa",
- "sp-core",
  "sp-runtime",
- "sp-trie",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
 name = "itc-parentchain-test"
 version = "0.9.0"
 dependencies = [
- "frame-support",
- "frame-system",
  "itp-types",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-core",
- "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -1928,8 +1882,7 @@ dependencies = [
  "serde 1.0.188",
  "serde_json 1.0.96",
  "sgx_tstd",
- "sgx_types",
- "thiserror 1.0.9",
+ "thiserror",
  "url",
 ]
 
@@ -1944,11 +1897,9 @@ dependencies = [
  "mio-extras",
  "rcgen",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
- "sgx_crypto_helper",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
- "thiserror 1.0.9",
+ "thiserror",
  "tungstenite",
  "webpki",
  "yasna",
@@ -1982,7 +1933,6 @@ name = "itp-api-client-types"
 version = "0.9.0"
 dependencies = [
  "itp-types",
- "sp-core",
  "sp-runtime",
  "substrate-api-client",
 ]
@@ -2003,7 +1953,6 @@ dependencies = [
  "itp-sgx-crypto",
  "itp-sgx-io",
  "itp-time-utils",
- "itp-types",
  "log",
  "num-bigint",
  "parity-scale-codec",
@@ -2015,8 +1964,7 @@ dependencies = [
  "sgx_tstd",
  "sgx_types",
  "sp-core",
- "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
  "webpki",
  "webpki-roots 0.21.0 (git+https://github.com/mesalock-linux/webpki-roots?branch=mesalock_sgx)",
  "yasna",
@@ -2027,7 +1975,7 @@ name = "itp-component-container"
 version = "0.8.0"
 dependencies = [
  "sgx_tstd",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2035,7 +1983,6 @@ name = "itp-enclave-bridge-storage"
 version = "0.9.0"
 dependencies = [
  "itp-storage",
- "itp-types",
  "parity-scale-codec",
  "sp-std",
 ]
@@ -2056,14 +2003,13 @@ dependencies = [
  "itp-node-api",
  "itp-nonce-cache",
  "itp-types",
- "log",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
  "sp-runtime",
  "substrate-api-client",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2079,7 +2025,7 @@ version = "0.8.0"
 dependencies = [
  "sgx_tstd",
  "sgx_types",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2107,16 +2053,15 @@ version = "0.9.0"
 dependencies = [
  "itp-node-api-metadata",
  "sgx_tstd",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
 name = "itp-nonce-cache"
 version = "0.8.0"
 dependencies = [
- "lazy_static",
  "sgx_tstd",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2139,7 +2084,7 @@ version = "0.9.0"
 dependencies = [
  "lazy_static",
  "sgx_tstd",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2163,13 +2108,11 @@ version = "0.9.0"
 dependencies = [
  "aes",
  "derive_more",
- "itp-settings",
  "itp-sgx-io",
  "itp-sgx-temp-dir",
  "log",
  "ofb",
  "parity-scale-codec",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3)",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx_crypto_helper",
  "sgx_rand",
@@ -2232,19 +2175,17 @@ dependencies = [
  "itp-stf-primitives",
  "itp-stf-state-handler",
  "itp-stf-state-observer",
- "itp-storage",
  "itp-test",
  "itp-time-utils",
  "itp-top-pool-author",
  "itp-types",
  "log",
  "parity-scale-codec",
- "sgx_crypto_helper",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2263,7 +2204,6 @@ name = "itp-stf-primitives"
 version = "0.9.0"
 dependencies = [
  "derive_more",
- "itp-hashing",
  "itp-sgx-runtime-primitives",
  "parity-scale-codec",
  "sp-core",
@@ -2285,15 +2225,13 @@ dependencies = [
  "itp-stf-state-observer",
  "itp-time-utils",
  "itp-types",
- "lazy_static",
  "log",
  "parity-scale-codec",
  "rust-base58",
- "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2302,9 +2240,8 @@ version = "0.9.0"
 dependencies = [
  "itp-types",
  "log",
- "parity-scale-codec",
  "sgx_tstd",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2322,23 +2259,13 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-trie",
- "thiserror 1.0.9",
-]
-
-[[package]]
-name = "itp-teerex-storage"
-version = "0.9.0"
-dependencies = [
- "itp-storage",
- "itp-types",
- "sp-std",
+ "thiserror",
 ]
 
 [[package]]
 name = "itp-test"
 version = "0.9.0"
 dependencies = [
- "derive_more",
  "itp-enclave-bridge-storage",
  "itp-node-api",
  "itp-node-api-metadata-provider",
@@ -2377,7 +2304,6 @@ dependencies = [
  "byteorder 1.4.3",
  "derive_more",
  "itc-direct-rpc-server",
- "itp-sgx-runtime-primitives",
  "itp-stf-primitives",
  "itp-types",
  "its-primitives",
@@ -2387,11 +2313,9 @@ dependencies = [
  "parity-scale-codec",
  "serde 1.0.188",
  "sgx_tstd",
- "sgx_types",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
 ]
 
 [[package]]
@@ -2407,22 +2331,18 @@ dependencies = [
  "itp-test",
  "itp-top-pool",
  "itp-types",
- "itp-utils",
  "jsonrpc-core",
  "log",
  "parity-scale-codec",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
 ]
 
 [[package]]
 name = "itp-types"
 version = "0.9.0"
 dependencies = [
- "chrono 0.4.26",
  "enclave-bridge-primitives",
  "frame-system",
  "itp-sgx-runtime-primitives",
@@ -2430,9 +2350,6 @@ dependencies = [
  "itp-utils",
  "pallet-balances",
  "parity-scale-codec",
- "primitive-types",
- "serde 1.0.188",
- "serde_json 1.0.96",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -2452,13 +2369,11 @@ dependencies = [
 name = "its-block-composer"
 version = "0.9.0"
 dependencies = [
- "ita-stf",
  "itp-node-api",
  "itp-settings",
  "itp-sgx-crypto",
  "itp-sgx-externalities",
  "itp-stf-executor",
- "itp-stf-interface",
  "itp-stf-primitives",
  "itp-time-utils",
  "itp-top-pool-author",
@@ -2471,7 +2386,7 @@ dependencies = [
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2487,7 +2402,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2495,7 +2410,6 @@ name = "its-consensus-aura"
 version = "0.9.0"
 dependencies = [
  "finality-grandpa",
- "frame-support",
  "ita-stf",
  "itc-parentchain-block-import-dispatcher",
  "itp-enclave-metrics",
@@ -2509,7 +2423,6 @@ dependencies = [
  "itp-time-utils",
  "itp-top-pool-author",
  "itp-types",
- "itp-utils",
  "its-block-composer",
  "its-block-verification",
  "its-consensus-common",
@@ -2546,7 +2459,7 @@ dependencies = [
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2555,7 +2468,6 @@ version = "0.9.0"
 dependencies = [
  "derive_more",
  "itp-settings",
- "itp-sgx-io",
  "itp-time-utils",
  "itp-types",
  "its-block-verification",
@@ -2578,7 +2490,6 @@ dependencies = [
  "scale-info",
  "serde 1.0.188",
  "sp-core",
- "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -2598,7 +2509,6 @@ dependencies = [
  "parity-scale-codec",
  "rust-base58",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
 ]
 
@@ -2626,12 +2536,10 @@ dependencies = [
  "its-primitives",
  "log",
  "parity-scale-codec",
- "serde 1.0.188",
  "sgx_tstd",
  "sp-core",
  "sp-io",
- "sp-std",
- "thiserror 1.0.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -2639,11 +2547,8 @@ name = "its-validateer-fetch"
 version = "0.9.0"
 dependencies = [
  "derive_more",
- "frame-support",
  "itp-enclave-bridge-storage",
  "itp-ocall-api",
- "itp-storage",
- "itp-teerex-storage",
  "itp-types",
  "its-primitives",
  "log",
@@ -2651,7 +2556,6 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -2661,7 +2565,7 @@ source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#0faf53c491c3222b9
 dependencies = [
  "futures 0.3.8",
  "log",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
 ]
@@ -3826,14 +3730,6 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 [[package]]
 name = "serde"
 version = "1.0.118"
-source = "git+https://github.com/mesalock-linux/serde-sgx?tag=sgx_1.1.3#db0226f1d5d70fca6b96af2c285851502204e21c"
-dependencies = [
- "sgx_tstd",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.118"
 source = "git+https://github.com/mesalock-linux/serde-sgx#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "serde_derive 1.0.118",
@@ -3854,7 +3750,7 @@ name = "serde-big-array"
 version = "0.3.0"
 source = "git+https://github.com/mesalock-linux/serde-big-array-sgx#94122c5167aee38b39b09a620a60db2c28cf7428"
 dependencies = [
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "serde_derive 1.0.118",
 ]
 
@@ -3887,7 +3783,7 @@ dependencies = [
  "indexmap 1.6.1",
  "itoa 0.4.5",
  "ryu",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "sgx_tstd",
 ]
 
@@ -3898,7 +3794,7 @@ source = "git+https://github.com/mesalock-linux/serde-json-sgx#380893814ad2a0577
 dependencies = [
  "itoa 0.4.5",
  "ryu",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "sgx_tstd",
 ]
 
@@ -3939,7 +3835,7 @@ version = "1.1.6"
 source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
 dependencies = [
  "itertools",
- "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
+ "serde 1.0.118",
  "serde-big-array",
  "serde_derive 1.0.118",
  "sgx_tcrypto",
@@ -4409,21 +4305,12 @@ dependencies = [
 name = "sp-io"
 version = "7.0.0"
 dependencies = [
- "environmental 1.1.3",
- "hash-db 0.15.2",
  "itp-sgx-externalities",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
  "sgx_tstd",
- "sgx_types",
  "sp-core",
- "sp-runtime-interface",
- "sp-std",
- "sp-tracing",
- "sp-wasm-interface",
- "tracing",
- "tracing-core",
 ]
 
 [[package]]
@@ -4780,16 +4667,7 @@ version = "1.0.9"
 source = "git+https://github.com/mesalock-linux/thiserror-sgx?tag=sgx_1.1.3#c2f806b88616e06aab0af770366a76885d974fdc"
 dependencies = [
  "sgx_tstd",
- "thiserror-impl 1.0.9",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
-dependencies = [
- "thiserror-impl 1.0.40",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4800,17 +4678,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.33",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
-dependencies = [
- "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.33",
 ]
 
 [[package]]
@@ -4917,7 +4784,7 @@ dependencies = [
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?tag=sgx_1.1.3)",
  "sgx_tstd",
  "sha1",
- "thiserror 1.0.9",
+ "thiserror",
  "url",
  "utf-8",
  "webpki",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -155,9 +155,6 @@ log = { git = "https://github.com/integritee-network/log-sgx" }
 [patch."https://github.com/paritytech/substrate"]
 sp-io = { path = "../core-primitives/substrate-sgx/sp-io" }
 
-#[patch."https://github.com/integritee-network/frontier"]
-#pallet-evm = { path = "../../frontier/frame/evm"}
-
 [patch."https://github.com/apache/teaclave-sgx-sdk.git"]
 sgx_alloc = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_crypto_helper = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
@@ -174,14 +171,3 @@ sgx_tseal = { version = "1.1.6", git = "https://github.com/apache/incubator-teac
 sgx_tstd = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_tunittest = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_types = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
-
-#[patch."https://github.com/scs/substrate-api-client"]
-#substrate-api-client = { path = "../../../scs/substrate-api-client" }
-
-#[patch."https://github.com/integritee-network/pallets.git"]
-#pallet-parentchain = { path = "../../pallets/parentchain" }
-#itp-types = {  path = "../../pallets/primitives/types" }
-#itp-utils = {  path = "../../pallets/primitives/utils" }
-
-#[patch."https://github.com/integritee-network/http_req"]
-#http_req-sgx = {  package = "http_req", path = '../../http_req' }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -79,8 +79,6 @@ log = { git = "https://github.com/integritee-network/log-sgx" }
 # Todo #1313: use the `once_cell` included in rusts core library once we use rust v1.70.0
 once_cell = { git = "https://github.com/mesalock-linux/once_cell-sgx" }
 rustls = { rev = "sgx_1.1.3", features = ["dangerous_configuration"], git = "https://github.com/mesalock-linux/rustls" }
-serde = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-sgx", features = ["alloc", "mesalock_sgx"] }
-serde_derive = { git = "https://github.com/mesalock-linux/serde-sgx" }
 serde_json = { tag = "sgx_1.1.3", git = "https://github.com/mesalock-linux/serde-json-sgx" }
 webpki = { git = "https://github.com/mesalock-linux/webpki", branch = "mesalock_sgx" }
 
@@ -105,7 +103,6 @@ itc-tls-websocket-server = { path = "../core/tls-websocket-server", default-feat
 itp-attestation-handler = { path = "../core-primitives/attestation-handler", default-features = false, features = ["sgx"] }
 itp-component-container = { path = "../core-primitives/component-container", default-features = false, features = ["sgx"] }
 itp-extrinsics-factory = { path = "../core-primitives/extrinsics-factory", default-features = false, features = ["sgx"] }
-itp-hashing = { path = "../core-primitives/hashing", default-features = false }
 itp-import-queue = { path = "../core-primitives/import-queue", default-features = false, features = ["sgx"] }
 itp-node-api = { path = "../core-primitives/node-api", default-features = false, features = ["sgx"] }
 itp-node-api-metadata = { path = "../core-primitives/node-api/metadata", default-features = false }
@@ -116,14 +113,12 @@ itp-rpc = { path = "../core-primitives/rpc", default-features = false, features 
 itp-settings = { path = "../core-primitives/settings" }
 itp-sgx-crypto = { path = "../core-primitives/sgx/crypto", default-features = false, features = ["sgx"] }
 itp-sgx-externalities = { path = "../core-primitives/substrate-sgx/externalities", default-features = false, features = ["sgx"] }
-itp-sgx-io = { path = "../core-primitives/sgx/io", default-features = false, features = ["sgx"] }
 itp-stf-executor = { path = "../core-primitives/stf-executor", default-features = false, features = ["sgx"] }
 itp-stf-interface = { path = "../core-primitives/stf-interface", default-features = false }
 itp-stf-primitives = { path = "../core-primitives/stf-primitives", default-features = false }
 itp-stf-state-handler = { path = "../core-primitives/stf-state-handler", default-features = false, features = ["sgx"] }
 itp-stf-state-observer = { path = "../core-primitives/stf-state-observer", default-features = false, features = ["sgx"] }
 itp-storage = { path = "../core-primitives/storage", default-features = false, features = ["sgx"] }
-itp-teerex-storage = { path = "../core-primitives/teerex-storage", default-features = false }
 itp-test = { path = "../core-primitives/test", default-features = false, optional = true }
 itp-time-utils = { path = "../core-primitives/time-utils", default-features = false, features = ["sgx"] }
 itp-top-pool = { path = "../core-primitives/top-pool", default-features = false, features = ["sgx"] }
@@ -139,7 +134,6 @@ frame-support = { default-features = false, git = "https://github.com/paritytech
 frame-system = { optional = true, default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # test-deps
 itp-sgx-temp-dir = { version = "0.1", default-features = false, optional = true, path = "../core-primitives/sgx/temp-dir" }

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -459,8 +459,6 @@ pub fn generate_generic_register_collateral_extrinsic<F>(
 where
 	F: Fn(&NodeMetadata) -> Result<[u8; 2], MetadataError>,
 {
-	let extrinsics_factory = get_extrinsic_factory_from_integritee_solo_or_parachain()?;
-
 	let node_metadata_repo = get_node_metadata_repository_from_integritee_solo_or_parachain()?;
 	let call_ids = node_metadata_repo
 		.get_from_metadata(getter)?
@@ -468,7 +466,7 @@ where
 	info!("    [Enclave] Compose register collateral call: {:?}", call_ids);
 	let call = OpaqueCall::from_tuple(&(call_ids, collateral_data, data_signature, issuer_chain));
 
-	let extrinsic = extrinsics_factory.create_extrinsics(&[call], None)?[0].clone();
+	let extrinsic = create_extrinsics(call)?;
 	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
 		return EnclaveError::BufferError(e).into()
 	};

--- a/enclave-runtime/src/shard_vault.rs
+++ b/enclave-runtime/src/shard_vault.rs
@@ -107,7 +107,10 @@ pub(crate) fn get_shard_vault_account(shard: ShardIdentifier) -> EnclaveResult<A
 
 pub(crate) fn init_proxied_shard_vault_internal(shard: ShardIdentifier) -> EnclaveResult<()> {
 	let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
-	if !state_handler.shard_exists(&shard).unwrap() {
+	if !state_handler
+		.shard_exists(&shard)
+		.map_err(|_| Error::Other("get shard_exists failed".into()))?
+	{
 		return Err(Error::Other("shard not initialized".into()))
 	};
 
@@ -172,7 +175,10 @@ pub(crate) fn add_shard_vault_proxy(
 	proxy: &AccountId,
 ) -> EnclaveResult<()> {
 	let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
-	if !state_handler.shard_exists(&shard).unwrap() {
+	if !state_handler
+		.shard_exists(&shard)
+		.map_err(|_| Error::Other("get shard_exists failed".into()))?
+	{
 		return Err(Error::Other("shard not initialized".into()))
 	};
 

--- a/enclave-runtime/src/tls_ra/authentication.rs
+++ b/enclave-runtime/src/tls_ra/authentication.rs
@@ -51,7 +51,11 @@ where
 		_sni: Option<&DNSName>,
 	) -> Result<rustls::ClientCertVerified, rustls::TLSError> {
 		debug!("client cert: {:?}", certs);
-		let issuer = cert::parse_cert_issuer(&certs[0].0).unwrap();
+		let issuer =
+			certs.get(0).ok_or(rustls::TLSError::NoCertificatesPresented).and_then(|cert| {
+				cert::parse_cert_issuer(&cert.0)
+					.map_err(|_| rustls::TLSError::NoCertificatesPresented)
+			})?;
 		info!("client signer (issuer) is: 0x{}", hex::encode(issuer));
 
 		// This call will automatically verify cert is properly signed
@@ -106,7 +110,11 @@ where
 		_ocsp: &[u8],
 	) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
 		debug!("server cert: {:?}", certs);
-		let issuer = cert::parse_cert_issuer(&certs[0].0).unwrap();
+		let issuer =
+			certs.get(0).ok_or(rustls::TLSError::NoCertificatesPresented).and_then(|cert| {
+				cert::parse_cert_issuer(&cert.0)
+					.map_err(|_| rustls::TLSError::NoCertificatesPresented)
+			})?;
 		info!("server signer (issuer) is: 0x{}", hex::encode(issuer));
 
 		if self.skip_ra {

--- a/enclave-runtime/src/tls_ra/tls_ra_server.rs
+++ b/enclave-runtime/src/tls_ra/tls_ra_server.rs
@@ -114,9 +114,8 @@ where
 			"    [Enclave] (MU-RA-Server) await_shard_request_from_client, calling read_exact()"
 		);
 		self.tls_stream.read_exact(&mut request)?;
-		let request: ClientProvisioningRequest = Decode::decode(&mut request.as_slice())
-			.expect("matching byte size can't fail to decode");
-		Ok(request)
+		ClientProvisioningRequest::decode(&mut request.as_slice())
+			.map_err(|_| EnclaveError::Other("matching byte size can't fail to decode".into()))
 	}
 
 	/// Sends all relevant data to the client.

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -30,7 +30,6 @@ warp = "0.3"
 
 # ipfs
 ipfs-api = "0.11.0"
-sha2 = { version = "0.7", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 primitive-types = { version = "0.12.1", default-features = false, features = ["codec"] }
@@ -69,7 +68,6 @@ teerex-primitives = { git = "https://github.com/integritee-network/pallets.git",
 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-consensus-grandpa = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/sidechain/block-composer/Cargo.toml
+++ b/sidechain/block-composer/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 
 [dependencies]
 # sgx dependencies
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
+
+# local dependencies
 itp-node-api = { path = "../../core-primitives/node-api", default-features = false }
 itp-settings = { path = "../../core-primitives/settings", default-features = false }
 itp-sgx-crypto = { path = "../../core-primitives/sgx/crypto", default-features = false }
@@ -17,8 +21,6 @@ itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-
 itp-types = { path = "../../core-primitives/types", default-features = false }
 its-primitives = { path = "../primitives", default-features = false, features = ["full_crypto"] }
 its-state = { path = "../state", default-features = false }
-sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/sidechain/block-composer/Cargo.toml
+++ b/sidechain/block-composer/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 
 [dependencies]
 # sgx dependencies
-sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 itp-node-api = { path = "../../core-primitives/node-api", default-features = false }
 itp-settings = { path = "../../core-primitives/settings", default-features = false }
 itp-sgx-crypto = { path = "../../core-primitives/sgx/crypto", default-features = false }
@@ -19,6 +17,8 @@ itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-
 itp-types = { path = "../../core-primitives/types", default-features = false }
 its-primitives = { path = "../primitives", default-features = false, features = ["full_crypto"] }
 its-state = { path = "../state", default-features = false }
+sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/sidechain/block-composer/Cargo.toml
+++ b/sidechain/block-composer/Cargo.toml
@@ -8,15 +8,11 @@ edition = "2021"
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-
-# local dependencies
-ita-stf = { path = "../../app-libs/stf", default-features = false }
 itp-node-api = { path = "../../core-primitives/node-api", default-features = false }
 itp-settings = { path = "../../core-primitives/settings", default-features = false }
 itp-sgx-crypto = { path = "../../core-primitives/sgx/crypto", default-features = false }
 itp-sgx-externalities = { path = "../../core-primitives/substrate-sgx/externalities", default-features = false }
 itp-stf-executor = { path = "../../core-primitives/stf-executor", default-features = false }
-itp-stf-interface = { path = "../../core-primitives/stf-interface", default-features = false }
 itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-features = false }
 itp-time-utils = { path = "../../core-primitives/time-utils", default-features = false }
 itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-features = false }
@@ -40,12 +36,10 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 [features]
 default = ["std"]
 std = [
-    "ita-stf/std",
     "itp-node-api/std",
     "itp-sgx-crypto/std",
     "itp-sgx-externalities/std",
     "itp-stf-executor/std",
-    "itp-stf-interface/std",
     "itp-stf-primitives/std",
     "itp-time-utils/std",
     "itp-top-pool-author/std",
@@ -57,7 +51,6 @@ std = [
 ]
 sgx = [
     "sgx_tstd",
-    "ita-stf/sgx",
     "itp-node-api/sgx",
     "itp-sgx-crypto/sgx",
     "itp-sgx-externalities/sgx",

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -11,9 +11,6 @@ log = { version = "0.4", default-features = false }
 
 # sgx deps
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-
-# substrate deps
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
@@ -31,7 +28,6 @@ itp-stf-state-handler = { path = "../../../core-primitives/stf-state-handler", d
 itp-time-utils = { path = "../../../core-primitives/time-utils", default-features = false }
 itp-top-pool-author = { path = "../../../core-primitives/top-pool-author", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
-itp-utils = { path = "../../../core-primitives/utils", default-features = false }
 its-block-composer = { path = "../../block-composer", default-features = false }
 its-block-verification = { path = "../../block-verification", optional = true, default-features = false }
 its-consensus-common = { path = "../common", default-features = false }
@@ -58,7 +54,6 @@ std = [
     "finality-grandpa/std",
     "log/std",
     #substrate
-    "frame-support/std",
     "sp-core/std",
     "sp-runtime/std",
     #local

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -11,6 +11,8 @@ log = { version = "0.4", default-features = false }
 
 # sgx deps
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
+
+# substrate deps
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -12,10 +12,10 @@ lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 log = { version = "0.4", default-features = false }
 
 # local deps
+futures-timer = { version = "3.0", optional = true }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
 its-block-verification = { path = "../../block-verification", default-features = false }
 its-primitives = { path = "../../primitives", default-features = false }
-futures-timer = { version = "3.0", optional = true }
 
 # sgx deps
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -12,10 +12,12 @@ lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 log = { version = "0.4", default-features = false }
 
 # local deps
-futures-timer = { version = "3.0", optional = true }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
 its-block-verification = { path = "../../block-verification", default-features = false }
 its-primitives = { path = "../../primitives", default-features = false }
+
+# only for slot-stream
+futures-timer = { version = "3.0", optional = true }
 
 # sgx deps
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true, features = ["untrusted_time"] }

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -15,9 +15,6 @@ log = { version = "0.4", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
 its-block-verification = { path = "../../block-verification", default-features = false }
 its-primitives = { path = "../../primitives", default-features = false }
-
-# only for slot-stream
-futures = { version = "0.3", optional = true }
 futures-timer = { version = "3.0", optional = true }
 
 # sgx deps
@@ -29,7 +26,6 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 
 # local deps
 itp-settings = { path = "../../../core-primitives/settings" }
-itp-sgx-io = { path = "../../../core-primitives/sgx/io", default-features = false }
 itp-time-utils = { path = "../../../core-primitives/time-utils", default-features = false }
 its-consensus-common = { path = "../common", default-features = false }
 
@@ -46,13 +42,11 @@ std = [
     "codec/std",
     "log/std",
     # only for slot-stream
-    "futures",
     "futures-timer",
     # substrate
     "sp-consensus-slots/std",
     "sp-runtime/std",
     # local
-    "itp-sgx-io/std",
     "itp-time-utils/std",
     "itp-types/std",
     "its-primitives/std",
@@ -60,7 +54,6 @@ std = [
     "its-consensus-common/std",
 ]
 sgx = [
-    "itp-sgx-io/sgx",
     "itp-time-utils/sgx",
     "its-consensus-common/sgx",
     "sgx_tstd",

--- a/sidechain/primitives/Cargo.toml
+++ b/sidechain/primitives/Cargo.toml
@@ -15,7 +15,6 @@ serde = { version = "1.0.13", default-features = false }
 
 # substrate dependencies
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
@@ -32,7 +31,6 @@ std = [
     "itp-types/std",
     # substrate
     "sp-core/std",
-    "sp-io/std",
     "sp-runtime/std",
     "sp-std/std",
 ]

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local dependencies
 itp-rpc = { path = "../../core-primitives/rpc", default-features = false }

--- a/sidechain/state/Cargo.toml
+++ b/sidechain/state/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 log = { version = "0.4", default-features = false }
-serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 
 # optional std deps
 thiserror = { version = "1.0.9", optional = true }
@@ -27,7 +26,6 @@ sp-io = { optional = true, default-features = false, features = ["disable_oom", 
 
 # substrate deps
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # test deps
 [dev-dependencies]
@@ -37,9 +35,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 default = ["std"]
 std = [
     "log/std",
-    "serde/std",
     # substrate
-    "sp-std/std",
     "sp-core/std",
     # local crates
     "itp-sgx-externalities/std",

--- a/sidechain/test/Cargo.toml
+++ b/sidechain/test/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", features = ["untrusted_time"], optional = true }
@@ -23,7 +22,6 @@ its-primitives = { path = "../primitives", default_features = false, features = 
 [features]
 default = ["std"]
 std = [
-    "codec/std",
     "itp-types/std",
     "its-primitives/std",
     # substrate

--- a/sidechain/validateer-fetch/Cargo.toml
+++ b/sidechain/validateer-fetch/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
 derive_more = "0.99.16"
 log = "0.4"
+
+# substrate deps
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/sidechain/validateer-fetch/Cargo.toml
+++ b/sidechain/validateer-fetch/Cargo.toml
@@ -8,10 +8,6 @@ edition = "2021"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
 derive_more = "0.99.16"
 log = "0.4"
-thiserror = "1.0.26"
-
-# substrate deps
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
@@ -19,8 +15,6 @@ sp-std = { default-features = false, git = "https://github.com/paritytech/substr
 # local deps
 itp-enclave-bridge-storage = { path = "../../core-primitives/enclave-bridge-storage", default-features = false }
 itp-ocall-api = { path = "../../core-primitives/ocall-api", default-features = false }
-itp-storage = { path = "../../core-primitives/storage", default-features = false }
-itp-teerex-storage = { path = "../../core-primitives/teerex-storage", default-features = false }
 itp-types = { path = "../../core-primitives/types", default-features = false }
 its-primitives = { path = "../primitives", default-features = false }
 
@@ -32,7 +26,6 @@ std = [
     "sp-runtime/std",
     "sp-std/std",
     "itp-types/std",
-    "itp-storage/std",
     "itp-ocall-api/std",
     "its-primitives/std",
     "itp-enclave-bridge-storage/std",


### PR DESCRIPTION
This PR:
- removes unneeded cargo dependencies with the help of `cargo machete`
- removes some commented deps
- fixes some clippy errors in `enclave-runtime/` (somehow I found this in Litentry repo, but not in integritee-repo, why? We use the same toolchain version)