### PR TITLE
support json-rpc request string id

### DIFF
--- a/core/direct-rpc-server/src/builders/rpc_response_builder.rs
+++ b/core/direct-rpc-server/src/builders/rpc_response_builder.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::builders::rpc_return_value_builder::RpcReturnValueBuilder;
-use itp_rpc::{RpcResponse, RpcReturnValue};
+use itp_rpc::{Id, RpcResponse, RpcReturnValue};
 use itp_utils::ToHexPrefixed;
 
 /// builder pattern for RpcResponse
@@ -52,7 +52,7 @@ impl RpcResponseBuilder {
 
 	#[allow(unused)]
 	pub fn build(self) -> RpcResponse {
-		let id = self.maybe_id.unwrap_or(1u32);
+		let id = Id::Number(self.maybe_id.unwrap_or(1u32));
 		let json_rpc = self.maybe_json_rpc.unwrap_or(String::from("json_rpc"));
 		let result = self
 			.maybe_result

--- a/core/direct-rpc-server/src/rpc_connection_registry.rs
+++ b/core/direct-rpc-server/src/rpc_connection_registry.rs
@@ -82,6 +82,7 @@ where
 #[cfg(test)]
 pub mod tests {
 	use super::*;
+	use itp_rpc::Id;
 
 	type TestRegistry = ConnectionRegistry<String, u64>;
 
@@ -119,6 +120,6 @@ pub mod tests {
 	}
 
 	fn dummy_rpc_response() -> RpcResponse {
-		RpcResponse { jsonrpc: String::new(), result: Default::default(), id: 1u32 }
+		RpcResponse { jsonrpc: String::new(), result: Default::default(), id: Id::Number(1u32) }
 	}
 }

--- a/core/direct-rpc-server/src/rpc_watch_extractor.rs
+++ b/core/direct-rpc-server/src/rpc_watch_extractor.rs
@@ -80,13 +80,17 @@ pub mod tests {
 		rpc_response_builder::RpcResponseBuilder, rpc_return_value_builder::RpcReturnValueBuilder,
 	};
 	use codec::Encode;
+	use itp_rpc::Id;
 	use itp_types::TrustedOperationStatus;
 
 	#[test]
 	fn invalid_rpc_response_returns_error() {
 		let watch_extractor = RpcWatchExtractor::<String>::new();
-		let rpc_response =
-			RpcResponse { id: 1u32, jsonrpc: String::from("json"), result: "hello".to_string() };
+		let rpc_response = RpcResponse {
+			id: Id::Number(1u32),
+			jsonrpc: String::from("json"),
+			result: "hello".to_string(),
+		};
 
 		assert!(watch_extractor.must_be_watched(&rpc_response).is_err());
 	}

--- a/core/rpc-server/src/mock.rs
+++ b/core/rpc-server/src/mock.rs
@@ -16,7 +16,7 @@
 */
 
 use itp_enclave_api::{direct_request::DirectRequest, EnclaveResult};
-use itp_rpc::RpcResponse;
+use itp_rpc::{Id, RpcResponse};
 use itp_utils::ToHexPrefixed;
 use its_primitives::{
 	traits::ShardIdentifierFor,
@@ -29,7 +29,12 @@ pub struct TestEnclave;
 
 impl DirectRequest for TestEnclave {
 	fn rpc(&self, _request: Vec<u8>) -> EnclaveResult<Vec<u8>> {
-		Ok(RpcResponse { jsonrpc: "mock_response".into(), result: "null".to_hex(), id: 1 }.encode())
+		Ok(RpcResponse {
+			jsonrpc: "mock_response".into(),
+			result: "null".to_hex(),
+			id: Id::Number(1),
+		}
+		.encode())
 	}
 }
 


### PR DESCRIPTION
Node fails silently to send direct rpc request status updates if request's id type is `String`. Client hangs out waiting for more responses because of `do_watch: true`.

```
[2023-09-14T12:18:18Z WARN  itp_top_pool::watcher] failed to update connection state: InvalidConnectionHash
[2023-09-14T12:18:24Z WARN  itp_top_pool::watcher] failed to send status update to rpc client: InvalidConnectionHash, InSidechainBlock(0xe85176151f962568ec126d7c8dd30fcba106d35388093c39d4937b60e29c0a85)
```

According to JSON-RPC 2.0 spec field `id` can be of type String, Number, or NULL.

We [reported it and fixed](https://github.com/litentry/litentry-parachain/issues/2129) in Litentry repo.
