### PR TITLE
Return encoded extrinsics without padding

### DIFF
--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -15,7 +15,8 @@ extern "C" {
 		quote: *const u8,
 		quote_size: u32,
 		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
+		unchecked_extrinsic_max_size: u32,
+		unchecked_extrinsic_size: *mut u32,
 	) -> sgx_status_t;
 
 	pub fn init(
@@ -139,7 +140,8 @@ extern "C" {
 		w_url: *const u8,
 		w_url_size: u32,
 		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
+		unchecked_extrinsic_max_size: u32,
+		unchecked_extrinsic_size: *mut u32,
 		skip_ra: c_int,
 	) -> sgx_status_t;
 
@@ -149,7 +151,8 @@ extern "C" {
 		w_url: *const u8,
 		w_url_size: u32,
 		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
+		unchecked_extrinsic_max_size: u32,
+		unchecked_extrinsic_size: *mut u32,
 		skip_ra: c_int,
 		quoting_enclave_target_info: Option<&sgx_target_info_t>,
 		quote_size: Option<&u32>,
@@ -170,7 +173,8 @@ extern "C" {
 		retval: *mut sgx_status_t,
 		collateral: *const sgx_ql_qve_collateral_t,
 		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
+		unchecked_extrinsic_max_size: u32,
+		unchecked_extrinsic_size: *mut u32,
 	) -> sgx_status_t;
 
 	pub fn generate_register_tcb_info_extrinsic(
@@ -178,7 +182,8 @@ extern "C" {
 		retval: *mut sgx_status_t,
 		collateral: *const sgx_ql_qve_collateral_t,
 		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
+		unchecked_extrinsic_max_size: u32,
+		unchecked_extrinsic_size: *mut u32,
 	) -> sgx_status_t;
 
 	pub fn dump_ias_ra_cert_to_disk(
@@ -218,7 +223,8 @@ extern "C" {
 		fiat_currency: *const u8,
 		fiat_currency_size: u32,
 		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
+		unchecked_extrinsic_max_size: u32,
+		unchecked_extrinsic_size: *mut u32,
 	) -> sgx_status_t;
 
 	pub fn update_weather_data_xt(
@@ -229,7 +235,8 @@ extern "C" {
 		weather_info_latitude: *const u8,
 		weather_info_latitude_size: u32,
 		unchecked_extrinsic: *mut u8,
-		unchecked_extrinsic_size: u32,
+		unchecked_extrinsic_max_size: u32,
+		unchecked_extrinsic_size: *mut u32,
 	) -> sgx_status_t;
 
 	pub fn run_state_provisioning_server(

--- a/core-primitives/enclave-api/src/remote_attestation.rs
+++ b/core-primitives/enclave-api/src/remote_attestation.rs
@@ -144,8 +144,9 @@ mod impl_ffi {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
 
 			let mut unchecked_extrinsic: Vec<u8> = vec![0u8; EXTRINSIC_MAX_SIZE];
+			let mut unchecked_extrinsic_size: u32 = 0;
 
-			trace!("Generating dcap_ra_extrinsic with URL: {}", w_url);
+			trace!("Generating ias_ra_extrinsic with URL: {}", w_url);
 
 			let url = w_url.encode();
 
@@ -157,6 +158,7 @@ mod impl_ffi {
 					url.len() as u32,
 					unchecked_extrinsic.as_mut_ptr(),
 					unchecked_extrinsic.len() as u32,
+					&mut unchecked_extrinsic_size as *mut u32,
 					skip_ra.into(),
 				)
 			};
@@ -164,7 +166,7 @@ mod impl_ffi {
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
 
-			Ok(unchecked_extrinsic)
+			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 		fn generate_dcap_ra_extrinsic_from_quote(
 			&self,
@@ -173,6 +175,7 @@ mod impl_ffi {
 		) -> EnclaveResult<Vec<u8>> {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
 			let mut unchecked_extrinsic: Vec<u8> = vec![0u8; EXTRINSIC_MAX_SIZE];
+			let mut unchecked_extrinsic_size: u32 = 0;
 			let url = url.encode();
 
 			let result = unsafe {
@@ -185,13 +188,14 @@ mod impl_ffi {
 					quote.len() as u32,
 					unchecked_extrinsic.as_mut_ptr(),
 					unchecked_extrinsic.len() as u32,
+					&mut unchecked_extrinsic_size as *mut u32,
 				)
 			};
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
 
-			Ok(unchecked_extrinsic.to_vec())
+			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
 		fn generate_dcap_ra_quote(&self, skip_ra: bool) -> EnclaveResult<Vec<u8>> {
@@ -250,7 +254,7 @@ mod impl_ffi {
 			trace!("Generating dcap_ra_extrinsic with URL: {}", w_url);
 
 			let mut unchecked_extrinsic: Vec<u8> = vec![0u8; EXTRINSIC_MAX_SIZE];
-
+			let mut unchecked_extrinsic_size: u32 = 0;
 			let url = w_url.encode();
 
 			let result = unsafe {
@@ -261,6 +265,7 @@ mod impl_ffi {
 					url.len() as u32,
 					unchecked_extrinsic.as_mut_ptr(),
 					unchecked_extrinsic.len() as u32,
+					&mut unchecked_extrinsic_size as *mut u32,
 					skip_ra.into(),
 					quoting_enclave_target_info.as_ref(),
 					quote_size.as_ref(),
@@ -270,7 +275,7 @@ mod impl_ffi {
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
 
-			Ok(unchecked_extrinsic)
+			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
 		fn generate_register_quoting_enclave_extrinsic(
@@ -279,6 +284,7 @@ mod impl_ffi {
 		) -> EnclaveResult<Vec<u8>> {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
 			let mut unchecked_extrinsic: Vec<u8> = vec![0u8; EXTRINSIC_MAX_SIZE];
+			let mut unchecked_extrinsic_size: u32 = 0;
 
 			trace!("Generating register quoting enclave");
 
@@ -291,6 +297,7 @@ mod impl_ffi {
 					collateral_ptr,
 					unchecked_extrinsic.as_mut_ptr(),
 					unchecked_extrinsic.len() as u32,
+					&mut unchecked_extrinsic_size as *mut u32,
 				)
 			};
 			let free_status = unsafe { sgx_ql_free_quote_verification_collateral(collateral_ptr) };
@@ -301,12 +308,13 @@ mod impl_ffi {
 				Error::SgxQuote(free_status)
 			);
 
-			Ok(unchecked_extrinsic)
+			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
 		fn generate_register_tcb_info_extrinsic(&self, fmspc: Fmspc) -> EnclaveResult<Vec<u8>> {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
 			let mut unchecked_extrinsic: Vec<u8> = vec![0u8; EXTRINSIC_MAX_SIZE];
+			let mut unchecked_extrinsic_size: u32 = 0;
 
 			trace!("Generating tcb_info registration");
 
@@ -319,6 +327,7 @@ mod impl_ffi {
 					collateral_ptr,
 					unchecked_extrinsic.as_mut_ptr(),
 					unchecked_extrinsic.len() as u32,
+					&mut unchecked_extrinsic_size as *mut u32,
 				)
 			};
 			let free_status = unsafe { sgx_ql_free_quote_verification_collateral(collateral_ptr) };
@@ -329,7 +338,7 @@ mod impl_ffi {
 				Error::SgxQuote(free_status)
 			);
 
-			Ok(unchecked_extrinsic)
+			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
 		fn dump_ias_ra_cert_to_disk(&self) -> EnclaveResult<()> {

--- a/core-primitives/enclave-api/src/teeracle_api.rs
+++ b/core-primitives/enclave-api/src/teeracle_api.rs
@@ -49,8 +49,9 @@ mod impl_ffi {
 				crypto_currency, fiat_currency
 			);
 			let mut retval = sgx_status_t::SGX_SUCCESS;
-			let response_len = 8192;
-			let mut response: Vec<u8> = vec![0u8; response_len as usize];
+			let response_max_len = 8192;
+			let mut response: Vec<u8> = vec![0u8; response_max_len as usize];
+			let mut response_len: u32 = 0;
 
 			let crypto_curr = crypto_currency.encode();
 			let fiat_curr = fiat_currency.encode();
@@ -64,14 +65,15 @@ mod impl_ffi {
 					fiat_curr.as_ptr(),
 					fiat_curr.len() as u32,
 					response.as_mut_ptr(),
-					response_len,
+					response_max_len,
+					&mut response_len as *mut u32,
 				)
 			};
 
 			ensure!(res == sgx_status_t::SGX_SUCCESS, Error::Sgx(res));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
 
-			Ok(response)
+			Ok(Vec::from(&response[..response_len as usize]))
 		}
 		fn update_weather_data_xt(
 			&self,
@@ -83,8 +85,9 @@ mod impl_ffi {
 				latitude, longitude
 			);
 			let mut retval = sgx_status_t::SGX_SUCCESS;
-			let response_len = 8192;
-			let mut response: Vec<u8> = vec![0u8; response_len as usize];
+			let response_max_len = 8192;
+			let mut response: Vec<u8> = vec![0u8; response_max_len as usize];
+			let mut response_len: u32 = 0;
 
 			let longitude_encoded: Vec<u8> = longitude.encode();
 			let latitude_encoded: Vec<u8> = latitude.encode();
@@ -98,13 +101,14 @@ mod impl_ffi {
 					latitude_encoded.as_ptr(),
 					latitude_encoded.len() as u32,
 					response.as_mut_ptr(),
-					response_len,
+					response_max_len,
+					&mut response_len as *mut u32,
 				)
 			};
 
 			ensure!(res == sgx_status_t::SGX_SUCCESS, Error::Sgx(res));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-			Ok(response)
+			Ok(Vec::from(&response[..response_len as usize]))
 		}
 	}
 }

--- a/core-primitives/utils/src/buffer.rs
+++ b/core-primitives/utils/src/buffer.rs
@@ -20,10 +20,12 @@
 use alloc::vec::Vec;
 
 /// Fills a given buffer with data and the left over buffer space with white spaces.
+/// Throw an error if the buffer size is not enough to hold `data`,
+/// return the length of `data` otherwise.
 pub fn write_slice_and_whitespace_pad(
 	writable: &mut [u8],
 	data: Vec<u8>,
-) -> Result<(), BufferError> {
+) -> Result<usize, BufferError> {
 	if data.len() > writable.len() {
 		return Err(BufferError::InsufficientBufferSize {
 			actual: writable.len(),
@@ -34,7 +36,7 @@ pub fn write_slice_and_whitespace_pad(
 	left.clone_from_slice(&data);
 	// fill the right side with whitespace
 	right.iter_mut().for_each(|x| *x = 0x20);
-	Ok(())
+	Ok(data.len())
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -46,6 +48,15 @@ pub enum BufferError {
 mod tests {
 	use super::*;
 	use alloc::vec;
+
+	#[test]
+	fn write_slice_and_whitespace_pad_works() {
+		let mut writable = vec![0; 32];
+		let data = vec![1; 30];
+		assert_eq!(write_slice_and_whitespace_pad(&mut writable, data), Ok(30));
+		assert_eq!(&writable[..30], vec![1; 30]);
+		assert_eq!(&writable[30..], vec![0x20; 2]);
+	}
 
 	#[test]
 	fn write_slice_and_whitespace_pad_returns_error_if_buffer_too_small() {

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -100,7 +100,8 @@ enclave {
 
 		public sgx_status_t generate_ias_ra_extrinsic(
 			[in, size=w_url_size] uint8_t* w_url, uint32_t w_url_size,
-			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size,
+			[out, size=unchecked_extrinsic_max_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_max_size,
+			[out] uint32_t* unchecked_extrinsic_size,
 			int skip_ra
 		);
 		public sgx_status_t generate_dcap_ra_quote(
@@ -113,12 +114,14 @@ enclave {
 		public sgx_status_t generate_dcap_ra_extrinsic_from_quote(
 			[in, size=w_url_size] uint8_t* w_url, uint32_t w_url_size,
 			[in, size=quote_size] uint8_t* quote, uint32_t quote_size,
-			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size
+			[out, size=unchecked_extrinsic_max_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_max_size,
+			[out] uint32_t* unchecked_extrinsic_size
 		);
 
 		public sgx_status_t generate_dcap_ra_extrinsic(
 			[in, size=w_url_size] uint8_t* w_url, uint32_t w_url_size,
-			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size,
+			[out, size=unchecked_extrinsic_max_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_max_size,
+			[out] uint32_t* unchecked_extrinsic_size,
 			int skip_ra,
 			[in] const sgx_target_info_t* quoting_enclave_target_info,
 			[in] uint32_t* quote_size
@@ -126,24 +129,28 @@ enclave {
 
 		public sgx_status_t generate_register_quoting_enclave_extrinsic(
 		    [in] const sgx_ql_qve_collateral_t *p_quote_collateral,
-			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size
+			[out, size=unchecked_extrinsic_max_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_max_size,
+			[out] uint32_t* unchecked_extrinsic_size
 		);
 
 		public sgx_status_t generate_register_tcb_info_extrinsic(
 		    [in] const sgx_ql_qve_collateral_t *p_quote_collateral,
-			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size
+			[out, size=unchecked_extrinsic_max_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_max_size,
+			[out] uint32_t* unchecked_extrinsic_size
 		);
 
 		public sgx_status_t update_market_data_xt(
 			[in, size=crypto_currency_size] uint8_t* crypto_currency, uint32_t crypto_currency_size,
 			[in, size=fiat_currency_size] uint8_t* fiat_currency, uint32_t fiat_currency_size,
-			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size
+			[out, size=unchecked_extrinsic_max_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_max_size,
+			[out] uint32_t* unchecked_extrinsic_size
 		);
 
 		public sgx_status_t update_weather_data_xt(
 			[in, size=weather_info_logitude_size] uint8_t* weather_info_logitude, uint32_t weather_info_logitude_size,
 			[in, size=weather_info_latitude_size] uint8_t* weather_info_latitude, uint32_t weather_info_latitude_size,
-			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size
+			[out, size=unchecked_extrinsic_max_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_max_size,
+			[out] uint32_t* unchecked_extrinsic_size
 		);
 
 		public sgx_status_t dump_ias_ra_cert_to_disk();

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -128,7 +128,8 @@ pub unsafe extern "C" fn generate_ias_ra_extrinsic(
 	w_url: *const u8,
 	w_url_size: u32,
 	unchecked_extrinsic: *mut u8,
-	unchecked_extrinsic_size: u32,
+	unchecked_extrinsic_max_size: u32,
+	unchecked_extrinsic_size: *mut u32,
 	skip_ra: c_int,
 ) -> sgx_status_t {
 	if w_url.is_null() || unchecked_extrinsic.is_null() {
@@ -137,17 +138,18 @@ pub unsafe extern "C" fn generate_ias_ra_extrinsic(
 	let mut url_slice = slice::from_raw_parts(w_url, w_url_size as usize);
 	let url = String::decode(&mut url_slice).expect("Could not decode url slice to a valid String");
 	let extrinsic_slice =
-		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
+		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_max_size as usize);
 
 	let extrinsic = match generate_ias_ra_extrinsic_internal(url, skip_ra == 1) {
 		Ok(xt) => xt,
 		Err(e) => return e.into(),
 	};
 
-	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
-		return EnclaveError::BufferError(e).into()
-	};
-
+	*unchecked_extrinsic_size =
+		match write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
+			Ok(l) => l as u32,
+			Err(e) => return EnclaveError::BufferError(e).into(),
+		};
 	sgx_status_t::SGX_SUCCESS
 }
 
@@ -156,7 +158,8 @@ pub unsafe extern "C" fn generate_dcap_ra_extrinsic(
 	w_url: *const u8,
 	w_url_size: u32,
 	unchecked_extrinsic: *mut u8,
-	unchecked_extrinsic_size: u32,
+	unchecked_extrinsic_max_size: u32,
+	unchecked_extrinsic_size: *mut u32,
 	skip_ra: c_int,
 	quoting_enclave_target_info: Option<&sgx_target_info_t>,
 	quote_size: Option<&u32>,
@@ -167,7 +170,7 @@ pub unsafe extern "C" fn generate_dcap_ra_extrinsic(
 	let mut url_slice = slice::from_raw_parts(w_url, w_url_size as usize);
 	let url = String::decode(&mut url_slice).expect("Could not decode url slice to a valid String");
 	let extrinsic_slice =
-		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
+		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_max_size as usize);
 
 	let extrinsic = match generate_dcap_ra_extrinsic_internal(
 		url,
@@ -179,9 +182,11 @@ pub unsafe extern "C" fn generate_dcap_ra_extrinsic(
 		Err(e) => return e.into(),
 	};
 
-	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
-		return EnclaveError::BufferError(e).into()
-	};
+	*unchecked_extrinsic_size =
+		match write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
+			Ok(l) => l as u32,
+			Err(e) => return EnclaveError::BufferError(e).into(),
+		};
 	sgx_status_t::SGX_SUCCESS
 }
 
@@ -261,7 +266,8 @@ pub unsafe extern "C" fn generate_dcap_ra_extrinsic_from_quote(
 	quote: *const u8,
 	quote_size: u32,
 	unchecked_extrinsic: *mut u8,
-	unchecked_extrinsic_size: u32,
+	unchecked_extrinsic_max_size: u32,
+	unchecked_extrinsic_size: *mut u32,
 ) -> sgx_status_t {
 	if w_url.is_null() || unchecked_extrinsic.is_null() {
 		return sgx_status_t::SGX_ERROR_INVALID_PARAMETER
@@ -270,7 +276,7 @@ pub unsafe extern "C" fn generate_dcap_ra_extrinsic_from_quote(
 	let url = String::decode(&mut url_slice).expect("Could not decode url slice to a valid String");
 
 	let extrinsic_slice =
-		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
+		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_max_size as usize);
 
 	let quote_slice = slice::from_raw_parts(quote, quote_size as usize);
 
@@ -279,9 +285,11 @@ pub unsafe extern "C" fn generate_dcap_ra_extrinsic_from_quote(
 		Err(e) => return e.into(),
 	};
 
-	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
-		return EnclaveError::BufferError(e).into()
-	};
+	*unchecked_extrinsic_size =
+		match write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
+			Ok(l) => l as u32,
+			Err(e) => return EnclaveError::BufferError(e).into(),
+		};
 	sgx_status_t::SGX_SUCCESS
 }
 
@@ -391,13 +399,14 @@ fn create_extrinsics(call: OpaqueCall) -> EnclaveResult<OpaqueExtrinsic> {
 pub unsafe extern "C" fn generate_register_quoting_enclave_extrinsic(
 	collateral: *const sgx_ql_qve_collateral_t,
 	unchecked_extrinsic: *mut u8,
-	unchecked_extrinsic_size: u32,
+	unchecked_extrinsic_max_size: u32,
+	unchecked_extrinsic_size: *mut u32,
 ) -> sgx_status_t {
 	if unchecked_extrinsic.is_null() || collateral.is_null() {
 		return sgx_status_t::SGX_ERROR_INVALID_PARAMETER
 	}
 	let extrinsic_slice =
-		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
+		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_max_size as usize);
 	let collateral = SgxQlQveCollateral::from_c_type(&*collateral);
 	let collateral_data = match collateral.get_quoting_enclave_split() {
 		Some(d) => d,
@@ -405,30 +414,31 @@ pub unsafe extern "C" fn generate_register_quoting_enclave_extrinsic(
 	};
 
 	let call_index_getter = |m: &NodeMetadata| m.register_quoting_enclave_call_indexes();
-	let extrinsic = generate_generic_register_collateral_extrinsic(
+	*unchecked_extrinsic_size = match generate_generic_register_collateral_extrinsic(
 		call_index_getter,
 		extrinsic_slice,
 		&collateral_data.0,
 		&collateral_data.1,
 		&collateral.qe_identity_issuer_chain,
-	);
-	match extrinsic {
-		Ok(_) => sgx_status_t::SGX_SUCCESS,
-		Err(e) => e.into(),
-	}
+	) {
+		Ok(l) => l as u32,
+		Err(e) => return e.into(),
+	};
+	sgx_status_t::SGX_SUCCESS
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn generate_register_tcb_info_extrinsic(
 	collateral: *const sgx_ql_qve_collateral_t,
 	unchecked_extrinsic: *mut u8,
-	unchecked_extrinsic_size: u32,
+	unchecked_extrinsic_max_size: u32,
+	unchecked_extrinsic_size: *mut u32,
 ) -> sgx_status_t {
 	if unchecked_extrinsic.is_null() || collateral.is_null() {
 		return sgx_status_t::SGX_ERROR_INVALID_PARAMETER
 	}
 	let extrinsic_slice =
-		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
+		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_max_size as usize);
 	let collateral = SgxQlQveCollateral::from_c_type(&*collateral);
 	let collateral_data = match collateral.get_tcb_info_split() {
 		Some(d) => d,
@@ -436,17 +446,17 @@ pub unsafe extern "C" fn generate_register_tcb_info_extrinsic(
 	};
 
 	let call_index_getter = |m: &NodeMetadata| m.register_tcb_info_call_indexes();
-	let extrinsic = generate_generic_register_collateral_extrinsic(
+	*unchecked_extrinsic_size = match generate_generic_register_collateral_extrinsic(
 		call_index_getter,
 		extrinsic_slice,
 		&collateral_data.0,
 		&collateral_data.1,
 		&collateral.tcb_info_issuer_chain,
-	);
-	match extrinsic {
-		Ok(_) => sgx_status_t::SGX_SUCCESS,
-		Err(e) => e.into(),
-	}
+	) {
+		Ok(l) => l as u32,
+		Err(e) => return e.into(),
+	};
+	sgx_status_t::SGX_SUCCESS
 }
 
 pub fn generate_generic_register_collateral_extrinsic<F>(
@@ -455,12 +465,10 @@ pub fn generate_generic_register_collateral_extrinsic<F>(
 	collateral_data: &str,
 	data_signature: &[u8],
 	issuer_chain: &[u8],
-) -> EnclaveResult<()>
+) -> EnclaveResult<usize>
 where
 	F: Fn(&NodeMetadata) -> Result<[u8; 2], MetadataError>,
 {
-	let extrinsics_factory = get_extrinsic_factory_from_integritee_solo_or_parachain()?;
-
 	let node_metadata_repo = get_node_metadata_repository_from_integritee_solo_or_parachain()?;
 	let call_ids = node_metadata_repo
 		.get_from_metadata(getter)?
@@ -468,11 +476,9 @@ where
 	info!("    [Enclave] Compose register collateral call: {:?}", call_ids);
 	let call = OpaqueCall::from_tuple(&(call_ids, collateral_data, data_signature, issuer_chain));
 
-	let extrinsic = extrinsics_factory.create_extrinsics(&[call], None)?[0].clone();
-	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, extrinsic.encode()) {
-		return EnclaveError::BufferError(e).into()
-	};
-	Ok(())
+	let xt = create_extrinsics(call)?;
+	write_slice_and_whitespace_pad(extrinsic_slice, xt.encode())
+		.map_err(|e| EnclaveError::Other(Box::new(e)))
 }
 
 #[no_mangle]

--- a/enclave-runtime/src/attestation.rs
+++ b/enclave-runtime/src/attestation.rs
@@ -478,7 +478,7 @@ where
 
 	let xt = create_extrinsics(call)?;
 	write_slice_and_whitespace_pad(extrinsic_slice, xt.encode())
-		.map_err(|e| EnclaveError::Other(Box::new(e)))
+		.map_err(|e| format!("{:?}", e).into())
 }
 
 #[no_mangle]

--- a/enclave-runtime/src/empty_impls.rs
+++ b/enclave-runtime/src/empty_impls.rs
@@ -31,7 +31,8 @@ pub unsafe extern "C" fn update_market_data_xt(
 	_fiat_currency_ptr: *const u8,
 	_fiat_currency_size: u32,
 	_unchecked_extrinsic: *mut u8,
-	_unchecked_extrinsic_size: u32,
+	_unchecked_extrinsic_max_size: u32,
+	_unchecked_extrinsic_size: *mut u32,
 ) -> sgx_types::sgx_status_t {
 	unreachable!("Cannot update market data, teeracle feature is not enabled.")
 }
@@ -45,7 +46,8 @@ pub unsafe extern "C" fn update_weather_data_xt(
 	_weather_info_latitude: *const u8,
 	_weather_info_latitude_size: u32,
 	_unchecked_extrinsic: *mut u8,
-	_unchecked_extrinsic_size: u32,
+	_unchecked_extrinsic_max_size: u32,
+	_unchecked_extrinsic_size: *mut u32,
 ) -> sgx_types::sgx_status_t {
 	unreachable!("Cannot update weather data, teeracle feature is not enabled.")
 }

--- a/enclave-runtime/src/teeracle/mod.rs
+++ b/enclave-runtime/src/teeracle/mod.rs
@@ -107,7 +107,8 @@ pub unsafe extern "C" fn update_weather_data_xt(
 	weather_info_latitude: *const u8,
 	weather_info_latitude_size: u32,
 	unchecked_extrinsic: *mut u8,
-	unchecked_extrinsic_size: u32,
+	unchecked_extrinsic_max_size: u32,
+	unchecked_extrinsic_size: *mut u32,
 ) -> sgx_status_t {
 	let mut weather_info_longitude_slice =
 		slice::from_raw_parts(weather_info_longitude, weather_info_longitude_size as usize);
@@ -141,13 +142,17 @@ pub unsafe extern "C" fn update_weather_data_xt(
 	};
 
 	let extrinsic_slice =
-		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
+		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_max_size as usize);
 
 	// Save created extrinsic as slice in the return value unchecked_extrinsic.
-	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, extrinsics.encode()) {
-		error!("Copying encoded extrinsics into return slice failed: {:?}", e);
-		return sgx_status_t::SGX_ERROR_UNEXPECTED
-	}
+	*unchecked_extrinsic_size =
+		match write_slice_and_whitespace_pad(extrinsic_slice, extrinsics.encode()) {
+			Ok(l) => l as u32,
+			Err(e) => {
+				error!("Copying encoded extrinsics into return slice failed: {:?}", e);
+				return sgx_status_t::SGX_ERROR_UNEXPECTED
+			},
+		};
 
 	sgx_status_t::SGX_SUCCESS
 }
@@ -160,7 +165,8 @@ pub unsafe extern "C" fn update_market_data_xt(
 	fiat_currency_ptr: *const u8,
 	fiat_currency_size: u32,
 	unchecked_extrinsic: *mut u8,
-	unchecked_extrinsic_size: u32,
+	unchecked_extrinsic_max_size: u32,
+	unchecked_extrinsic_size: *mut u32,
 ) -> sgx_status_t {
 	let mut crypto_currency_slice =
 		slice::from_raw_parts(crypto_currency_ptr, crypto_currency_size as usize);
@@ -183,13 +189,17 @@ pub unsafe extern "C" fn update_market_data_xt(
 		return sgx_status_t::SGX_ERROR_UNEXPECTED
 	}
 	let extrinsic_slice =
-		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_size as usize);
+		slice::from_raw_parts_mut(unchecked_extrinsic, unchecked_extrinsic_max_size as usize);
 
 	// Save created extrinsic as slice in the return value unchecked_extrinsic.
-	if let Err(e) = write_slice_and_whitespace_pad(extrinsic_slice, extrinsics.encode()) {
-		error!("Copying encoded extrinsics into return slice failed: {:?}", e);
-		return sgx_status_t::SGX_ERROR_UNEXPECTED
-	}
+	*unchecked_extrinsic_size =
+		match write_slice_and_whitespace_pad(extrinsic_slice, extrinsics.encode()) {
+			Ok(l) => l as u32,
+			Err(e) => {
+				error!("Copying encoded extrinsics into return slice failed: {:?}", e);
+				return sgx_status_t::SGX_ERROR_UNEXPECTED
+			},
+		};
 
 	sgx_status_t::SGX_SUCCESS
 }

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -1007,7 +1007,11 @@ fn send_extrinsic(
 	}
 
 	info!("[>] send extrinsic");
-	trace!("  encoded extrinsic: 0x{:}", hex::encode(extrinsic.clone()));
+	trace!(
+		"  encoded extrinsic len: {}, payload: 0x{:}",
+		extrinsic.len(),
+		hex::encode(extrinsic.clone())
+	);
 
 	// fixme: wait ...until_success doesn't work due to https://github.com/scs/substrate-api-client/issues/624
 	// fixme: currently, we don't verify if the extrinsic was a success here


### PR DESCRIPTION
It should fix the `ExtrinsicNotFound` error during enclave registration.

With the padded version (post-padded with spaces `0x20`) the extrinsic submission would succeed since the decoding goes through even with postpositioned (unused) bytes. However, the substrate-api-client wouldn't find the hash with the prolonged extrinsic that we pass in. 

Related: https://github.com/scs/substrate-api-client/issues/624