### PR TITLE
ensure extrinsic success for enclave RA registration and fix #1515

### DIFF
--- a/core-primitives/enclave-api/src/remote_attestation.rs
+++ b/core-primitives/enclave-api/src/remote_attestation.rs
@@ -165,7 +165,10 @@ mod impl_ffi {
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 		fn generate_dcap_ra_extrinsic_from_quote(
@@ -194,7 +197,10 @@ mod impl_ffi {
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
@@ -274,7 +280,10 @@ mod impl_ffi {
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
@@ -307,7 +316,10 @@ mod impl_ffi {
 				free_status == sgx_quote3_error_t::SGX_QL_SUCCESS,
 				Error::SgxQuote(free_status)
 			);
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
@@ -337,7 +349,10 @@ mod impl_ffi {
 				free_status == sgx_quote3_error_t::SGX_QL_SUCCESS,
 				Error::SgxQuote(free_status)
 			);
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 


### PR DESCRIPTION
closes #1515 

also, ensure success of enclave RA registration extrinsic, now that we can rely on api-client to return result