### PR TITLE
skip indirect invocations for initial sync of integritee parentchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-cli"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "array-bytes 6.1.0",
  "base58",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-service"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-cli"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -67,6 +67,17 @@ extern "C" {
 		parentchain_id_size: u32,
 	) -> sgx_status_t;
 
+	pub fn init_shard_birth_parentchain_header(
+		eid: sgx_enclave_id_t,
+		retval: *mut sgx_status_t,
+		shard: *const u8,
+		shard_size: u32,
+		parentchain_id: *const u8,
+		parentchain_id_size: u32,
+		header: *const u8,
+		header_size: u32,
+	) -> sgx_status_t;
+
 	pub fn execute_trusted_calls(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
 
 	pub fn sync_parentchain(

--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -67,7 +67,7 @@ extern "C" {
 		parentchain_id_size: u32,
 	) -> sgx_status_t;
 
-	pub fn init_shard_birth_parentchain_header(
+	pub fn init_shard_creation_parentchain_header(
 		eid: sgx_enclave_id_t,
 		retval: *mut sgx_status_t,
 		shard: *const u8,
@@ -78,13 +78,13 @@ extern "C" {
 		header_size: u32,
 	) -> sgx_status_t;
 
-	pub fn get_shard_birth_header(
+	pub fn get_shard_creation_header(
 		eid: sgx_enclave_id_t,
 		retval: *mut sgx_status_t,
 		shard: *const u8,
 		shard_size: u32,
-		birth: *mut u8,
-		birth_size: u32,
+		creation: *mut u8,
+		creation_size: u32,
 	) -> sgx_status_t;
 
 	pub fn execute_trusted_calls(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;

--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -100,7 +100,7 @@ extern "C" {
 		events_proofs_size: usize,
 		parentchain_id: *const u8,
 		parentchain_id_size: u32,
-		is_syncing: c_int,
+		immediate_import: c_int,
 	) -> sgx_status_t;
 
 	pub fn set_nonce(

--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -78,6 +78,15 @@ extern "C" {
 		header_size: u32,
 	) -> sgx_status_t;
 
+	pub fn get_shard_birth_header(
+		eid: sgx_enclave_id_t,
+		retval: *mut sgx_status_t,
+		shard: *const u8,
+		shard_size: u32,
+		birth: *mut u8,
+		birth_size: u32,
+	) -> sgx_status_t;
+
 	pub fn execute_trusted_calls(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
 
 	pub fn sync_parentchain(

--- a/core-primitives/enclave-api/src/enclave_base.rs
+++ b/core-primitives/enclave-api/src/enclave_base.rs
@@ -255,12 +255,11 @@ mod impl_ffi {
 			shard: &ShardIdentifier,
 		) -> EnclaveResult<(ParentchainId, Header)> {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
-			let mut birth =
-				[0u8; std::mem::size_of::<Header>() + std::mem::size_of::<ParentchainId>()];
+			let mut birth = [0u8; HEADER_MAX_SIZE + std::mem::size_of::<ParentchainId>()];
 			let shard_bytes = shard.encode();
 
 			let result = unsafe {
-				ffi::get_ecc_vault_pubkey(
+				ffi::get_shard_birth_header(
 					self.eid,
 					&mut retval,
 					shard_bytes.as_ptr(),

--- a/core-primitives/enclave-api/src/enclave_base.rs
+++ b/core-primitives/enclave-api/src/enclave_base.rs
@@ -58,14 +58,14 @@ pub trait EnclaveBase: Send + Sync + 'static {
 	) -> EnclaveResult<()>;
 
 	/// Initialize parentchain checkpoint after which invocations will be processed
-	fn init_shard_birth_parentchain_header(
+	fn init_shard_creation_parentchain_header(
 		&self,
 		shard: &ShardIdentifier,
 		parentchain_id: &ParentchainId,
 		header: &Header,
 	) -> EnclaveResult<()>;
 
-	fn get_shard_birth_header(
+	fn get_shard_creation_header(
 		&self,
 		shard: &ShardIdentifier,
 	) -> EnclaveResult<(ParentchainId, Header)>;
@@ -221,7 +221,7 @@ mod impl_ffi {
 			Ok(())
 		}
 
-		fn init_shard_birth_parentchain_header(
+		fn init_shard_creation_parentchain_header(
 			&self,
 			shard: &ShardIdentifier,
 			parentchain_id: &ParentchainId,
@@ -232,7 +232,7 @@ mod impl_ffi {
 			let header_bytes = header.encode();
 			let shard_bytes = shard.encode();
 			let result = unsafe {
-				ffi::init_shard_birth_parentchain_header(
+				ffi::init_shard_creation_parentchain_header(
 					self.eid,
 					&mut retval,
 					shard_bytes.as_ptr(),
@@ -250,30 +250,30 @@ mod impl_ffi {
 			Ok(())
 		}
 
-		fn get_shard_birth_header(
+		fn get_shard_creation_header(
 			&self,
 			shard: &ShardIdentifier,
 		) -> EnclaveResult<(ParentchainId, Header)> {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
-			let mut birth = [0u8; HEADER_MAX_SIZE + std::mem::size_of::<ParentchainId>()];
+			let mut creation = [0u8; HEADER_MAX_SIZE + std::mem::size_of::<ParentchainId>()];
 			let shard_bytes = shard.encode();
 
 			let result = unsafe {
-				ffi::get_shard_birth_header(
+				ffi::get_shard_creation_header(
 					self.eid,
 					&mut retval,
 					shard_bytes.as_ptr(),
 					shard_bytes.len() as u32,
-					birth.as_mut_ptr(),
-					birth.len() as u32,
+					creation.as_mut_ptr(),
+					creation.len() as u32,
 				)
 			};
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-			let (birth_parentchain_id, birth_header): (ParentchainId, Header) =
-				Decode::decode(&mut birth.as_slice())?;
-			Ok((birth_parentchain_id, birth_header))
+			let (creation_parentchain_id, creation_header): (ParentchainId, Header) =
+				Decode::decode(&mut creation.as_slice())?;
+			Ok((creation_parentchain_id, creation_header))
 		}
 
 		fn set_nonce(&self, nonce: u32, parentchain_id: ParentchainId) -> EnclaveResult<()> {

--- a/core-primitives/enclave-api/src/remote_attestation.rs
+++ b/core-primitives/enclave-api/src/remote_attestation.rs
@@ -165,7 +165,10 @@ mod impl_ffi {
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 		fn generate_dcap_ra_extrinsic_from_quote(
@@ -194,7 +197,10 @@ mod impl_ffi {
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
@@ -274,7 +280,10 @@ mod impl_ffi {
 
 			ensure!(result == sgx_status_t::SGX_SUCCESS, Error::Sgx(result));
 			ensure!(retval == sgx_status_t::SGX_SUCCESS, Error::Sgx(retval));
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
@@ -307,7 +316,10 @@ mod impl_ffi {
 				free_status == sgx_quote3_error_t::SGX_QL_SUCCESS,
 				Error::SgxQuote(free_status)
 			);
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 
@@ -337,7 +349,10 @@ mod impl_ffi {
 				free_status == sgx_quote3_error_t::SGX_QL_SUCCESS,
 				Error::SgxQuote(free_status)
 			);
-
+			ensure!(
+				(unchecked_extrinsic_size as usize) < unchecked_extrinsic.len(),
+				Error::Sgx(sgx_status_t::SGX_ERROR_INVALID_PARAMETER)
+			);
 			Ok(Vec::from(&unchecked_extrinsic[..unchecked_extrinsic_size as usize]))
 		}
 

--- a/core-primitives/enclave-api/src/sidechain.rs
+++ b/core-primitives/enclave-api/src/sidechain.rs
@@ -32,7 +32,7 @@ pub trait Sidechain: Send + Sync + 'static {
 		events: &[Vec<u8>],
 		events_proofs: &[StorageProof],
 		parentchain_id: &ParentchainId,
-		is_syncing: bool,
+		immediate_import: bool,
 	) -> EnclaveResult<()>;
 
 	fn execute_trusted_calls(&self) -> EnclaveResult<()>;
@@ -57,7 +57,7 @@ mod impl_ffi {
 			events: &[Vec<u8>],
 			events_proofs: &[StorageProof],
 			parentchain_id: &ParentchainId,
-			is_syncing: bool,
+			immediate_import: bool,
 		) -> EnclaveResult<()> {
 			let mut retval = sgx_status_t::SGX_SUCCESS;
 			let blocks_enc = blocks.encode();
@@ -77,7 +77,7 @@ mod impl_ffi {
 					events_proofs_enc.len(),
 					parentchain_id_enc.as_ptr(),
 					parentchain_id_enc.len() as u32,
-					is_syncing.into(),
+					immediate_import.into(),
 				)
 			};
 

--- a/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
+++ b/core-primitives/node-api/api-client-extensions/src/pallet_teerex.rs
@@ -17,7 +17,9 @@
 
 use crate::ApiResult;
 use itp_api_client_types::{traits::GetStorage, Api, Config, Request};
-use itp_types::{AccountId, IpfsHash, MultiEnclave, ShardIdentifier, ShardStatus};
+use itp_types::{
+	AccountId, IpfsHash, MultiEnclave, ShardIdentifier, ShardSignerStatus, ShardStatus,
+};
 use log::error;
 
 pub const TEEREX: &str = "Teerex";
@@ -40,6 +42,11 @@ pub trait PalletTeerexApi {
 		shard: &ShardIdentifier,
 		at_block: Option<Self::Hash>,
 	) -> ApiResult<Option<MultiEnclave<Vec<u8>>>>;
+	fn shard_status(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Self::Hash>,
+	) -> ApiResult<Option<Vec<ShardSignerStatus>>>;
 	fn latest_ipfs_hash(
 		&self,
 		shard: &ShardIdentifier,
@@ -98,6 +105,14 @@ where
 					)
 				},
 			)
+	}
+
+	fn shard_status(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Self::Hash>,
+	) -> ApiResult<Option<Vec<ShardSignerStatus>>> {
+		self.get_storage_map(ENCLAVE_BRIDGE, "ShardStatus", shard, at_block)
 	}
 
 	fn latest_ipfs_hash(

--- a/core-primitives/stf-interface/src/lib.rs
+++ b/core-primitives/stf-interface/src/lib.rs
@@ -37,6 +37,7 @@ pub mod sudo_pallet;
 pub mod system_pallet;
 
 pub const SHARD_VAULT_KEY: &str = "ShardVaultPubKey";
+pub const SHARD_BIRTH_HEADER_KEY: &str = "ShardBirthHeaderKey";
 
 /// Interface to initialize a new state.
 pub trait InitState<State, AccountId> {

--- a/core-primitives/stf-interface/src/lib.rs
+++ b/core-primitives/stf-interface/src/lib.rs
@@ -37,7 +37,7 @@ pub mod sudo_pallet;
 pub mod system_pallet;
 
 pub const SHARD_VAULT_KEY: &str = "ShardVaultPubKey";
-pub const SHARD_BIRTH_HEADER_KEY: &str = "ShardBirthHeaderKey";
+pub const SHARD_CREATION_HEADER_KEY: &str = "ShardCreationHeaderKey";
 
 /// Interface to initialize a new state.
 pub trait InitState<State, AccountId> {

--- a/core/parentchain/block-import-dispatcher/src/immediate_dispatcher.rs
+++ b/core/parentchain/block-import-dispatcher/src/immediate_dispatcher.rs
@@ -51,9 +51,9 @@ where
 		&self,
 		blocks: Vec<SignedBlockType>,
 		events: Vec<Vec<u8>>,
-		_is_syncing: bool,
+		_immediate_import: bool,
 	) -> Result<()> {
-		// _is_syncing does not matter for the immediate dispatcher, behavoiur is the same. Immediate block import.
+		// _immediate_import does not matter for the immediate dispatcher, behavoiur is the same. Immediate block import.
 
 		debug!("Importing {} parentchain blocks", blocks.len());
 		self.block_importer.import_parentchain_blocks(blocks, events)?;

--- a/core/parentchain/block-import-dispatcher/src/lib.rs
+++ b/core/parentchain/block-import-dispatcher/src/lib.rs
@@ -49,7 +49,7 @@ pub trait DispatchBlockImport<SignedBlockType> {
 		&self,
 		blocks: Vec<SignedBlockType>,
 		events: Vec<Vec<u8>>,
-		is_syncing: bool,
+		immediate_import: bool,
 	) -> Result<()>;
 }
 
@@ -105,16 +105,16 @@ where
 		&self,
 		blocks: Vec<SignedBlockType>,
 		events: Vec<Vec<u8>>,
-		is_syncing: bool,
+		immediate_import: bool,
 	) -> Result<()> {
 		match self {
 			BlockImportDispatcher::TriggeredDispatcher(dispatcher) => {
 				log::trace!("TRIGGERED DISPATCHER MATCH");
-				dispatcher.dispatch_import(blocks, events, is_syncing)
+				dispatcher.dispatch_import(blocks, events, immediate_import)
 			},
 			BlockImportDispatcher::ImmediateDispatcher(dispatcher) => {
 				log::trace!("IMMEDIATE DISPATCHER MATCH");
-				dispatcher.dispatch_import(blocks, events, is_syncing)
+				dispatcher.dispatch_import(blocks, events, immediate_import)
 			},
 			BlockImportDispatcher::EmptyDispatcher => {
 				log::trace!("EMPTY DISPATCHER DISPATCHER MATCH");

--- a/core/parentchain/block-import-dispatcher/src/triggered_dispatcher.rs
+++ b/core/parentchain/block-import-dispatcher/src/triggered_dispatcher.rs
@@ -100,7 +100,7 @@ where
 		&self,
 		blocks: Vec<SignedBlockType>,
 		events: Vec<RawEventsPerBlock>,
-		is_syncing: bool,
+		immediate_import: bool,
 	) -> Result<()> {
 		let parentchain_id = self.block_importer.parentchain_id();
 		trace!(
@@ -109,7 +109,7 @@ where
 			blocks.len(),
 			events.len()
 		);
-		if is_syncing {
+		if immediate_import {
 			trace!(
 				"[{:?}] Triggered is in sync mode, immediately importing blocks and events",
 				parentchain_id

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -18,7 +18,7 @@
 //! Imports parentchain blocks and executes any indirect calls found in the extrinsics.
 
 use crate::{error::Result, ImportParentchainBlocks};
-use codec::Decode;
+
 use ita_stf::ParentchainHeader;
 use itc_parentchain_indirect_calls_executor::ExecuteIndirectCalls;
 use itc_parentchain_light_client::{
@@ -28,7 +28,7 @@ use itp_extrinsics_factory::CreateExtrinsics;
 use itp_stf_executor::traits::StfUpdateState;
 use itp_types::{
 	parentchain::{Header, IdentifyParentchain, ParentchainId},
-	OpaqueCall, ShardIdentifier, H256,
+	OpaqueCall, H256,
 };
 use log::*;
 use sp_runtime::{

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -138,10 +138,6 @@ impl<
 							birth_header.number
 						);
 						continue
-					} else {
-						trace!(
-							"only Integritee parentchain is supported for shard birth fast-syncing"
-						);
 					}
 				}
 			}

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -134,7 +134,7 @@ impl<
 				if let Some(birth_header) = self.maybe_birth_header.clone() {
 					if signed_block.block.header().number < birth_header.number {
 						trace!(
-							"fast-syncing block import, ignoring any invocations up to block {:}",
+							"fast-syncing block import, ignoring any invocations before block {:}",
 							birth_header.number
 						);
 						continue

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -131,7 +131,7 @@ impl<
 
 			// check if we can fast-sync
 			if id == ParentchainId::Integritee {
-				if let Some(birth_header) = self.maybe_birth_header.clone() {
+				if let Some(ref birth_header) = self.maybe_birth_header {
 					if signed_block.block.header().number < birth_header.number {
 						trace!(
 							"fast-syncing block import, ignoring any invocations before block {:}",

--- a/core/parentchain/block-importer/src/block_importer.rs
+++ b/core/parentchain/block-importer/src/block_importer.rs
@@ -49,7 +49,7 @@ pub struct ParentchainBlockImporter<
 	stf_executor: Arc<StfExecutor>,
 	extrinsics_factory: Arc<ExtrinsicsFactory>,
 	pub indirect_calls_executor: Arc<IndirectCallsExecutor>,
-	maybe_birth_header: Option<Header>,
+	maybe_creation_header: Option<Header>,
 	_phantom: PhantomData<ParentchainBlock>,
 }
 
@@ -73,14 +73,14 @@ impl<
 		stf_executor: Arc<StfExecutor>,
 		extrinsics_factory: Arc<ExtrinsicsFactory>,
 		indirect_calls_executor: Arc<IndirectCallsExecutor>,
-		maybe_birth_header: Option<Header>,
+		maybe_creation_header: Option<Header>,
 	) -> Self {
 		ParentchainBlockImporter {
 			validator_accessor,
 			stf_executor,
 			extrinsics_factory,
 			indirect_calls_executor,
-			maybe_birth_header,
+			maybe_creation_header,
 			_phantom: Default::default(),
 		}
 	}
@@ -126,16 +126,17 @@ impl<
 				.execute_mut_on_validator(|v| v.submit_block(&signed_block))
 			{
 				error!("[{:?}] Header submission to light client failed: {:?}", id, e);
+
 				return Err(e.into())
 			}
 
 			// check if we can fast-sync
 			if id == ParentchainId::Integritee {
-				if let Some(ref birth_header) = self.maybe_birth_header {
-					if signed_block.block.header().number < birth_header.number {
+				if let Some(ref creation_header) = self.maybe_creation_header {
+					if signed_block.block.header().number < creation_header.number {
 						trace!(
 							"fast-syncing block import, ignoring any invocations before block {:}",
-							birth_header.number
+							creation_header.number
 						);
 						continue
 					}

--- a/core/parentchain/parentchain-crate/src/primitives.rs
+++ b/core/parentchain/parentchain-crate/src/primitives.rs
@@ -22,7 +22,9 @@ use codec::{Decode, Encode};
 
 use sp_runtime::traits::Block;
 
+use itp_types::ShardIdentifier;
 pub use itp_types::{parentchain::ParentchainId, Block as ParachainBlock, Block as SolochainBlock};
+
 pub type HeaderFor<B> = <B as Block>::Header;
 pub type SolochainHeader = HeaderFor<SolochainBlock>;
 pub type ParachainHeader = HeaderFor<ParachainBlock>;
@@ -33,8 +35,8 @@ pub type ParachainParams = SimpleParams<ParachainHeader>;
 /// Allows to use a single E-call for the initialization of different parentchain types.
 #[derive(Encode, Decode, Clone)]
 pub enum ParentchainInitParams {
-	Solochain { id: ParentchainId, params: SolochainParams },
-	Parachain { id: ParentchainId, params: ParachainParams },
+	Solochain { id: ParentchainId, shard: ShardIdentifier, params: SolochainParams },
+	Parachain { id: ParentchainId, shard: ShardIdentifier, params: ParachainParams },
 }
 
 impl ParentchainInitParams {
@@ -46,14 +48,14 @@ impl ParentchainInitParams {
 	}
 }
 
-impl From<(ParentchainId, SolochainParams)> for ParentchainInitParams {
-	fn from(value: (ParentchainId, SolochainParams)) -> Self {
-		Self::Solochain { id: value.0, params: value.1 }
+impl From<(ParentchainId, ShardIdentifier, SolochainParams)> for ParentchainInitParams {
+	fn from(value: (ParentchainId, ShardIdentifier, SolochainParams)) -> Self {
+		Self::Solochain { id: value.0, shard: value.1, params: value.2 }
 	}
 }
 
-impl From<(ParentchainId, ParachainParams)> for ParentchainInitParams {
-	fn from(value: (ParentchainId, ParachainParams)) -> Self {
-		Self::Parachain { id: value.0, params: value.1 }
+impl From<(ParentchainId, ShardIdentifier, ParachainParams)> for ParentchainInitParams {
+	fn from(value: (ParentchainId, ShardIdentifier, ParachainParams)) -> Self {
+		Self::Parachain { id: value.0, shard: value.1, params: value.2 }
 	}
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 25
-    command: "--clean-reset --data-dir /tmp/worker2 --ws-external -M integritee-worker-2 -T wss://integritee-worker-2 -u ws://integritee-node -U ws://integritee-worker-2 -P 2012 -w 2102 -p 9912 -h 4646 run --dev --request-state ${ADDITIONAL_RUNTIME_FLAGS}"
+    command: "--clean-reset --data-dir /tmp/worker2 --ws-external -M integritee-worker-2 -T wss://integritee-worker-2 -u ws://integritee-node -U ws://integritee-worker-2 -P 2012 -w 2102 -p 9912 -h 4646 run --dev ${ADDITIONAL_RUNTIME_FLAGS}"
     restart: "no"
 networks:
   integritee-test-network:

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "itc-offchain-worker-executor",
  "itc-parentchain",
  "itc-parentchain-block-import-dispatcher",
+ "itc-parentchain-block-importer",
  "itc-parentchain-test",
  "itc-tls-websocket-server",
  "itp-attestation-handler",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runtime"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "array-bytes 6.1.0",
  "cid",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -98,6 +98,7 @@ itc-direct-rpc-server = { path = "../core/direct-rpc-server", default-features =
 itc-offchain-worker-executor = { path = "../core/offchain-worker-executor", default-features = false, features = ["sgx"] }
 itc-parentchain = { path = "../core/parentchain/parentchain-crate", default-features = false, features = ["sgx"] }
 itc-parentchain-block-import-dispatcher = { path = "../core/parentchain/block-import-dispatcher", default-features = false, features = ["sgx"] }
+itc-parentchain-block-importer = { path = "../core/parentchain/block-importer", default-features = false, features = ["sgx"] }
 itc-parentchain-test = { path = "../core/parentchain/test", default-features = false }
 itc-tls-websocket-server = { path = "../core/tls-websocket-server", default-features = false, features = ["sgx"] }
 itp-attestation-handler = { path = "../core-primitives/attestation-handler", default-features = false, features = ["sgx"] }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runtime"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -63,15 +63,15 @@ enclave {
 			[in, size=parentchain_id_size] uint8_t* parentchain_id, uint32_t parentchain_id_size
 		);
 
-		public sgx_status_t init_shard_birth_parentchain_header(
+		public sgx_status_t init_shard_creation_parentchain_header(
 		    [in, size=shard_size] uint8_t* shard, uint32_t shard_size,
 			[in, size=parentchain_id_size] uint8_t* parentchain_id, uint32_t parentchain_id_size,
     		[in, size=header_size] uint8_t* header, uint32_t header_size
 		);
 
-		public sgx_status_t get_shard_birth_header(
+		public sgx_status_t get_shard_creation_header(
 			[in, size=shard_size] uint8_t* shard, uint32_t shard_size,
-			[out, size=birth_size] uint8_t* birth, uint32_t birth_size);
+			[out, size=creation_size] uint8_t* creation, uint32_t creation_size);
 
 		public sgx_status_t execute_trusted_calls();
 

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -63,6 +63,16 @@ enclave {
 			[in, size=parentchain_id_size] uint8_t* parentchain_id, uint32_t parentchain_id_size
 		);
 
+		public sgx_status_t init_shard_birth_parentchain_header(
+		    [in, size=shard_size] uint8_t* shard, uint32_t shard_size,
+			[in, size=parentchain_id_size] uint8_t* parentchain_id, uint32_t parentchain_id_size,
+    		[in, size=header_size] uint8_t* header, uint32_t header_size
+		);
+
+		public sgx_status_t get_shard_birth_header(
+			[in, size=shard_size] uint8_t* shard, uint32_t shard_size,
+			[out, size=birth_size] uint8_t* birth, uint32_t birth_size);
+
 		public sgx_status_t execute_trusted_calls();
 
 		public sgx_status_t sync_parentchain(

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -80,7 +80,7 @@ enclave {
 			[in, size=events_size] uint8_t* events, size_t events_size,
 			[in, size=events_proofs_size] uint8_t* events_proofs, size_t events_proofs_size,
 			[in, size=parentchain_id_size] uint8_t* parentchain_id, uint32_t parentchain_id_size,
-			int is_syncing
+			int immediate_import
 		);
 
 		public sgx_status_t set_nonce(

--- a/enclave-runtime/src/initialization/parentchain/common.rs
+++ b/enclave-runtime/src/initialization/parentchain/common.rs
@@ -46,6 +46,7 @@ use crate::{
 use itp_component_container::ComponentGetter;
 use itp_nonce_cache::NonceCache;
 use itp_sgx_crypto::key_repository::AccessKey;
+use itp_types::parentchain::Header;
 use log::*;
 use sp_core::H256;
 use std::sync::Arc;
@@ -55,6 +56,7 @@ pub(crate) fn create_integritee_parentchain_block_importer(
 	stf_executor: Arc<EnclaveStfExecutor>,
 	extrinsics_factory: Arc<EnclaveExtrinsicsFactory>,
 	node_metadata_repository: Arc<EnclaveNodeMetadataRepository>,
+	birth_header: Header,
 ) -> Result<IntegriteeParentchainBlockImporter> {
 	let state_observer = GLOBAL_STATE_OBSERVER_COMPONENT.get()?;
 	let top_pool_author = GLOBAL_TOP_POOL_AUTHOR_COMPONENT.get()?;
@@ -78,6 +80,7 @@ pub(crate) fn create_integritee_parentchain_block_importer(
 		stf_executor,
 		extrinsics_factory,
 		indirect_calls_executor,
+		Some(birth_header),
 	))
 }
 
@@ -109,6 +112,7 @@ pub(crate) fn create_target_a_parentchain_block_importer(
 		stf_executor,
 		extrinsics_factory,
 		indirect_calls_executor,
+		None,
 	))
 }
 
@@ -140,6 +144,7 @@ pub(crate) fn create_target_b_parentchain_block_importer(
 		stf_executor,
 		extrinsics_factory,
 		indirect_calls_executor,
+		None,
 	))
 }
 

--- a/enclave-runtime/src/initialization/parentchain/common.rs
+++ b/enclave-runtime/src/initialization/parentchain/common.rs
@@ -56,7 +56,7 @@ pub(crate) fn create_integritee_parentchain_block_importer(
 	stf_executor: Arc<EnclaveStfExecutor>,
 	extrinsics_factory: Arc<EnclaveExtrinsicsFactory>,
 	node_metadata_repository: Arc<EnclaveNodeMetadataRepository>,
-	birth_header: Header,
+	maybe_birth_header: Option<Header>,
 ) -> Result<IntegriteeParentchainBlockImporter> {
 	let state_observer = GLOBAL_STATE_OBSERVER_COMPONENT.get()?;
 	let top_pool_author = GLOBAL_TOP_POOL_AUTHOR_COMPONENT.get()?;
@@ -80,7 +80,7 @@ pub(crate) fn create_integritee_parentchain_block_importer(
 		stf_executor,
 		extrinsics_factory,
 		indirect_calls_executor,
-		Some(birth_header),
+		maybe_birth_header,
 	))
 }
 

--- a/enclave-runtime/src/initialization/parentchain/common.rs
+++ b/enclave-runtime/src/initialization/parentchain/common.rs
@@ -56,7 +56,7 @@ pub(crate) fn create_integritee_parentchain_block_importer(
 	stf_executor: Arc<EnclaveStfExecutor>,
 	extrinsics_factory: Arc<EnclaveExtrinsicsFactory>,
 	node_metadata_repository: Arc<EnclaveNodeMetadataRepository>,
-	maybe_birth_header: Option<Header>,
+	maybe_creation_header: Option<Header>,
 ) -> Result<IntegriteeParentchainBlockImporter> {
 	let state_observer = GLOBAL_STATE_OBSERVER_COMPONENT.get()?;
 	let top_pool_author = GLOBAL_TOP_POOL_AUTHOR_COMPONENT.get()?;
@@ -80,7 +80,7 @@ pub(crate) fn create_integritee_parentchain_block_importer(
 		stf_executor,
 		extrinsics_factory,
 		indirect_calls_executor,
-		maybe_birth_header,
+		maybe_creation_header,
 	))
 }
 

--- a/enclave-runtime/src/initialization/parentchain/integritee_parachain.rs
+++ b/enclave-runtime/src/initialization/parentchain/integritee_parachain.rs
@@ -40,7 +40,7 @@ use itp_types::parentchain::ParentchainId;
 use std::{path::PathBuf, sync::Arc};
 
 pub use itc_parentchain::primitives::{ParachainBlock, ParachainHeader, ParachainParams};
-
+use itp_types::parentchain::Header;
 #[derive(Clone)]
 pub struct IntegriteeParachainHandler {
 	pub genesis_header: ParachainHeader,
@@ -55,6 +55,7 @@ impl IntegriteeParachainHandler {
 	pub fn init<WorkerModeProvider: ProvideWorkerMode>(
 		_base_path: PathBuf,
 		params: ParachainParams,
+		birth_header: Header,
 	) -> Result<Self> {
 		let ocall_api = GLOBAL_OCALL_API_COMPONENT.get()?;
 		let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
@@ -91,6 +92,7 @@ impl IntegriteeParachainHandler {
 			stf_executor.clone(),
 			extrinsics_factory.clone(),
 			node_metadata_repository.clone(),
+			birth_header,
 		)?;
 
 		let import_dispatcher = match WorkerModeProvider::worker_mode() {

--- a/enclave-runtime/src/initialization/parentchain/integritee_parachain.rs
+++ b/enclave-runtime/src/initialization/parentchain/integritee_parachain.rs
@@ -55,7 +55,7 @@ impl IntegriteeParachainHandler {
 	pub fn init<WorkerModeProvider: ProvideWorkerMode>(
 		_base_path: PathBuf,
 		params: ParachainParams,
-		maybe_birth_header: Option<Header>,
+		maybe_creation_header: Option<Header>,
 	) -> Result<Self> {
 		let ocall_api = GLOBAL_OCALL_API_COMPONENT.get()?;
 		let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
@@ -92,7 +92,7 @@ impl IntegriteeParachainHandler {
 			stf_executor.clone(),
 			extrinsics_factory.clone(),
 			node_metadata_repository.clone(),
-			maybe_birth_header,
+			maybe_creation_header,
 		)?;
 
 		let import_dispatcher = match WorkerModeProvider::worker_mode() {

--- a/enclave-runtime/src/initialization/parentchain/integritee_parachain.rs
+++ b/enclave-runtime/src/initialization/parentchain/integritee_parachain.rs
@@ -55,7 +55,7 @@ impl IntegriteeParachainHandler {
 	pub fn init<WorkerModeProvider: ProvideWorkerMode>(
 		_base_path: PathBuf,
 		params: ParachainParams,
-		birth_header: Header,
+		maybe_birth_header: Option<Header>,
 	) -> Result<Self> {
 		let ocall_api = GLOBAL_OCALL_API_COMPONENT.get()?;
 		let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
@@ -92,7 +92,7 @@ impl IntegriteeParachainHandler {
 			stf_executor.clone(),
 			extrinsics_factory.clone(),
 			node_metadata_repository.clone(),
-			birth_header,
+			maybe_birth_header,
 		)?;
 
 		let import_dispatcher = match WorkerModeProvider::worker_mode() {

--- a/enclave-runtime/src/initialization/parentchain/integritee_solochain.rs
+++ b/enclave-runtime/src/initialization/parentchain/integritee_solochain.rs
@@ -36,7 +36,7 @@ use crate::{
 use itc_parentchain::light_client::{concurrent_access::ValidatorAccess, LightClientState};
 use itp_component_container::ComponentGetter;
 use itp_settings::worker_mode::{ProvideWorkerMode, WorkerMode};
-use itp_types::parentchain::ParentchainId;
+use itp_types::parentchain::{Header, ParentchainId};
 use std::{path::PathBuf, sync::Arc};
 
 pub use itc_parentchain::primitives::{SolochainBlock, SolochainHeader, SolochainParams};
@@ -54,6 +54,7 @@ impl IntegriteeSolochainHandler {
 	pub fn init<WorkerModeProvider: ProvideWorkerMode>(
 		_base_path: PathBuf,
 		params: SolochainParams,
+		birth_header: Header,
 	) -> Result<Self> {
 		let ocall_api = GLOBAL_OCALL_API_COMPONENT.get()?;
 		let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
@@ -90,6 +91,7 @@ impl IntegriteeSolochainHandler {
 			stf_executor.clone(),
 			extrinsics_factory.clone(),
 			node_metadata_repository.clone(),
+			birth_header,
 		)?;
 
 		let import_dispatcher = match WorkerModeProvider::worker_mode() {

--- a/enclave-runtime/src/initialization/parentchain/integritee_solochain.rs
+++ b/enclave-runtime/src/initialization/parentchain/integritee_solochain.rs
@@ -54,7 +54,7 @@ impl IntegriteeSolochainHandler {
 	pub fn init<WorkerModeProvider: ProvideWorkerMode>(
 		_base_path: PathBuf,
 		params: SolochainParams,
-		maybe_birth_header: Option<Header>,
+		maybe_creation_header: Option<Header>,
 	) -> Result<Self> {
 		let ocall_api = GLOBAL_OCALL_API_COMPONENT.get()?;
 		let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
@@ -91,7 +91,7 @@ impl IntegriteeSolochainHandler {
 			stf_executor.clone(),
 			extrinsics_factory.clone(),
 			node_metadata_repository.clone(),
-			maybe_birth_header,
+			maybe_creation_header,
 		)?;
 
 		let import_dispatcher = match WorkerModeProvider::worker_mode() {

--- a/enclave-runtime/src/initialization/parentchain/integritee_solochain.rs
+++ b/enclave-runtime/src/initialization/parentchain/integritee_solochain.rs
@@ -54,7 +54,7 @@ impl IntegriteeSolochainHandler {
 	pub fn init<WorkerModeProvider: ProvideWorkerMode>(
 		_base_path: PathBuf,
 		params: SolochainParams,
-		birth_header: Header,
+		maybe_birth_header: Option<Header>,
 	) -> Result<Self> {
 		let ocall_api = GLOBAL_OCALL_API_COMPONENT.get()?;
 		let state_handler = GLOBAL_STATE_HANDLER_COMPONENT.get()?;
@@ -91,7 +91,7 @@ impl IntegriteeSolochainHandler {
 			stf_executor.clone(),
 			extrinsics_factory.clone(),
 			node_metadata_repository.clone(),
-			birth_header,
+			maybe_birth_header,
 		)?;
 
 		let import_dispatcher = match WorkerModeProvider::worker_mode() {

--- a/enclave-runtime/src/initialization/parentchain/mod.rs
+++ b/enclave-runtime/src/initialization/parentchain/mod.rs
@@ -17,7 +17,7 @@
 
 use crate::{
 	error::Result,
-	get_shard_birth_parentchain_header_internal,
+	get_shard_creation_parentchain_header_internal,
 	initialization::{
 		global_components::{
 			GLOBAL_INTEGRITEE_PARACHAIN_HANDLER_COMPONENT,
@@ -61,24 +61,26 @@ pub(crate) fn init_parentchain_components<WorkerModeProvider: ProvideWorkerMode>
 ) -> Result<Vec<u8>> {
 	match ParentchainInitParams::decode(&mut encoded_params.as_slice())? {
 		ParentchainInitParams::Parachain { id, shard, params } => {
-			let maybe_birth: Option<(ParentchainId, Header)> =
-				get_shard_birth_parentchain_header_internal(shard).ok();
-			let maybe_birth_header = if let Some((birth_parachain_id, birth_header)) = maybe_birth {
-				if birth_parachain_id != ParentchainId::Integritee {
-					unimplemented!("only Integritee parentchain is supported for shard birth");
+			let maybe_creation: Option<(ParentchainId, Header)> =
+				get_shard_creation_parentchain_header_internal(shard).ok();
+			let maybe_creation_header = if let Some((creation_parachain_id, creation_header)) =
+				maybe_creation
+			{
+				if creation_parachain_id != ParentchainId::Integritee {
+					unimplemented!("only Integritee parentchain is supported for shard creation");
 				}
-				Some(birth_header)
+				Some(creation_header)
 			} else {
 				None
 			};
 
-			// todo: query timestamp of birth header to give a birth reference to target_a/b as well in order to fast-sync
+			// todo: query timestamp of creation header to give a creation reference to target_a/b as well in order to fast-sync
 			match id {
 				ParentchainId::Integritee => {
 					let handler = IntegriteeParachainHandler::init::<WorkerModeProvider>(
 						base_path,
 						params,
-						maybe_birth_header,
+						maybe_creation_header,
 					)?;
 					let header = handler
 						.validator_accessor
@@ -107,23 +109,25 @@ pub(crate) fn init_parentchain_components<WorkerModeProvider: ProvideWorkerMode>
 			}
 		},
 		ParentchainInitParams::Solochain { id, shard, params } => {
-			let maybe_birth: Option<(ParentchainId, Header)> =
-				get_shard_birth_parentchain_header_internal(shard).ok();
-			let maybe_birth_header = if let Some((birth_parachain_id, birth_header)) = maybe_birth {
-				if birth_parachain_id != ParentchainId::Integritee {
-					unimplemented!("only Integritee parentchain is supported for shard birth");
+			let maybe_creation: Option<(ParentchainId, Header)> =
+				get_shard_creation_parentchain_header_internal(shard).ok();
+			let maybe_creation_header = if let Some((creation_parachain_id, creation_header)) =
+				maybe_creation
+			{
+				if creation_parachain_id != ParentchainId::Integritee {
+					unimplemented!("only Integritee parentchain is supported for shard creation");
 				}
-				Some(birth_header)
+				Some(creation_header)
 			} else {
 				None
 			};
-			// todo: query timestamp of birth header to give a birth reference to target_a/b as well in order to fast-sync
+			// todo: query timestamp of creation header to give a creation reference to target_a/b as well in order to fast-sync
 			match id {
 				ParentchainId::Integritee => {
 					let handler = IntegriteeSolochainHandler::init::<WorkerModeProvider>(
 						base_path,
 						params,
-						maybe_birth_header,
+						maybe_creation_header,
 					)?;
 					let header = handler
 						.validator_accessor

--- a/enclave-runtime/src/initialization/parentchain/mod.rs
+++ b/enclave-runtime/src/initialization/parentchain/mod.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-	error::{Error, Result},
+	error::Result,
 	get_shard_birth_parentchain_header_internal,
 	initialization::{
 		global_components::{

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -531,7 +531,7 @@ pub unsafe extern "C" fn get_shard_birth_header(
 	};
 	trace!("fetched shard birth header from state: {:?}", shard_birth);
 
-	let mut birth_slice = slice::from_raw_parts_mut(birth, birth_size as usize);
+	let birth_slice = slice::from_raw_parts_mut(birth, birth_size as usize);
 	if let Err(e) = write_slice_and_whitespace_pad(birth_slice, shard_birth.encode()) {
 		return Error::BufferError(e).into()
 	};

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -550,7 +550,7 @@ pub unsafe extern "C" fn sync_parentchain(
 	events_proofs_to_sync_size: usize,
 	parentchain_id: *const u8,
 	parentchain_id_size: u32,
-	is_syncing: c_int,
+	immediate_import: c_int,
 ) -> sgx_status_t {
 	if let Err(e) = sync_parentchain_internal(
 		blocks_to_sync,
@@ -561,7 +561,7 @@ pub unsafe extern "C" fn sync_parentchain(
 		events_proofs_to_sync_size,
 		parentchain_id,
 		parentchain_id_size,
-		is_syncing == 1,
+		immediate_import == 1,
 	) {
 		error!("Error synching parentchain: {:?}", e);
 	}
@@ -579,7 +579,7 @@ unsafe fn sync_parentchain_internal(
 	events_proofs_to_sync_size: usize,
 	parentchain_id: *const u8,
 	parentchain_id_size: u32,
-	is_syncing: bool,
+	immediate_import: bool,
 ) -> Result<()> {
 	let blocks_to_sync = Vec::<SignedBlock>::decode_raw(blocks_to_sync, blocks_to_sync_size)?;
 	let events_to_sync = Vec::<Vec<u8>>::decode_raw(events_to_sync, events_to_sync_size)?;
@@ -600,7 +600,7 @@ unsafe fn sync_parentchain_internal(
 		blocks_to_sync,
 		events_to_sync,
 		&parentchain_id,
-		is_syncing,
+		immediate_import,
 	)
 }
 
@@ -616,7 +616,7 @@ fn dispatch_parentchain_blocks_for_import<WorkerModeProvider: ProvideWorkerMode>
 	blocks_to_sync: Vec<SignedBlock>,
 	events_to_sync: Vec<Vec<u8>>,
 	id: &ParentchainId,
-	is_syncing: bool,
+	immediate_import: bool,
 ) -> Result<()> {
 	if WorkerModeProvider::worker_mode() == WorkerMode::Teeracle {
 		trace!("Not importing any parentchain blocks");
@@ -634,13 +634,13 @@ fn dispatch_parentchain_blocks_for_import<WorkerModeProvider: ProvideWorkerMode>
 				handler.import_dispatcher.dispatch_import(
 					blocks_to_sync,
 					events_to_sync,
-					is_syncing,
+					immediate_import,
 				)?;
 			} else if let Ok(handler) = GLOBAL_INTEGRITEE_PARACHAIN_HANDLER_COMPONENT.get() {
 				handler.import_dispatcher.dispatch_import(
 					blocks_to_sync,
 					events_to_sync,
-					is_syncing,
+					immediate_import,
 				)?;
 			} else {
 				return Err(Error::NoIntegriteeParentchainAssigned)
@@ -651,13 +651,13 @@ fn dispatch_parentchain_blocks_for_import<WorkerModeProvider: ProvideWorkerMode>
 				handler.import_dispatcher.dispatch_import(
 					blocks_to_sync,
 					events_to_sync,
-					is_syncing,
+					immediate_import,
 				)?;
 			} else if let Ok(handler) = GLOBAL_TARGET_A_PARACHAIN_HANDLER_COMPONENT.get() {
 				handler.import_dispatcher.dispatch_import(
 					blocks_to_sync,
 					events_to_sync,
-					is_syncing,
+					immediate_import,
 				)?;
 			} else {
 				return Err(Error::NoTargetAParentchainAssigned)
@@ -668,13 +668,13 @@ fn dispatch_parentchain_blocks_for_import<WorkerModeProvider: ProvideWorkerMode>
 				handler.import_dispatcher.dispatch_import(
 					blocks_to_sync,
 					events_to_sync,
-					is_syncing,
+					immediate_import,
 				)?;
 			} else if let Ok(handler) = GLOBAL_TARGET_B_PARACHAIN_HANDLER_COMPONENT.get() {
 				handler.import_dispatcher.dispatch_import(
 					blocks_to_sync,
 					events_to_sync,
-					is_syncing,
+					immediate_import,
 				)?;
 			} else {
 				return Err(Error::NoTargetBParentchainAssigned)

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -470,9 +470,10 @@ fn init_shard_birth_parentchain_header_internal(
 	header: Header,
 ) -> Result<()> {
 	if let Ok((id, _hdr)) = get_shard_birth_parentchain_header_internal(shard) {
-		error!("first relevant parentchain header has been initialized: {:?}", id);
+		error!("first relevant parentchain header has been previously initialized. cannot change: {:?}", id);
 		return Err(Error::Other(
-			"first relevant parentchain header has been previously initialized".into(),
+			"first relevant parentchain header has been previously initialized. cannot change"
+				.into(),
 		))
 	}
 	debug!("initializing shard birth header: {:?}", parentchain_id);

--- a/enclave-runtime/src/tls_ra/tests.rs
+++ b/enclave-runtime/src/tls_ra/tests.rs
@@ -128,13 +128,14 @@ pub fn test_tls_ra_server_client_networking() {
 	assert_eq!(*client_shielding_key.read().unwrap(), shielding_key_encoded);
 	assert_eq!(*client_light_client_state.read().unwrap(), light_client_state_encoded);
 
-	// State and state-key are provisioned only in sidechain mode
-	if WorkerModeProvider::worker_mode() == WorkerMode::Sidechain {
-		assert_eq!(*client_state.read().unwrap(), state_encoded);
-		assert_eq!(*client_state_key.read().unwrap(), state_key_encoded);
-	} else {
+	// State and state-key are provisioned only in sidechain or OCW mode
+	if WorkerModeProvider::worker_mode() == WorkerMode::Teeracle {
 		assert_eq!(*client_state.read().unwrap(), initial_client_state);
 		assert_eq!(*client_state_key.read().unwrap(), initial_client_state_key);
+	} else {
+		// Sidechain or OffchainWorker
+		assert_eq!(*client_state.read().unwrap(), state_encoded);
+		assert_eq!(*client_state_key.read().unwrap(), state_key_encoded);
 	}
 }
 

--- a/enclave-runtime/src/tls_ra/tls_ra_server.rs
+++ b/enclave-runtime/src/tls_ra/tls_ra_server.rs
@@ -55,8 +55,8 @@ enum ProvisioningPayload {
 impl From<WorkerMode> for ProvisioningPayload {
 	fn from(m: WorkerMode) -> Self {
 		match m {
-			WorkerMode::OffChainWorker | WorkerMode::Teeracle =>
-				ProvisioningPayload::ShieldingKeyAndLightClient,
+			WorkerMode::Teeracle => ProvisioningPayload::ShieldingKeyAndLightClient,
+			WorkerMode::OffChainWorker => ProvisioningPayload::Everything,
 			WorkerMode::Sidechain => ProvisioningPayload::Everything,
 		}
 	}

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-service"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["Integritee AG <hello@integritee.network>"]
 build = "build.rs"
 edition = "2021"

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -124,10 +124,6 @@ subcommands:
                 long: dev
                 short: d
                 help: Set this flag if running in development mode to bootstrap enclave account on parentchain via //Alice.
-            - request-state:
-                long: request-state
-                short: r
-                help: Run the worker and request key and state provisioning from another worker.
             - teeracle-interval:
                 required: false
                 long: teeracle-interval
@@ -140,7 +136,7 @@ subcommands:
                 help: Set the teeracle reregistration interval. Example of accepted syntax <5 seconds 15 minutes 2 hours 1 days> or short <5s15m2h1d>
                 takes_value: true
     - request-state:
-        about: join a shard by requesting key provisioning from another worker
+        about: (DEPRECATED) join a shard by requesting key provisioning from another worker
         args:
             - shard:
                 long: shard

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -265,8 +265,6 @@ pub struct RunConfig {
 	skip_ra: bool,
 	/// Set this flag if running in development mode to bootstrap enclave account on parentchain via //Alice.
 	dev: bool,
-	/// Request key and state provisioning from a peer worker.
-	request_state: bool,
 	/// Shard identifier base58 encoded. Defines the shard that this worker operates on. Default is mrenclave.
 	shard: Option<String>,
 	/// Optional teeracle update interval
@@ -284,10 +282,6 @@ impl RunConfig {
 
 	pub fn dev(&self) -> bool {
 		self.dev
-	}
-
-	pub fn request_state(&self) -> bool {
-		self.request_state
 	}
 
 	pub fn shard(&self) -> Option<&str> {
@@ -319,7 +313,6 @@ impl From<&ArgMatches<'_>> for RunConfig {
 	fn from(m: &ArgMatches<'_>) -> Self {
 		let skip_ra = m.is_present("skip-ra");
 		let dev = m.is_present("dev");
-		let request_state = m.is_present("request-state");
 		let shard = m.value_of("shard").map(|s| s.to_string());
 		let teeracle_update_interval = m.value_of("teeracle-interval").map(|i| {
 			parse(i).unwrap_or_else(|e| panic!("teeracle-interval parsing error {:?}", e))
@@ -337,7 +330,6 @@ impl From<&ArgMatches<'_>> for RunConfig {
 		Self {
 			skip_ra,
 			dev,
-			request_state,
 			shard,
 			teeracle_update_interval,
 			reregister_teeracle_interval,
@@ -464,7 +456,6 @@ mod test {
 		let empty_args = ArgMatches::default();
 		let run_config = RunConfig::from(&empty_args);
 
-		assert_eq!(run_config.request_state, false);
 		assert_eq!(run_config.dev, false);
 		assert_eq!(run_config.skip_ra, false);
 		assert!(run_config.shard.is_none());
@@ -477,7 +468,6 @@ mod test {
 
 		let mut args = ArgMatches::default();
 		args.args = HashMap::from([
-			("request-state", Default::default()),
 			("dev", Default::default()),
 			("skip-ra", Default::default()),
 			("shard", Default::default()),
@@ -489,7 +479,6 @@ mod test {
 
 		let run_config = RunConfig::from(&args);
 
-		assert_eq!(run_config.request_state, true);
 		assert_eq!(run_config.dev, true);
 		assert_eq!(run_config.skip_ra, true);
 		assert_eq!(run_config.shard.unwrap(), shard_identifier.to_string());

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -16,7 +16,7 @@
 
 use codec::Error as CodecError;
 use itp_node_api::api_client::ApiClientError;
-use itp_types::ShardIdentifier;
+use itp_types::{parentchain::Hash, ShardIdentifier};
 
 pub type ServiceResult<T> = Result<T, Error>;
 
@@ -50,6 +50,8 @@ pub enum Error {
 	MissingGenesisHeader,
 	#[error("Could not find last finalized block of the parentchain")]
 	MissingLastFinalizedBlock,
+	#[error("Could not find block in parentchain")]
+	UnknownBlockHeader(Hash),
 	#[error("{0}")]
 	Custom(Box<dyn std::error::Error + Sync + Send + 'static>),
 }

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -543,6 +543,17 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	debug!("getting shard birth: {:?}", enclave.get_shard_birth_header(shard));
 	initialization_handler.registered_on_parentchain();
 
+	// re-initialize integritee parentchain to make sure to use birth_header for fast-sync
+	// todo: this should only be necessary if we are the primary validateer running for the first time
+	let (integritee_parentchain_handler, integritee_last_synced_header_at_last_run) =
+		init_parentchain(
+			&enclave,
+			&integritee_rpc_api,
+			&tee_accountid,
+			ParentchainId::Integritee,
+			shard,
+		);
+
 	match WorkerModeProvider::worker_mode() {
 		WorkerMode::Teeracle => {
 			// ------------------------------------------------------------------------

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -512,9 +512,9 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 							primary.to_ss58check(),
 						);
 						info!("The primary worker enclave is {:?}", primary_enclave);
-						if enclave.get_shard_birth_header(shard).is_err() {
+						if enclave.get_shard_creation_header(shard).is_err() {
 							//obtain provisioning from last active worker
-							info!("my state doesn't know the birth header of the shard. will request provisioning");
+							info!("my state doesn't know the creation header of the shard. will request provisioning");
 							sync_state::sync_state::<_, _, WorkerModeProvider>(
 								&integritee_rpc_api,
 								&shard,
@@ -534,7 +534,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 			None => {
 				println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
 				enclave
-					.init_shard_birth_parentchain_header(
+					.init_shard_creation_parentchain_header(
 						shard,
 						&ParentchainId::Integritee,
 						&register_enclave_xt_header,
@@ -543,10 +543,10 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 				true
 			},
 		};
-	debug!("getting shard birth: {:?}", enclave.get_shard_birth_header(shard));
+	debug!("getting shard creation: {:?}", enclave.get_shard_creation_header(shard));
 	initialization_handler.registered_on_parentchain();
 
-	// re-initialize integritee parentchain to make sure to use birth_header for fast-sync
+	// re-initialize integritee parentchain to make sure to use creation_header for fast-sync
 	// todo: this should only be necessary if we are the primary validateer running for the first time
 	let (integritee_parentchain_handler, integritee_last_synced_header_at_last_run) =
 		init_parentchain(

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -512,13 +512,16 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 							primary.to_ss58check(),
 						);
 						info!("The primary worker enclave is {:?}", primary_enclave);
-						//obtain provisioning from last active worker
-						sync_state::sync_state::<_, _, WorkerModeProvider>(
-							&integritee_rpc_api,
-							&shard,
-							enclave.as_ref(),
-							skip_ra,
-						);
+						if enclave.get_shard_birth_header(shard).is_err() {
+							//obtain provisioning from last active worker
+							info!("my state doesn't know the birth header of the shard. will request provisioning");
+							sync_state::sync_state::<_, _, WorkerModeProvider>(
+								&integritee_rpc_api,
+								&shard,
+								enclave.as_ref(),
+								skip_ra,
+							);
+						}
 						false
 					},
 				_ => {

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -414,6 +414,17 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		);
 	}
 
+	// ------------------------------------------------------------------------
+	// Init parentchain specific stuff. Needed early for parentchain communication.
+	let (integritee_parentchain_handler, integritee_last_synced_header_at_last_run) =
+		init_parentchain(
+			&enclave,
+			&integritee_rpc_api,
+			&tee_accountid,
+			ParentchainId::Integritee,
+			shard,
+		);
+
 	#[cfg(feature = "dcap")]
 	register_collateral(
 		&integritee_rpc_api,
@@ -531,15 +542,6 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		};
 	debug!("getting shard birth: {:?}", enclave.get_shard_birth_header(shard));
 	initialization_handler.registered_on_parentchain();
-
-	let (integritee_parentchain_handler, integritee_last_synced_header_at_last_run) =
-		init_parentchain(
-			&enclave,
-			&integritee_rpc_api,
-			&tee_accountid,
-			ParentchainId::Integritee,
-			shard,
-		);
 
 	match WorkerModeProvider::worker_mode() {
 		WorkerMode::Teeracle => {

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -164,7 +164,7 @@ where
 		// verify that the last_synced_header is indeed a block from this chain
 		self.parentchain_api
 			.get_block(Some(last_synced_header.hash()))?
-			.ok_or(Error::UnknownBlockHeader(last_synced_header.hash()))?;
+			.ok_or_else(|| Error::UnknownBlockHeader(last_synced_header.hash()))?;
 
 		info!(
 			"[{:?}] Syncing blocks from {} to {}",

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -173,17 +173,22 @@ where
 			"[{:?}] Syncing blocks from {} to {}",
 			id, last_synced_header.number, curr_block_number
 		);
-		let maybe_birth = self.enclave_api.get_shard_birth_header(&shard).ok();
-		let maybe_birth_header = if let Some((birth_parentchain_id, birth_header)) = maybe_birth {
-			trace!("shard_birth header is from {:?}: {:?}", birth_parentchain_id, birth_header);
-			if *id == birth_parentchain_id {
-				Some(birth_header)
+		let maybe_creation = self.enclave_api.get_shard_creation_header(&shard).ok();
+		let maybe_creation_header =
+			if let Some((creation_parentchain_id, creation_header)) = maybe_creation {
+				trace!(
+					"shard_creation header is from {:?}: {:?}",
+					creation_parentchain_id,
+					creation_header
+				);
+				if *id == creation_parentchain_id {
+					Some(creation_header)
+				} else {
+					None
+				}
 			} else {
 				None
-			}
-		} else {
-			None
-		};
+			};
 
 		let mut until_synced_header = last_synced_header;
 		loop {
@@ -196,11 +201,11 @@ where
 				return Ok(until_synced_header)
 			}
 
-			let skip_invocations = if let Some(birth_header) = maybe_birth_header.clone() {
+			let skip_invocations = if let Some(creation_header) = maybe_creation_header.clone() {
 				let max_blocknumber_in_chunk =
 					block_chunk_to_sync.last().map_or_else(|| 0, |b| b.block.header.number());
-				if max_blocknumber_in_chunk < *birth_header.number() {
-					trace!("skipping invocations for fast-sync for blocks older than shard birth: {} < {}", max_blocknumber_in_chunk, birth_header.number());
+				if max_blocknumber_in_chunk < *creation_header.number() {
+					trace!("skipping invocations for fast-sync for blocks older than shard creation: {} < {}", max_blocknumber_in_chunk, creation_header.number());
 					true
 				} else {
 					false

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -50,11 +50,10 @@ mod needs_enclave {
 		println!("[+] Initialize the shard");
 		init_shard(enclave, shard_identifier);
 
-		println!("[+] Generate key files");
-		generate_signing_key_file(enclave);
-		// if we are not the primary worker, this might be overwritten later upon provisioning
-		generate_shielding_key_file(enclave);
-
+		let pubkey = enclave.get_ecc_signing_pubkey().unwrap();
+		debug!("Enclave signing key (public) raw: {:?}", pubkey);
+		let pubkey = enclave.get_rsa_shielding_pubkey().unwrap();
+		debug!("Enclave shielding key (public) raw (may be overwritten later): {:?}", pubkey);
 		Ok(())
 	}
 

--- a/service/src/setup.rs
+++ b/service/src/setup.rs
@@ -52,6 +52,7 @@ mod needs_enclave {
 
 		println!("[+] Generate key files");
 		generate_signing_key_file(enclave);
+		// if we are not the primary worker, this might be overwritten later upon provisioning
 		generate_shielding_key_file(enclave);
 
 		Ok(())

--- a/service/src/sidechain_setup.rs
+++ b/service/src/sidechain_setup.rs
@@ -75,7 +75,7 @@ where
 			"We're the first validateer to be registered, syncing parentchain blocks until the one we have registered ourselves on."
 		);
 		updated_header =
-			Some(parentchain_handler.sync_and_import_parentchain_until(
+			Some(parentchain_handler.await_sync_and_import_parentchain_until_at_least(
 				last_synced_header,
 				register_enclave_xt_header,
 			)?);

--- a/service/src/sidechain_setup.rs
+++ b/service/src/sidechain_setup.rs
@@ -28,7 +28,7 @@ use itp_settings::{
 	files::{SIDECHAIN_PURGE_INTERVAL, SIDECHAIN_PURGE_LIMIT},
 	sidechain::SLOT_DURATION,
 };
-use itp_types::Header;
+use itp_types::{Header, ShardIdentifier};
 use its_consensus_slots::start_slot_worker;
 use its_primitives::types::block::SignedBlock as SignedSidechainBlock;
 use its_storage::{interface::FetchBlocks, start_sidechain_pruning_loop, BlockPruner};
@@ -61,6 +61,7 @@ pub(crate) fn sidechain_init_block_production<Enclave, SidechainStorage, Parentc
 	parentchain_handler: Arc<ParentchainHandler>,
 	sidechain_storage: Arc<SidechainStorage>,
 	last_synced_header: &Header,
+	shard: ShardIdentifier,
 ) -> ServiceResult<Header>
 where
 	Enclave: EnclaveBase + Sidechain,
@@ -78,6 +79,7 @@ where
 			Some(parentchain_handler.await_sync_and_import_parentchain_until_at_least(
 				last_synced_header,
 				register_enclave_xt_header,
+				shard,
 			)?);
 	}
 

--- a/service/src/sync_state.rs
+++ b/service/src/sync_state.rs
@@ -28,9 +28,12 @@ use itp_enclave_api::{
 };
 use itp_node_api::api_client::PalletTeerexApi;
 use itp_settings::worker_mode::{ProvideWorkerMode, WorkerMode};
-use itp_types::ShardIdentifier;
+use itp_types::{parentchain::AccountId, ShardIdentifier};
+use log::info;
 use sgx_types::sgx_quote_sign_type_t;
+use sp_runtime::MultiSigner;
 use std::string::String;
+use teerex_primitives::AnySigner;
 
 pub(crate) fn sync_state<
 	E: TlsRemoteAttestation + EnclaveBase + RemoteAttestation,
@@ -42,13 +45,13 @@ pub(crate) fn sync_state<
 	enclave_api: &E,
 	skip_ra: bool,
 ) {
-	// FIXME: we now assume that keys are equal for all shards.
 	let provider_url = match WorkerModeProvider::worker_mode() {
-		WorkerMode::Sidechain =>
-			executor::block_on(get_author_url_of_last_finalized_sidechain_block(node_api, shard))
+		WorkerMode::Sidechain | WorkerMode::OffChainWorker =>
+			executor::block_on(get_enclave_url_of_last_active(node_api, enclave_api, shard))
+				.expect("author of most recent shard update not found"),
+		WorkerMode::Teeracle =>
+			executor::block_on(get_enclave_url_of_first_registered(node_api, enclave_api))
 				.expect("Author of last finalized sidechain block could not be found"),
-		_ => executor::block_on(get_enclave_url_of_first_registered(node_api, enclave_api))
-			.expect("Author of last finalized sidechain block could not be found"),
 	};
 
 	println!("Requesting state provisioning from worker at {}", &provider_url);
@@ -82,20 +85,51 @@ async fn get_author_url_of_last_finalized_sidechain_block<NodeApi: PalletTeerexA
 	Ok(worker_api_direct.get_mu_ra_url()?)
 }
 
-/// Returns the url of the first Enclave that matches our own MRENCLAVE.
-///
-/// This should be run before we register ourselves as enclave, to ensure we don't get our own url.
+/// Returns the url of the first Enclave that matches our own MRENCLAVE which isn't ourself.
+/// this is not reliable because there may be other active peers although the very first one went offline
 async fn get_enclave_url_of_first_registered<NodeApi: PalletTeerexApi, EnclaveApi: EnclaveBase>(
 	node_api: &NodeApi,
 	enclave_api: &EnclaveApi,
 ) -> Result<String> {
 	let self_mr_enclave = enclave_api.get_fingerprint()?;
+	let self_account = enclave_api.get_ecc_signing_pubkey()?;
 	let first_enclave = node_api
 		.all_enclaves(None)?
 		.into_iter()
+		.filter(|e| e.instance_signer() != AnySigner::Known(MultiSigner::Ed25519(self_account)))
 		.find(|e| e.fingerprint() == self_mr_enclave)
 		.ok_or(Error::NoPeerWorkerFound)?;
 	let worker_api_direct =
 		DirectWorkerApi::new(String::from_utf8(first_enclave.instance_url().unwrap()).unwrap());
+	Ok(worker_api_direct.get_mu_ra_url()?)
+}
+
+/// Returns the url of the last active worker on our shard
+async fn get_enclave_url_of_last_active<NodeApi: PalletTeerexApi, EnclaveApi: EnclaveBase>(
+	node_api: &NodeApi,
+	enclave_api: &EnclaveApi,
+	shard: &ShardIdentifier,
+) -> Result<String> {
+	let self_account = enclave_api.get_ecc_signing_pubkey()?;
+	let shard_status = node_api
+		.shard_status(shard, None)
+		.expect("must be able to fetch shard status")
+		.expect("can only sync state for active shards");
+	info!("fetching active peer. shard status: {:?}", shard_status);
+	let last_active_signer_status = shard_status
+		.iter()
+		.filter(|&s| s.signer != AccountId::from(self_account))
+		.max_by_key(|&signer_status| signer_status.last_activity)
+		.expect("there has to be a most recently active peer")
+		.clone();
+	info!("most recently active signer on this shard: {:?}", last_active_signer_status);
+	let provider_enclave = node_api
+		.enclave(&last_active_signer_status.signer, None)
+		.expect("must be able to fetch enclaves")
+		.expect("active peer must exist in registry");
+	let worker_api_direct = DirectWorkerApi::new(
+		String::from_utf8(provider_enclave.instance_url().expect("provider must specify url"))
+			.unwrap(),
+	);
 	Ok(worker_api_direct.get_mu_ra_url()?)
 }

--- a/service/src/tests/mock.rs
+++ b/service/src/tests/mock.rs
@@ -16,10 +16,11 @@
 */
 
 use codec::Encode;
+use enclave_bridge_primitives::ShardSignerStatus;
 use itp_node_api::api_client::{ApiResult, PalletTeerexApi};
 use itp_types::{
-	AccountId, MultiEnclave, SgxBuildMode, SgxEnclave, SgxReportData, SgxStatus, ShardIdentifier,
-	H256 as Hash,
+	parentchain::BlockNumber, AccountId, MultiEnclave, SgxBuildMode, SgxEnclave, SgxReportData,
+	SgxStatus, ShardIdentifier, H256 as Hash,
 };
 
 pub struct TestNodeApi;
@@ -79,6 +80,15 @@ impl PalletTeerexApi for TestNodeApi {
 	) -> ApiResult<Option<MultiEnclave<Vec<u8>>>> {
 		unreachable!()
 	}
+
+	fn shard_status(
+		&self,
+		_: &ShardIdentifier,
+		_at_block: Option<Hash>,
+	) -> ApiResult<Option<Vec<ShardSignerStatus<AccountId, BlockNumber>>>> {
+		unreachable!()
+	}
+
 	fn latest_ipfs_hash(
 		&self,
 		_: &ShardIdentifier,

--- a/service/src/tests/mocks/enclave_api_mock.rs
+++ b/service/src/tests/mocks/enclave_api_mock.rs
@@ -69,7 +69,7 @@ impl EnclaveBase for EnclaveMock {
 		unimplemented!()
 	}
 
-	fn init_shard_birth_parentchain_header(
+	fn init_shard_creation_parentchain_header(
 		&self,
 		shard: &ShardIdentifier,
 		parentchain_id: &ParentchainId,
@@ -78,7 +78,7 @@ impl EnclaveBase for EnclaveMock {
 		unimplemented!()
 	}
 
-	fn get_shard_birth_header(
+	fn get_shard_creation_header(
 		&self,
 		shard: &ShardIdentifier,
 	) -> EnclaveResult<(ParentchainId, Header)> {

--- a/service/src/tests/mocks/enclave_api_mock.rs
+++ b/service/src/tests/mocks/enclave_api_mock.rs
@@ -25,7 +25,7 @@ use itc_parentchain::primitives::{
 use itp_enclave_api::{enclave_base::EnclaveBase, sidechain::Sidechain, EnclaveResult};
 use itp_settings::worker::MR_ENCLAVE_SIZE;
 use itp_storage::StorageProof;
-use itp_types::ShardIdentifier;
+use itp_types::{parentchain::Header, ShardIdentifier};
 use sgx_crypto_helper::rsa3072::Rsa3072PubKey;
 use sp_core::ed25519;
 
@@ -66,6 +66,22 @@ impl EnclaveBase for EnclaveMock {
 		_shard: &ShardIdentifier,
 		_parentchain_id: &ParentchainId,
 	) -> EnclaveResult<()> {
+		unimplemented!()
+	}
+
+	fn init_shard_birth_parentchain_header(
+		&self,
+		shard: &ShardIdentifier,
+		parentchain_id: &ParentchainId,
+		header: &Header,
+	) -> EnclaveResult<()> {
+		unimplemented!()
+	}
+
+	fn get_shard_birth_header(
+		&self,
+		shard: &ShardIdentifier,
+	) -> EnclaveResult<(ParentchainId, Header)> {
 		unimplemented!()
 	}
 


### PR DESCRIPTION
closes #1514, #1519

* postpone state provisioning to after registering self onchain (prerequisite for #85 and deprecating direct MU-RA)
  * enhance fetching peer for provisioning to use most active on own shard by shard_status now and avoid fetching from self
  * OCW: also provision entire state, not only light client
* fast-sync for Integritee parentchain: introduce concept of `shard_creation_header`, the integritee parentchain header of the first registered enclave for own shard:
   * do not fetch events & proofs from rpc & 
   * ignore indirect invocations 
   * ...for all blocks up to the one where the primary worker registered its enclave for the first time 
   * doing the same for target_a/b needs more thinking, because headers don't include timestamps which are the only thing the parentchains have as a common reference (unless they are on the same relaychain)