### PR TITLE
peer discovery by shard status with flexible url prefix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -290,11 +290,11 @@ jobs:
             demo_name: demo-shielding-unshielding-multiworker
             host: test-runner-sgx
             sgx_mode: HW
-          - test: Teeracle
-            flavor_id: teeracle
-            demo_name: demo-teeracle
-            host: test-runner-sgx
-            sgx_mode: HW
+#          - test: Teeracle
+#            flavor_id: teeracle
+#            demo_name: demo-teeracle
+#            host: test-runner-sgx
+#            sgx_mode: HW
           - test: Teeracle
             flavor_id: teeracle
             demo_name: demo-teeracle-generic

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -323,7 +323,7 @@ jobs:
           echo "PROJECT=${{ matrix.flavor_id }}-${{ matrix.demo_name }}" >> $GITHUB_ENV
           echo "VERSION=dev.$version" >> $GITHUB_ENV
           echo "WORKER_IMAGE_TAG=integritee-worker:dev.$version" >> $GITHUB_ENV
-          echo "INTEGRITEE_NODE=integritee-node:1.1.3.$version" >> $GITHUB_ENV
+          echo "INTEGRITEE_NODE=integritee-node:1.1.4.$version" >> $GITHUB_ENV
           echo "CLIENT_IMAGE_TAG=integritee-cli:dev.$version" >> $GITHUB_ENV
           if [[ ${{ matrix.sgx_mode }} == 'HW' ]]; then
              echo "SGX_PROVISION=/dev/sgx/provision" >> $GITHUB_ENV
@@ -368,8 +368,8 @@ jobs:
           fi
           docker tag integritee-worker-${{ env.IMAGE_SUFFIX }} ${{ env.WORKER_IMAGE_TAG }}
           docker tag integritee-cli-client-${{ env.IMAGE_SUFFIX }} ${{ env.CLIENT_IMAGE_TAG }}
-          docker pull integritee/integritee-node:1.1.3
-          docker tag integritee/integritee-node:1.1.3 ${{ env.INTEGRITEE_NODE }}
+          docker pull integritee/integritee-node:1.1.4
+          docker tag integritee/integritee-node:1.1.4 ${{ env.INTEGRITEE_NODE }}
           docker images --all
 
       ##

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-cli"
-version = "0.12.2"
+version = "0.12.6"
 dependencies = [
  "array-bytes 6.2.2",
  "base58",
@@ -2794,7 +2794,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-service"
-version = "0.12.2"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,11 +1680,11 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -2607,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi 0.3.13",
  "unicode-normalization 0.1.22",
@@ -2855,6 +2855,7 @@ dependencies = [
  "teerex-primitives",
  "thiserror 1.0.40",
  "tokio",
+ "url 2.5.0",
  "warp",
 ]
 
@@ -2933,7 +2934,7 @@ dependencies = [
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -3192,7 +3193,7 @@ dependencies = [
  "thiserror 1.0.40",
  "thiserror 1.0.9",
  "url 2.1.1",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -3215,7 +3216,7 @@ dependencies = [
  "serde_json 1.0.106",
  "sgx_crypto_helper",
  "thiserror 1.0.40",
- "url 2.4.0",
+ "url 2.5.0",
  "ws",
 ]
 
@@ -3260,7 +3261,7 @@ dependencies = [
  "thiserror 1.0.9",
  "tungstenite 0.14.0",
  "tungstenite 0.15.0",
- "url 2.4.0",
+ "url 2.5.0",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
  "yasna 0.3.1",
@@ -4174,7 +4175,7 @@ dependencies = [
  "serde 1.0.188",
  "serde_json 1.0.106",
  "thiserror 1.0.40",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -4270,7 +4271,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util 0.6.10",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5699,11 +5700,11 @@ dependencies = [
  "byteorder 1.4.3",
  "data-encoding",
  "multihash",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "serde 1.0.188",
  "static_assertions",
  "unsigned-varint 0.7.1",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -5879,9 +5880,9 @@ source = "git+https://github.com/mesalock-linux/rust-url-sgx?tag=sgx_1.1.3#23832
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
@@ -6449,7 +6450,7 @@ dependencies = [
  "mime",
  "native-tls",
  "once_cell 1.18.0",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "serde 1.0.188",
  "serde_json 1.0.106",
@@ -6457,7 +6458,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tower-service",
- "url 2.4.0",
+ "url 2.5.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -8240,7 +8241,7 @@ dependencies = [
  "sp-runtime",
  "sp-runtime-interface",
  "tungstenite 0.18.0",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -8833,7 +8834,7 @@ dependencies = [
  "rustls 0.19.1",
  "sha-1 0.9.8",
  "thiserror 1.0.40",
- "url 2.4.0",
+ "url 2.5.0",
  "utf-8 0.7.6",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.21.1",
@@ -8855,7 +8856,7 @@ dependencies = [
  "rand 0.8.5",
  "sha1 0.10.5",
  "thiserror 1.0.40",
- "url 2.4.0",
+ "url 2.5.0",
  "utf-8 0.7.6",
 ]
 
@@ -8865,7 +8866,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
@@ -9008,13 +9009,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna 0.4.0",
- "percent-encoding 2.3.0",
+ "idna 0.5.0",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -9097,7 +9098,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "multer",
- "percent-encoding 2.3.0",
+ "percent-encoding 2.3.1",
  "pin-project",
  "rustls-pemfile",
  "scoped-tls",
@@ -9277,7 +9278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64b20236ab624147dfbb62cf12a19aaf66af0e41b8398838b66e997d07d269d4"
 dependencies = [
  "indexmap 1.9.3",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]
@@ -9723,7 +9724,7 @@ dependencies = [
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.2",
  "slab 0.4.8",
- "url 2.4.0",
+ "url 2.5.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 dependencies = [
  "lazy_static",
- "regex 1.9.5",
+ "regex 1.10.2",
 ]
 
 [[package]]
@@ -18,7 +18,7 @@ version = "0.4.2"
 source = "git+https://github.com/scs/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0#d31ce7684a60a55b943b3355b2dacc6d0edcc371"
 dependencies = [
  "ac-primitives",
- "log 0.4.19",
+ "log 0.4.20",
  "maybe-async",
 ]
 
@@ -33,14 +33,14 @@ dependencies = [
  "either",
  "frame-metadata",
  "hex",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-bits",
  "scale-decode",
  "scale-encode",
  "scale-info",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
@@ -59,8 +59,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sp-application-crypto",
  "sp-core",
  "sp-core-hashing",
@@ -82,11 +82,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
- "gimli 0.27.2",
+ "gimli 0.27.3",
 ]
 
 [[package]]
@@ -151,20 +151,11 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr 2.6.3",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
- "memchr 2.6.3",
+ "memchr 2.6.4",
 ]
 
 [[package]]
@@ -193,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "approx"
@@ -203,7 +194,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -214,9 +205,9 @@ checksum = "f52f63c5c1316a16a4b35eaac8b76a98248961a533f061684cb2a7cb0eafb6c6"
 
 [[package]]
 name = "array-bytes"
-version = "6.1.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b1c5a481ec30a5abd8dfbd94ab5cf1bb4e9a66be7f1b3b322f2f1170c200fd"
+checksum = "6f840fb7195bcfc5e17ea40c26e5ce6d5b9ce5d584466e17703209657e459ae0"
 
 [[package]]
 name = "arrayref"
@@ -232,19 +223,19 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -287,16 +278,16 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
- "addr2line 0.19.0",
+ "addr2line 0.20.0",
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.6.2",
- "object 0.30.4",
+ "miniz_oxide",
+ "object 0.31.1",
  "rustc-demangle",
 ]
 
@@ -360,16 +351,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "hash-db 0.16.0",
- "log 0.4.19",
+ "log 0.4.20",
 ]
 
 [[package]]
@@ -378,7 +369,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -387,7 +378,7 @@ version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -395,7 +386,7 @@ dependencies = [
  "peeking_take_while",
  "proc-macro2",
  "quote",
- "regex 1.9.5",
+ "regex 1.10.2",
  "rustc-hash",
  "shlex",
  "syn 1.0.109",
@@ -412,6 +403,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -441,7 +438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "constant_time_eq",
 ]
 
@@ -490,10 +487,10 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5b05133427c07c4776906f673ccf36c21b102c9829c641a5b56bd151d44fd6"
 dependencies = [
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -504,12 +501,12 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
- "memchr 2.6.3",
- "serde 1.0.188",
+ "memchr 2.6.4",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -596,20 +593,20 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -620,10 +617,10 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.17",
- "serde 1.0.188",
- "serde_json 1.0.106",
- "thiserror 1.0.40",
+ "semver 1.0.18",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -650,7 +647,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
 dependencies = [
- "smallvec 1.10.0",
+ "smallvec 1.11.0",
 ]
 
 [[package]]
@@ -684,8 +681,8 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-traits 0.2.15",
- "serde 1.0.188",
+ "num-traits 0.2.16",
+ "serde 1.0.192",
  "time",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -703,12 +700,12 @@ dependencies = [
 [[package]]
 name = "claims-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "parity-scale-codec",
  "rustc-hex",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
  "sp-std",
@@ -733,7 +730,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -748,7 +745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "indexmap 1.9.3",
@@ -797,18 +794,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d0a7a42b9c13f2b2a1a7e64b949a19bcb56a49b190076e60261001ceaa5304"
 dependencies = [
  "bytes 1.4.0",
- "futures 0.3.28",
+ "futures 0.3.29",
  "http 0.2.9",
  "mime",
  "mime_guess",
  "rand 0.8.5",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -820,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
 
 [[package]]
 name = "constant_time_eq"
@@ -863,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -876,7 +873,7 @@ version = "0.93.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42ea692c7b450ad18b8c9889661505d51c09ec4380cf1c2d278dbb2da22cae1"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -939,9 +936,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
+checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
  "generic-array 0.14.7",
  "rand_core 0.6.4",
@@ -1016,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109308c20e8445959c2792e81871054c6a17e6976489a93d2769641a2ba5839c"
+checksum = "f68e12e817cb19eaab81aaec582b4052d07debd3c3c6b083b9d361db47c7dc9d"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1028,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf4c6755cdf10798b97510e0e2b3edb9573032bd9379de8fffa59d68165494f"
+checksum = "e789217e4ab7cf8cc9ce82253180a9fe331f35f5d339f0ccfe0270b39433f397"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1038,24 +1035,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882074421238e84fe3b4c65d0081de34e5b323bf64555d3e61991f76eb64a7bb"
+checksum = "78a19f4c80fd9ab6c882286fa865e92e07688f4387370a209508014ead8751d0"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.95"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a076022ece33e7686fb76513518e219cca4fce5750a8ae6d1ce6c0f48fd1af9"
+checksum = "b8fcfa71f66c8563c4fa9dd2bb68368d50267856f831ac5d85367e0805f9606c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1112,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1247,17 +1244,17 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
- "der 0.7.6",
+ "der 0.7.8",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
@@ -1302,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -1328,13 +1325,13 @@ dependencies = [
 [[package]]
 name = "enclave-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "common-primitives",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
@@ -1343,9 +1340,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.32"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1358,8 +1355,21 @@ checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.19",
- "regex 1.9.5",
+ "log 0.4.20",
+ "regex 1.10.2",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log 0.4.20",
+ "regex 1.10.2",
  "termcolor",
 ]
 
@@ -1431,7 +1441,7 @@ dependencies = [
  "parity-scale-codec",
  "rlp",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sha3",
  "triehash",
 ]
@@ -1464,12 +1474,12 @@ dependencies = [
  "evm-core",
  "evm-gasometer",
  "evm-runtime",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "primitive-types",
  "rlp",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sha3",
 ]
 
@@ -1482,7 +1492,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -1559,12 +1569,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "ff"
@@ -1595,10 +1602,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36530797b9bf31cd4ff126dcfee8170f86b00cfdcea3269d73133cc0415945c3"
 dependencies = [
  "either",
- "futures 0.3.28",
+ "futures 0.3.29",
  "futures-timer",
- "log 0.4.19",
- "num-traits 0.2.15",
+ "log 0.4.20",
+ "num-traits 0.2.16",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "scale-info",
@@ -1629,7 +1636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1638,7 +1645,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -1695,10 +1702,10 @@ dependencies = [
  "hex",
  "impl-serde",
  "libsecp256k1",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
@@ -1714,7 +1721,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -1735,11 +1742,11 @@ dependencies = [
  "frame-support-procedural",
  "frame-system",
  "linregress",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "paste",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -1776,7 +1783,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -1784,19 +1791,19 @@ name = "frame-support"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "environmental 1.1.4",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "k256",
- "log 0.4.19",
+ "log 0.4.20",
  "once_cell 1.18.0",
  "parity-scale-codec",
  "paste",
  "scale-info",
- "serde 1.0.188",
- "smallvec 1.10.0",
+ "serde 1.0.192",
+ "smallvec 1.11.0",
  "sp-api",
  "sp-arithmetic",
  "sp-core",
@@ -1825,7 +1832,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1837,7 +1844,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1847,7 +1854,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1856,10 +1863,10 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "frame-support",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
@@ -1871,7 +1878,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#569aae5341ea0c1d10426fa1ec13a36c0b64393b"
+source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1904,7 +1911,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fuchsia-zircon-sys",
 ]
 
@@ -1937,17 +1944,17 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
 dependencies = [
- "futures-channel 0.3.28",
- "futures-core 0.3.28",
- "futures-executor 0.3.28",
- "futures-io 0.3.28",
- "futures-sink 0.3.28",
- "futures-task 0.3.28",
- "futures-util 0.3.28",
+ "futures-channel 0.3.29",
+ "futures-core 0.3.29",
+ "futures-executor 0.3.29",
+ "futures-io 0.3.29",
+ "futures-sink 0.3.29",
+ "futures-task 0.3.29",
+ "futures-util 0.3.29",
 ]
 
 [[package]]
@@ -1962,12 +1969,12 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
- "futures-core 0.3.28",
- "futures-sink 0.3.28",
+ "futures-core 0.3.29",
+ "futures-sink 0.3.29",
 ]
 
 [[package]]
@@ -1980,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-executor"
@@ -1997,13 +2004,13 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
 dependencies = [
- "futures-core 0.3.28",
- "futures-task 0.3.28",
- "futures-util 0.3.28",
+ "futures-core 0.3.29",
+ "futures-task 0.3.29",
+ "futures-util 0.3.29",
  "num_cpus",
 ]
 
@@ -2017,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
@@ -2034,13 +2041,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2050,9 +2057,9 @@ source = "git+https://github.com/mesalock-linux/futures-rs-sgx#d54882f24ddf7d613
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
@@ -2065,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-timer"
@@ -2097,17 +2104,17 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
- "futures-channel 0.3.28",
- "futures-core 0.3.28",
- "futures-io 0.3.28",
- "futures-macro 0.3.28",
- "futures-sink 0.3.28",
- "futures-task 0.3.28",
- "memchr 2.6.3",
+ "futures-channel 0.3.29",
+ "futures-core 0.3.29",
+ "futures-io 0.3.29",
+ "futures-macro 0.3.29",
+ "futures-sink 0.3.29",
+ "futures-task 0.3.29",
+ "memchr 2.6.4",
  "pin-project-lite",
  "pin-utils",
  "slab 0.4.8",
@@ -2178,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "glob"
@@ -2190,15 +2197,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+checksum = "1391ab1f92ffcc08911957149833e682aa3fe252b9f45f966d2ef972274c97df"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "bstr",
  "fnv 1.0.7",
- "log 0.4.19",
- "regex 1.9.5",
+ "log 0.4.20",
+ "regex 1.10.2",
 ]
 
 [[package]]
@@ -2214,15 +2221,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes 1.4.0",
  "fnv 1.0.7",
- "futures-core 0.3.28",
- "futures-sink 0.3.28",
- "futures-util 0.3.28",
+ "futures-core 0.3.29",
+ "futures-sink 0.3.29",
+ "futures-util 0.3.29",
  "http 0.2.9",
  "indexmap 1.9.3",
  "slab 0.4.8",
@@ -2291,20 +2298,20 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 [[package]]
 name = "hashbrown_tstd"
 version = "0.12.0"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.2"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "byteorder 1.4.3",
  "crossbeam-channel",
  "flate2",
  "nom",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -2314,7 +2321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes 1.4.0",
  "headers-core",
  "http 0.2.9",
@@ -2349,18 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -2433,7 +2431,7 @@ checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes 1.4.0",
  "fnv 1.0.7",
- "itoa 1.0.6",
+ "itoa 1.0.9",
 ]
 
 [[package]]
@@ -2452,9 +2450,9 @@ name = "http_req"
 version = "0.8.1"
 source = "git+https://github.com/integritee-network/http_req?branch=master#3723e88235f2b29bc1a31835853b072ffd0455fd"
 dependencies = [
- "log 0.4.19",
+ "log 0.4.20",
  "rustls 0.19.1",
- "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.7.0",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.21.1",
 ]
@@ -2464,10 +2462,10 @@ name = "http_req"
 version = "0.8.1"
 source = "git+https://github.com/integritee-network/http_req#3723e88235f2b29bc1a31835853b072ffd0455fd"
 dependencies = [
- "log 0.4.19",
+ "log 0.4.20",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?branch=mesalock_sgx)",
  "sgx_tstd",
- "unicase 2.6.0 (git+https://github.com/mesalock-linux/unicase-sgx)",
+ "unicase 2.6.0",
  "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
  "webpki-roots 0.21.0 (git+https://github.com/mesalock-linux/webpki-roots?branch=mesalock_sgx)",
 ]
@@ -2500,22 +2498,22 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes 1.4.0",
- "futures-channel 0.3.28",
- "futures-core 0.3.28",
- "futures-util 0.3.28",
+ "futures-channel 0.3.29",
+ "futures-core 0.3.29",
+ "futures-util 0.3.29",
  "h2",
  "http 0.2.9",
  "http-body",
  "httparse 1.8.0",
  "httpdate",
- "itoa 1.0.6",
+ "itoa 1.0.9",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -2530,7 +2528,7 @@ checksum = "3538ce6aeb81f7cd0d547a42435944d2283714a3f696630318bc47bd839fcfc9"
 dependencies = [
  "bytes 1.4.0",
  "common-multipart-rfc7578",
- "futures 0.3.28",
+ "futures 0.3.29",
  "http 0.2.9",
  "hyper",
 ]
@@ -2542,9 +2540,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
  "ct-logs",
- "futures-util 0.3.28",
+ "futures-util 0.3.29",
  "hyper",
- "log 0.4.19",
+ "log 0.4.20",
  "rustls 0.19.1",
  "rustls-native-certs",
  "tokio",
@@ -2639,7 +2637,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -2671,7 +2669,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -2699,19 +2697,19 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
 name = "integritee-cli"
 version = "0.12.2"
 dependencies = [
- "array-bytes 6.1.0",
+ "array-bytes 6.2.2",
  "base58",
  "chrono 0.4.26",
  "clap 3.2.25",
  "enclave-bridge-primitives",
- "env_logger",
+ "env_logger 0.9.3",
  "hdrhistogram",
  "hex",
  "integritee-node-runtime",
@@ -2724,7 +2722,7 @@ dependencies = [
  "itp-time-utils",
  "itp-types",
  "itp-utils",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-balances",
  "pallet-enclave-bridge",
  "pallet-evm",
@@ -2732,10 +2730,10 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "rayon",
- "regex 1.9.5",
+ "regex 1.10.2",
  "reqwest",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sgx_crypto_helper",
  "sp-application-crypto",
  "sp-core",
@@ -2744,14 +2742,14 @@ dependencies = [
  "sp-runtime",
  "substrate-api-client",
  "substrate-client-keystore",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "urlencoding",
 ]
 
 [[package]]
 name = "integritee-node-runtime"
-version = "1.1.34"
-source = "git+https://github.com/integritee-network/integritee-node.git?branch=sdk-v0.12.0-polkadot-v0.9.42#1fb7b051ca3b3ce63fcb1ae2f898aa067f8b3a1d"
+version = "1.1.35"
+source = "git+https://github.com/integritee-network/integritee-node.git?branch=sdk-v0.12.6-polkadot-v0.9.42#996e58883207766ff996a9b97ad2868bf51976f7"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2804,9 +2802,9 @@ dependencies = [
  "clap 2.34.0",
  "dirs",
  "enclave-bridge-primitives",
- "env_logger",
+ "env_logger 0.9.3",
  "frame-support",
- "futures 0.3.28",
+ "futures 0.3.29",
  "hex",
  "integritee-node-runtime",
  "ipfs-api",
@@ -2831,7 +2829,7 @@ dependencies = [
  "its-test",
  "jsonrpsee",
  "lazy_static",
- "log 0.4.19",
+ "log 0.4.20",
  "mockall",
  "pallet-balances",
  "parity-scale-codec",
@@ -2839,11 +2837,11 @@ dependencies = [
  "parse_duration",
  "primitive-types",
  "prometheus",
- "regex 1.9.5",
+ "regex 1.10.2",
  "scale-info",
- "serde 1.0.188",
- "serde_derive 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_derive 1.0.192",
+ "serde_json 1.0.108",
  "sgx-verify",
  "sgx_crypto_helper",
  "sgx_types",
@@ -2853,7 +2851,7 @@ dependencies = [
  "sp-runtime",
  "substrate-api-client",
  "teerex-primitives",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "tokio",
  "url 2.5.0",
  "warp",
@@ -2865,7 +2863,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2896,14 +2894,14 @@ dependencies = [
  "bytes 1.4.0",
  "dirs",
  "failure",
- "futures 0.3.28",
+ "futures 0.3.29",
  "http 0.2.9",
  "hyper",
  "hyper-multipart-rfc7578",
  "hyper-tls",
  "parity-multiaddr",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "serde_urlencoded",
  "tokio",
  "tokio-util 0.6.10",
@@ -2919,6 +2917,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "rustix 0.38.4",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ita-oracle"
 version = "0.9.0"
 dependencies = [
@@ -2926,12 +2935,12 @@ dependencies = [
  "itp-enclave-metrics",
  "itp-ocall-api",
  "lazy_static",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sgx_tstd",
  "substrate-fixed",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
  "url 2.1.1",
  "url 2.5.0",
@@ -2942,7 +2951,7 @@ name = "ita-parentchain-interface"
 version = "0.9.0"
 dependencies = [
  "bs58",
- "env_logger",
+ "env_logger 0.9.3",
  "ita-sgx-runtime",
  "ita-stf",
  "itc-parentchain-indirect-calls-executor",
@@ -2956,7 +2965,7 @@ dependencies = [
  "itp-top-pool-author",
  "itp-types",
  "itp-utils",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
@@ -3015,7 +3024,7 @@ dependencies = [
  "itp-storage",
  "itp-types",
  "itp-utils",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-balances",
  "pallet-parentchain",
  "pallet-sudo",
@@ -3040,12 +3049,12 @@ dependencies = [
  "itp-utils",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
- "serde_json 1.0.106",
+ "serde_json 1.0.108",
  "sgx_tstd",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3063,12 +3072,12 @@ dependencies = [
  "itp-test",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-io 7.0.0",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3092,10 +3101,10 @@ dependencies = [
  "itc-parentchain-block-importer",
  "itp-import-queue",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "sgx_tstd",
  "sgx_types",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3109,12 +3118,12 @@ dependencies = [
  "itp-extrinsics-factory",
  "itp-stf-executor",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3124,8 +3133,8 @@ version = "0.9.0"
 dependencies = [
  "binary-merkle-tree",
  "bs58",
- "env_logger",
- "futures 0.3.28",
+ "env_logger 0.9.3",
+ "futures 0.3.29",
  "futures 0.3.8",
  "itc-parentchain-test",
  "itp-api-client-types",
@@ -3137,13 +3146,13 @@ dependencies = [
  "itp-test",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3159,13 +3168,13 @@ dependencies = [
  "itp-storage",
  "itp-test",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-consensus-grandpa",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3186,11 +3195,11 @@ dependencies = [
  "http 0.2.9",
  "http_req 0.8.1 (git+https://github.com/integritee-network/http_req?branch=master)",
  "http_req 0.8.1 (git+https://github.com/integritee-network/http_req)",
- "log 0.4.19",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "log 0.4.20",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sgx_tstd",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
  "url 2.1.1",
  "url 2.5.0",
@@ -3200,7 +3209,7 @@ dependencies = [
 name = "itc-rpc-client"
 version = "0.9.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.3",
  "frame-metadata",
  "itc-tls-websocket-server",
  "itp-api-client-types",
@@ -3208,14 +3217,14 @@ dependencies = [
  "itp-rpc",
  "itp-types",
  "itp-utils",
- "log 0.4.19",
+ "log 0.4.20",
  "openssl",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rustls 0.19.1",
- "serde_json 1.0.106",
+ "serde_json 1.0.108",
  "sgx_crypto_helper",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "url 2.5.0",
  "ws",
 ]
@@ -3225,7 +3234,7 @@ name = "itc-rpc-server"
 version = "0.9.0"
 dependencies = [
  "anyhow",
- "env_logger",
+ "env_logger 0.10.0",
  "itp-enclave-api",
  "itp-rpc",
  "itp-utils",
@@ -3235,7 +3244,7 @@ dependencies = [
  "its-storage",
  "its-test",
  "jsonrpsee",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sp-core",
  "tokio",
@@ -3247,8 +3256,8 @@ version = "0.9.0"
 dependencies = [
  "bit-vec",
  "chrono 0.4.26",
- "env_logger",
- "log 0.4.19",
+ "env_logger 0.9.3",
+ "log 0.4.20",
  "mio 0.6.21",
  "mio 0.6.23",
  "mio-extras 2.0.6 (git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b)",
@@ -3257,7 +3266,7 @@ dependencies = [
  "rustls 0.19.1",
  "sgx_tstd",
  "sp-core",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
  "tungstenite 0.14.0",
  "tungstenite 0.15.0",
@@ -3287,9 +3296,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "itp-api-client-extensions"
@@ -3297,7 +3306,7 @@ version = "0.9.0"
 dependencies = [
  "itp-api-client-types",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "sp-consensus-grandpa",
  "sp-runtime",
  "substrate-api-client",
@@ -3317,7 +3326,7 @@ dependencies = [
 name = "itp-attestation-handler"
 version = "0.8.0"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "base64 0.13.0 (git+https://github.com/mesalock-linux/rust-base64-sgx?rev=sgx_1.1.3)",
  "base64 0.13.1",
  "bit-vec",
@@ -3331,12 +3340,12 @@ dependencies = [
  "itp-sgx-crypto",
  "itp-sgx-io",
  "itp-time-utils",
- "log 0.4.19",
+ "log 0.4.20",
  "num-bigint 0.2.5",
  "parity-scale-codec",
  "rustls 0.19.0 (git+https://github.com/mesalock-linux/rustls?rev=sgx_1.1.3)",
  "rustls 0.19.1",
- "serde_json 1.0.106",
+ "serde_json 1.0.108",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx_rand",
  "sgx_tcrypto",
@@ -3344,7 +3353,7 @@ dependencies = [
  "sgx_tstd",
  "sgx_types",
  "sp-core",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.4 (git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx)",
@@ -3357,7 +3366,7 @@ name = "itp-component-container"
 version = "0.8.0"
 dependencies = [
  "sgx_tstd",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3372,16 +3381,16 @@ dependencies = [
  "itp-settings",
  "itp-storage",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
- "serde_json 1.0.106",
+ "serde_json 1.0.108",
  "sgx_crypto_helper",
  "sgx_types",
  "sgx_urts",
  "sp-core",
  "sp-runtime",
  "teerex-primitives",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -3422,7 +3431,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "substrate-api-client",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3439,7 +3448,7 @@ version = "0.8.0"
 dependencies = [
  "sgx_tstd",
  "sgx_types",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3467,7 +3476,7 @@ version = "0.9.0"
 dependencies = [
  "itp-api-client-types",
  "sp-core",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -3486,7 +3495,7 @@ version = "0.9.0"
 dependencies = [
  "itp-node-api-metadata",
  "sgx_tstd",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3495,7 +3504,7 @@ name = "itp-nonce-cache"
 version = "0.8.0"
 dependencies = [
  "sgx_tstd",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3519,7 +3528,7 @@ version = "0.9.0"
 dependencies = [
  "lazy_static",
  "sgx_tstd",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3529,8 +3538,8 @@ version = "0.9.0"
 dependencies = [
  "itp-types",
  "parity-scale-codec",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sgx_tstd",
 ]
 
@@ -3546,10 +3555,10 @@ dependencies = [
  "derive_more",
  "itp-sgx-io",
  "itp-sgx-temp-dir",
- "log 0.4.19",
+ "log 0.4.20",
  "ofb",
  "parity-scale-codec",
- "serde_json 1.0.106",
+ "serde_json 1.0.108",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx?tag=sgx_1.1.3)",
  "sgx_crypto_helper",
  "sgx_rand",
@@ -3565,10 +3574,10 @@ dependencies = [
  "derive_more",
  "environmental 1.1.3",
  "itp-hashing",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "postcard",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sgx_tstd",
  "sp-core",
 ]
@@ -3618,13 +3627,13 @@ dependencies = [
  "itp-top-pool",
  "itp-top-pool-author",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3665,14 +3674,14 @@ dependencies = [
  "itp-stf-state-observer",
  "itp-time-utils",
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3681,9 +3690,9 @@ name = "itp-stf-state-observer"
 version = "0.9.0"
 dependencies = [
  "itp-types",
- "log 0.4.19",
+ "log 0.4.20",
  "sgx_tstd",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3703,7 +3712,7 @@ dependencies = [
  "sp-state-machine",
  "sp-std",
  "sp-trie",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3733,7 +3742,7 @@ dependencies = [
  "itp-time-utils",
  "itp-types",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
@@ -3766,10 +3775,10 @@ dependencies = [
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
  "linked-hash-map 0.5.2",
  "linked-hash-map 0.5.6",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "parity-util-mem",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sgx_tstd",
  "sp-application-crypto",
  "sp-core",
@@ -3781,7 +3790,7 @@ name = "itp-top-pool-author"
 version = "0.9.0"
 dependencies = [
  "derive_more",
- "futures 0.3.28",
+ "futures 0.3.29",
  "itp-enclave-metrics",
  "itp-ocall-api",
  "itp-sgx-crypto",
@@ -3792,7 +3801,7 @@ dependencies = [
  "itp-types",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_crypto_helper",
  "sgx_tstd",
@@ -3842,13 +3851,13 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-state",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3862,13 +3871,13 @@ dependencies = [
  "itp-utils",
  "its-primitives",
  "its-test",
- "log 0.4.19",
+ "log 0.4.20",
  "sgx_tstd",
  "sp-consensus-slots",
  "sp-core",
  "sp-keyring",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3876,7 +3885,7 @@ dependencies = [
 name = "its-consensus-aura"
 version = "0.9.0"
 dependencies = [
- "env_logger",
+ "env_logger 0.9.3",
  "finality-grandpa",
  "ita-stf",
  "itc-parentchain-block-import-dispatcher",
@@ -3903,7 +3912,7 @@ dependencies = [
  "its-state",
  "its-test",
  "its-validateer-fetch",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
@@ -3933,13 +3942,13 @@ dependencies = [
  "its-primitives",
  "its-state",
  "its-test",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -3958,7 +3967,7 @@ dependencies = [
  "its-primitives",
  "its-test",
  "lazy_static",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-consensus-slots",
@@ -3981,10 +3990,10 @@ dependencies = [
  "its-storage",
  "its-test",
  "jsonrpsee",
- "log 0.4.19",
- "serde 1.0.188",
- "serde_json 1.0.106",
- "thiserror 1.0.40",
+ "log 0.4.20",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
+ "thiserror 1.0.44",
  "tokio",
 ]
 
@@ -3995,7 +4004,7 @@ dependencies = [
  "itp-types",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -4013,7 +4022,7 @@ dependencies = [
  "its-primitives",
  "jsonrpc-core 18.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 18.0.0 (git+https://github.com/scs/jsonrpc?branch=no_std_v18)",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "rust-base58 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
@@ -4043,13 +4052,13 @@ dependencies = [
  "itp-sgx-externalities",
  "itp-storage",
  "its-primitives",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
  "sp-io 7.0.0",
  "sp-runtime",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "thiserror 1.0.9",
 ]
 
@@ -4062,14 +4071,14 @@ dependencies = [
  "itp-types",
  "its-primitives",
  "its-test",
- "log 0.4.19",
+ "log 0.4.20",
  "mockall",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rocksdb",
  "sp-core",
  "temp-dir",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -4093,7 +4102,7 @@ dependencies = [
  "itp-test",
  "itp-types",
  "its-primitives",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
@@ -4124,13 +4133,13 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.28",
- "futures-executor 0.3.28",
- "futures-util 0.3.28",
- "log 0.4.19",
- "serde 1.0.188",
- "serde_derive 1.0.188",
- "serde_json 1.0.106",
+ "futures 0.3.29",
+ "futures-executor 0.3.29",
+ "futures-util 0.3.29",
+ "log 0.4.20",
+ "serde 1.0.192",
+ "serde_derive 1.0.192",
+ "serde_json 1.0.108",
 ]
 
 [[package]]
@@ -4172,10 +4181,10 @@ dependencies = [
  "hyper-rustls",
  "jsonrpsee-types",
  "jsonrpsee-utils",
- "log 0.4.19",
- "serde 1.0.188",
- "serde_json 1.0.106",
- "thiserror 1.0.40",
+ "log 0.4.20",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
+ "thiserror 1.0.44",
  "url 2.5.0",
 ]
 
@@ -4185,20 +4194,20 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22372378f63f7d16de453e786afc740fca5ee80bd260be024a616b6ac2cefe5"
 dependencies = [
- "futures-channel 0.3.28",
- "futures-util 0.3.28",
+ "futures-channel 0.3.29",
+ "futures-util 0.3.29",
  "globset",
  "hyper",
  "jsonrpsee-types",
  "jsonrpsee-utils",
  "lazy_static",
- "log 0.4.19",
- "serde 1.0.188",
- "serde_json 1.0.106",
- "socket2",
- "thiserror 1.0.40",
+ "log 0.4.20",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
+ "socket2 0.4.9",
+ "thiserror 1.0.44",
  "tokio",
- "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.7.0",
 ]
 
 [[package]]
@@ -4222,14 +4231,14 @@ checksum = "c0cf7bd4e93b3b56e59131de7f24afbea871faf914e97bcdd942c86927ab0172"
 dependencies = [
  "async-trait",
  "beef",
- "futures-channel 0.3.28",
- "futures-util 0.3.28",
+ "futures-channel 0.3.29",
+ "futures-util 0.3.29",
  "hyper",
- "log 0.4.19",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "log 0.4.20",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "soketto",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -4238,17 +4247,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47554ecaacb479285da68799d9b6afc258c32b332cc8b85829c6a9304ee98776"
 dependencies = [
- "futures-channel 0.3.28",
- "futures-util 0.3.28",
+ "futures-channel 0.3.29",
+ "futures-util 0.3.29",
  "hyper",
  "jsonrpsee-types",
- "log 0.4.19",
+ "log 0.4.20",
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "rustc-hash",
- "serde 1.0.188",
- "serde_json 1.0.106",
- "thiserror 1.0.40",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -4259,16 +4268,16 @@ checksum = "6ec51150965544e1a4468f372bdab8545243a1b045d4ab272023aac74c60de32"
 dependencies = [
  "async-trait",
  "fnv 1.0.7",
- "futures 0.3.28",
+ "futures 0.3.29",
  "jsonrpsee-types",
- "log 0.4.19",
+ "log 0.4.20",
  "pin-project",
  "rustls 0.19.1",
  "rustls-native-certs",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "soketto",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.6.10",
@@ -4281,16 +4290,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b512c3c679a89d20f97802f69188a2d01f6234491b7513076e21e8424efccafe"
 dependencies = [
- "futures-channel 0.3.28",
- "futures-util 0.3.28",
+ "futures-channel 0.3.29",
+ "futures-util 0.3.29",
  "jsonrpsee-types",
  "jsonrpsee-utils",
- "log 0.4.19",
+ "log 0.4.20",
  "rustc-hash",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "soketto",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "tokio",
  "tokio-stream",
  "tokio-util 0.6.10",
@@ -4306,7 +4315,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell 1.18.0",
- "sha2 0.10.6",
+ "sha2 0.10.7",
 ]
 
 [[package]]
@@ -4345,9 +4354,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libloading"
@@ -4395,7 +4404,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sha2 0.9.9",
  "typenum 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4431,9 +4440,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "24e6ab01971eb092ffe6a7d42f49f9ff42662f17604681e2843ad65077ba47dc"
 dependencies = [
  "cc",
  "pkg-config",
@@ -4442,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
@@ -4465,9 +4474,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linregress"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475015a7f8f017edb28d2e69813be23500ad4b32cfe3421c4148efc97324ee52"
+checksum = "4de0b5f52a9f84544d268f5fabb71b38962d6aa3c6600b8bcd27d44ccf9c9c45"
 dependencies = [
  "nalgebra",
 ]
@@ -4483,6 +4492,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -4514,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lz4-sys"
@@ -4584,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.3"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memfd"
@@ -4594,7 +4609,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix 0.37.20",
+ "rustix 0.37.23",
 ]
 
 [[package]]
@@ -4655,7 +4670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
- "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.7.0",
 ]
 
 [[package]]
@@ -4663,15 +4678,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -4708,9 +4714,9 @@ dependencies = [
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys",
  "libc",
- "log 0.4.19",
+ "log 0.4.20",
  "miow",
- "net2 0.2.38",
+ "net2 0.2.39",
  "slab 0.4.8",
  "winapi 0.2.8",
 ]
@@ -4733,7 +4739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.19",
+ "log 0.4.20",
  "mio 0.6.23",
  "slab 0.4.8",
 ]
@@ -4744,7 +4750,7 @@ version = "2.0.6"
 source = "git+https://github.com/integritee-network/mio-extras-sgx?rev=963234b#963234bf55e44f9efff921938255126c48deef3a"
 dependencies = [
  "lazycell",
- "log 0.4.19",
+ "log 0.4.20",
  "mio 0.6.21",
  "mio 0.6.23",
  "sgx_tstd",
@@ -4759,7 +4765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
- "net2 0.2.38",
+ "net2 0.2.39",
  "winapi 0.2.8",
  "ws2_32-sys",
 ]
@@ -4799,11 +4805,11 @@ checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
 dependencies = [
  "bytes 1.4.0",
  "encoding_rs",
- "futures-util 0.3.28",
+ "futures-util 0.3.29",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.19",
- "memchr 2.6.3",
+ "log 0.4.20",
+ "memchr 2.6.4",
  "mime",
  "spin 0.9.8",
  "version_check",
@@ -4836,25 +4842,25 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d47bba83f9e2006d117a9a33af1524e655516b8919caac694427a6fb1e511"
+checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex 0.4.3",
  "num-rational 0.4.1",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "simba",
  "typenum 1.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232c68884c0c99810a5a4d333ef7e47689cfd0edc85efc9e54e1e6bf5212766"
+checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4869,7 +4875,7 @@ checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
- "log 0.4.19",
+ "log 0.4.20",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -4891,9 +4897,9 @@ dependencies = [
 
 [[package]]
 name = "net2"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+checksum = "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -4912,7 +4918,7 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "memchr 2.6.3",
+ "memchr 2.6.4",
  "minimal-lexical",
 ]
 
@@ -4946,21 +4952,21 @@ dependencies = [
  "num-integer 0.1.45",
  "num-iter 0.1.43",
  "num-rational 0.2.4",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint 0.4.3",
  "num-complex 0.4.3",
  "num-integer 0.1.45",
  "num-iter 0.1.43",
  "num-rational 0.4.1",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -4982,7 +4988,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer 0.1.45",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -4993,7 +4999,7 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer 0.1.45",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -5013,7 +5019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg 1.1.0",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -5022,7 +5028,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -5042,8 +5048,8 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec 0.7.3",
- "itoa 1.0.6",
+ "arrayvec 0.7.4",
+ "itoa 1.0.9",
 ]
 
 [[package]]
@@ -5063,7 +5069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg 1.1.0",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -5084,7 +5090,7 @@ checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer 0.1.45",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -5108,7 +5114,7 @@ dependencies = [
  "autocfg 1.1.0",
  "num-bigint 0.2.6",
  "num-integer 0.1.45",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -5120,7 +5126,7 @@ dependencies = [
  "autocfg 1.1.0",
  "num-bigint 0.4.3",
  "num-integer 0.1.45",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -5134,20 +5140,20 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg 1.1.0",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 
@@ -5160,16 +5166,16 @@ dependencies = [
  "crc32fast",
  "hashbrown 0.12.3",
  "indexmap 1.9.3",
- "memchr 2.6.3",
+ "memchr 2.6.4",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
- "memchr 2.6.3",
+ "memchr 2.6.4",
 ]
 
 [[package]]
@@ -5209,11 +5215,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.54"
+version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b3f656a17a6cbc115b5c7a40c616947d213ba182135b014d6051b73ab6f019"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -5230,7 +5236,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -5241,9 +5247,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.88"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ce0f250f34a308dcfdbb351f511359857d4ed2134ba715a4eadd46e1ffd617"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
@@ -5253,9 +5259,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.1"
+version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "pallet-assets"
@@ -5310,7 +5316,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -5320,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "pallet-claims"
 version = "0.9.12"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "claims-primitives",
  "frame-support",
@@ -5328,8 +5334,8 @@ dependencies = [
  "parity-scale-codec",
  "rustc-hex",
  "scale-info",
- "serde 1.0.188",
- "serde_derive 1.0.188",
+ "serde 1.0.192",
+ "serde_derive 1.0.192",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
  "sp-std",
@@ -5337,18 +5343,18 @@ dependencies = [
 
 [[package]]
 name = "pallet-enclave-bridge"
-version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+version = "0.11.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-teerex",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
@@ -5370,7 +5376,7 @@ dependencies = [
  "frame-system",
  "hex",
  "impl-trait-for-tuples",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "rlp",
  "scale-info",
@@ -5388,7 +5394,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
@@ -5425,7 +5431,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
@@ -5436,14 +5442,14 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
@@ -5457,7 +5463,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
@@ -5488,7 +5494,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
@@ -5505,7 +5511,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -5521,18 +5527,18 @@ dependencies = [
 [[package]]
 name = "pallet-sidechain"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "enclave-bridge-primitives",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-enclave-bridge",
  "pallet-teerex",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sidechain-primitives",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
@@ -5558,11 +5564,11 @@ dependencies = [
 [[package]]
 name = "pallet-teeracle"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-teerex",
  "parity-scale-codec",
  "scale-info",
@@ -5578,16 +5584,17 @@ dependencies = [
 [[package]]
 name = "pallet-teerex"
 version = "0.10.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "log 0.4.19",
+ "log 0.4.20",
  "pallet-timestamp",
  "parity-scale-codec",
+ "rustls-webpki",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sgx-verify",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
@@ -5604,7 +5611,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
  "sp-inherents",
@@ -5623,7 +5630,7 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
@@ -5654,7 +5661,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-runtime",
  "sp-std",
 ]
@@ -5683,7 +5690,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
@@ -5702,7 +5709,7 @@ dependencies = [
  "data-encoding",
  "multihash",
  "percent-encoding 2.3.1",
- "serde 1.0.188",
+ "serde 1.0.192",
  "static_assertions",
  "unsigned-varint 0.7.1",
  "url 2.5.0",
@@ -5710,24 +5717,24 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "3.6.5"
+version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dec8a8073036902368c2cdc0387e85ff9a37054d7e7c98e592145e0c92cd4fb"
+checksum = "dd8e946cc0cc711189c0b0249fb8b599cbeeab9784d83c415719368bb8d4ac64"
 dependencies = [
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "bitvec",
  "byte-slice-cast",
  "bytes 1.4.0",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "3.6.5"
+version = "3.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312270ee71e1cd70289dacf597cab7b207aa107d2f28191c2ae45b2ece18a260"
+checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5796,7 +5803,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall 0.2.16",
- "smallvec 1.10.0",
+ "smallvec 1.11.0",
  "winapi 0.3.9",
 ]
 
@@ -5809,8 +5816,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.3.5",
- "smallvec 1.10.0",
- "windows-targets 0.48.0",
+ "smallvec 1.11.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -5821,14 +5828,14 @@ checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
 dependencies = [
  "lazy_static",
  "num 0.2.1",
- "regex 1.9.5",
+ "regex 1.10.2",
 ]
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
@@ -5887,29 +5894,29 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -5923,7 +5930,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.6",
+ "der 0.7.8",
  "spki 0.7.2",
 ]
 
@@ -5940,7 +5947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
 dependencies = [
  "postcard-cobs",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -5971,7 +5978,7 @@ dependencies = [
  "itertools",
  "normalize-line-endings",
  "predicates-core",
- "regex 1.9.5",
+ "regex 1.10.2",
 ]
 
 [[package]]
@@ -6058,14 +6065,14 @@ checksum = "0e99670bafb56b9a106419397343bdbc8b8742c3cc449fec6345f86173f47cd4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -6076,11 +6083,11 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder 1.4.3",
  "hex",
  "lazy_static",
- "rustix 0.36.14",
+ "rustix 0.36.16",
 ]
 
 [[package]]
@@ -6093,11 +6100,11 @@ dependencies = [
  "fnv 1.0.7",
  "lazy_static",
  "libc",
- "memchr 2.6.3",
+ "memchr 2.6.4",
  "parking_lot 0.12.1",
  "procfs",
  "protobuf",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -6304,7 +6311,7 @@ dependencies = [
  "pem 0.8.2",
  "pem 1.1.1",
  "ring 0.16.19",
- "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.16.20",
  "sgx_tstd",
  "yasna 0.3.1",
  "yasna 0.4.0",
@@ -6325,7 +6332,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6334,7 +6341,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6345,27 +6352,27 @@ checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.10",
  "redox_syscall 0.2.16",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43faa91b1c8b36841ee70e97188a869d37ae21759da6846d4be66de5bf7b12c"
+checksum = "61ef7e18e8841942ddb1cf845054f8008410030a3997875d9e49b7a363063df1"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
+checksum = "2dfaf0c85b766276c797f3791f5bc6d5bd116b41d53049af2789666b0c0bc9fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -6379,14 +6386,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
- "aho-corasick 1.0.2",
- "memchr 2.6.3",
- "regex-automata 0.3.8",
- "regex-syntax 0.7.5",
+ "aho-corasick",
+ "memchr 2.6.4",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -6400,13 +6407,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
- "aho-corasick 1.0.2",
- "memchr 2.6.3",
- "regex-syntax 0.7.5",
+ "aho-corasick",
+ "memchr 2.6.4",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -6425,21 +6432,21 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
  "base64 0.21.2",
  "bytes 1.4.0",
  "encoding_rs",
- "futures-core 0.3.28",
- "futures-util 0.3.28",
+ "futures-core 0.3.29",
+ "futures-util 0.3.29",
  "h2",
  "http 0.2.9",
  "http-body",
@@ -6447,15 +6454,16 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "log 0.4.19",
+ "log 0.4.20",
  "mime",
  "native-tls",
  "once_cell 1.18.0",
  "percent-encoding 2.3.1",
  "pin-project-lite",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -6484,36 +6492,21 @@ dependencies = [
  "cc",
  "sgx_tstd",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "ring"
 version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+source = "git+https://github.com/betrusted-io/ring-xous?branch=0.16.20-cleanup#4296c2e7904898766cf7d8d589759a129794783b"
 dependencies = [
  "cc",
  "libc",
- "once_cell 1.18.0",
- "spin 0.5.2",
- "untrusted",
- "web-sys",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup#8b2f60a7d4a063e2170cd47bc5591c39f49ca825"
-dependencies = [
- "cc",
- "libc",
- "log 0.4.19",
+ "log 0.4.20",
  "once_cell 1.18.0",
  "rkyv",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "winapi 0.3.9",
  "xous",
  "xous-api-names",
@@ -6580,7 +6573,7 @@ version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b313b91fcdc6719ad41fa2dad2b7e810b03833fae4bf911950e15529a5f04439"
 dependencies = [
- "num 0.4.0",
+ "num 0.4.1",
 ]
 
 [[package]]
@@ -6625,16 +6618,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver 1.0.18",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.36.14"
+version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
+checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -6644,15 +6637,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -6702,8 +6708,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.1",
- "log 0.4.19",
- "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.20",
+ "ring 0.16.20",
  "sct 0.6.1",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6722,24 +6728,40 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.12"
+name = "rustls-pki-types"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "a47003264dea418db67060fa420ad16d0d2f8f0a0360d825c00e177ac52cb5d8"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.0-alpha.3"
+source = "git+https://github.com/rustls/webpki?rev=da923ed#da923edaab56f599971e58773617fb574cd019dc"
+dependencies = [
+ "ring 0.16.20",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "safe-lock"
@@ -6758,9 +6780,9 @@ dependencies = [
 
 [[package]]
 name = "safe_arch"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a7484307bd40f8f7ccbacccac730108f2cae119a3b11c74485b48aa9ea650f"
+checksum = "f398075ce1e6a179b46f51bd88d0598b92b00d3551f1a2d4ac49e771b56ac354"
 dependencies = [
  "bytemuck",
 ]
@@ -6782,11 +6804,11 @@ dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
  "parking_lot 0.12.1",
- "serde_json 1.0.106",
+ "serde_json 1.0.108",
  "sp-application-crypto",
  "sp-core",
  "sp-keystore",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -6797,7 +6819,7 @@ checksum = "036575c29af9b6e4866ffb7fa055dbf623fe7a9cc159b33786de6013a6969d89"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -6811,7 +6833,7 @@ dependencies = [
  "scale-bits",
  "scale-decode-derive",
  "scale-info",
- "smallvec 1.10.0",
+ "smallvec 1.11.0",
 ]
 
 [[package]]
@@ -6838,7 +6860,7 @@ dependencies = [
  "scale-bits",
  "scale-encode-derive",
  "scale-info",
- "smallvec 1.10.0",
+ "smallvec 1.11.0",
 ]
 
 [[package]]
@@ -6856,23 +6878,23 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.7.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
 name = "scale-info-derive"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6882,11 +6904,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6926,15 +6948,15 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
 name = "sct"
@@ -6943,7 +6965,7 @@ source = "git+https://github.com/mesalock-linux/sct.rs?branch=mesalock_sgx#c4d85
 dependencies = [
  "ring 0.16.19",
  "sgx_tstd",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -6952,18 +6974,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
- "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "sec1"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der 0.7.6",
+ "der 0.7.8",
  "generic-array 0.14.7",
  "pkcs8",
  "subtle",
@@ -6999,11 +7021,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7012,9 +7034,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7040,11 +7062,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -7064,11 +7086,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
- "serde_derive 1.0.188",
+ "serde_derive 1.0.192",
 ]
 
 [[package]]
@@ -7077,8 +7099,8 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b926cfbabfe8011609dda0350cb24d884955d294909ac71c0db7027366c77e3e"
 dependencies = [
- "serde 1.0.188",
- "serde_derive 1.0.188",
+ "serde 1.0.192",
+ "serde_derive 1.0.192",
 ]
 
 [[package]]
@@ -7102,13 +7124,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7136,23 +7158,23 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.106"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "indexmap 2.0.0",
- "itoa 1.0.6",
+ "itoa 1.0.9",
  "ryu",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
@@ -7162,15 +7184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.6",
+ "itoa 1.0.9",
  "ryu",
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
 name = "sgx-verify"
 version = "0.1.4"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "base64 0.13.1",
  "chrono 0.4.26",
@@ -7178,29 +7200,29 @@ dependencies = [
  "frame-support",
  "hex",
  "hex-literal",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
- "ring 0.16.20 (git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup)",
+ "ring 0.16.20",
+ "rustls-webpki",
  "scale-info",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-std",
  "teerex-primitives",
- "webpki 0.21.0",
  "x509-cert",
 ]
 
 [[package]]
 name = "sgx_alloc"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 
 [[package]]
 name = "sgx_backtrace_sys"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "cc",
  "sgx_build_helper",
@@ -7210,21 +7232,21 @@ dependencies = [
 [[package]]
 name = "sgx_build_helper"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 
 [[package]]
 name = "sgx_crypto_helper"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "itertools",
  "libc",
  "serde 1.0.118",
- "serde 1.0.188",
+ "serde 1.0.192",
  "serde-big-array 0.1.5",
  "serde-big-array 0.3.0",
  "serde_derive 1.0.118",
- "serde_derive 1.0.188",
+ "serde_derive 1.0.192",
  "sgx_tcrypto",
  "sgx_tstd",
  "sgx_types",
@@ -7234,12 +7256,12 @@ dependencies = [
 [[package]]
 name = "sgx_demangle"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 
 [[package]]
 name = "sgx_libc"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "sgx_types",
 ]
@@ -7247,7 +7269,7 @@ dependencies = [
 [[package]]
 name = "sgx_rand"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "sgx_trts",
  "sgx_tstd",
@@ -7257,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "sgx_tcrypto"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "sgx_types",
 ]
@@ -7265,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "sgx_tprotected_fs"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "sgx_trts",
  "sgx_types",
@@ -7274,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "sgx_trts"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "sgx_libc",
  "sgx_types",
@@ -7283,7 +7305,7 @@ dependencies = [
 [[package]]
 name = "sgx_tse"
 version = "1.1.6"
-source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/teaclave-sgx-sdk.git?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "sgx_types",
 ]
@@ -7291,7 +7313,7 @@ dependencies = [
 [[package]]
 name = "sgx_tstd"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "hashbrown_tstd",
  "sgx_alloc",
@@ -7307,12 +7329,12 @@ dependencies = [
 [[package]]
 name = "sgx_types"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 
 [[package]]
 name = "sgx_ucrypto"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "libc",
  "rand_core 0.3.1",
@@ -7323,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "sgx_unwind"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "sgx_build_helper",
 ]
@@ -7331,7 +7353,7 @@ dependencies = [
 [[package]]
 name = "sgx_urts"
 version = "1.1.6"
-source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#f1776a7cec1caab2959813f87bb4924805b92011"
+source = "git+https://github.com/apache/incubator-teaclave-sgx-sdk?branch=master#1b1d03376056321441ef99716aa0888bd5ef19f7"
 dependencies = [
  "libc",
  "sgx_types",
@@ -7408,9 +7430,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -7445,11 +7467,11 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-runtime",
@@ -7489,7 +7511,7 @@ checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex 0.4.3",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "paste",
  "wide",
 ]
@@ -7521,9 +7543,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -7536,6 +7558,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "soketto"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7543,9 +7575,9 @@ checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.4.0",
- "futures 0.3.28",
+ "futures 0.3.29",
  "httparse 1.8.0",
- "log 0.4.19",
+ "log 0.4.20",
  "rand 0.8.5",
  "sha-1 0.9.8",
 ]
@@ -7556,7 +7588,7 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "hash-db 0.16.0",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
  "sp-api-proc-macro",
@@ -7567,7 +7599,7 @@ dependencies = [
  "sp-std",
  "sp-trie",
  "sp-version",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -7581,7 +7613,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7591,7 +7623,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
  "sp-std",
@@ -7603,10 +7635,10 @@ version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "integer-sqrt",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-std",
  "static_assertions",
 ]
@@ -7629,13 +7661,13 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "async-trait",
- "futures 0.3.28",
- "log 0.4.19",
+ "futures 0.3.29",
+ "log 0.4.20",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -7662,10 +7694,10 @@ version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "finality-grandpa",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -7681,7 +7713,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-std",
  "sp-timestamp",
 ]
@@ -7692,31 +7724,31 @@ version = "7.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "array-bytes 4.2.0",
- "bitflags",
+ "bitflags 1.3.2",
  "blake2",
  "bounded-collections",
  "bs58",
  "dyn-clonable",
  "ed25519-zebra",
- "futures 0.3.28",
+ "futures 0.3.29",
  "hash-db 0.16.0",
  "hash256-std-hasher",
  "impl-serde",
  "lazy_static",
  "libsecp256k1",
- "log 0.4.19",
+ "log 0.4.20",
  "merlin",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "paste",
  "primitive-types",
  "rand 0.8.5",
- "regex 1.9.5",
+ "regex 1.10.2",
  "scale-info",
  "schnorrkel",
  "secp256k1",
  "secrecy",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core-hashing",
  "sp-debug-derive",
  "sp-externalities",
@@ -7725,7 +7757,7 @@ dependencies = [
  "sp-storage",
  "ss58-registry",
  "substrate-bip39",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "tiny-bip39",
  "zeroize",
 ]
@@ -7738,7 +7770,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder 1.4.3",
  "digest 0.10.7",
- "sha2 0.10.6",
+ "sha2 0.10.7",
  "sha3",
  "sp-std",
  "twox-hash",
@@ -7752,7 +7784,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7762,7 +7794,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7788,7 +7820,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -7797,7 +7829,7 @@ version = "7.0.0"
 dependencies = [
  "itp-sgx-externalities",
  "libsecp256k1",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sgx_tstd",
  "sp-core",
@@ -7811,9 +7843,9 @@ dependencies = [
  "bytes 1.4.0",
  "ed25519",
  "ed25519-dalek",
- "futures 0.3.28",
+ "futures 0.3.29",
  "libsecp256k1",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "rustversion",
  "secp256k1",
@@ -7845,13 +7877,13 @@ name = "sp-keystore"
 version = "0.13.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
- "futures 0.3.28",
+ "futures 0.3.29",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-externalities",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -7859,7 +7891,7 @@ name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "zstd",
 ]
 
@@ -7891,7 +7923,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "backtrace",
  "lazy_static",
- "regex 1.9.5",
+ "regex 1.10.2",
 ]
 
 [[package]]
@@ -7902,12 +7934,12 @@ dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "paste",
  "rand 0.8.5",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-application-crypto",
  "sp-arithmetic",
  "sp-core",
@@ -7943,7 +7975,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -7967,7 +7999,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -7979,17 +8011,17 @@ version = "0.13.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "hash-db 0.16.0",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "smallvec 1.10.0",
+ "smallvec 1.11.0",
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
  "sp-std",
  "sp-trie",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "tracing",
 ]
 
@@ -8006,7 +8038,7 @@ dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "ref-cast",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-debug-derive",
  "sp-std",
 ]
@@ -8018,12 +8050,12 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "async-trait",
  "futures-timer",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -8064,7 +8096,7 @@ dependencies = [
  "schnellru",
  "sp-core",
  "sp-std",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "tracing",
  "trie-db",
  "trie-root",
@@ -8079,12 +8111,12 @@ dependencies = [
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core-hashing-proc-macro",
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
 ]
 
 [[package]]
@@ -8095,7 +8127,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -8105,7 +8137,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "sp-std",
  "wasmi",
@@ -8119,8 +8151,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
- "smallvec 1.10.0",
+ "serde 1.0.192",
+ "smallvec 1.11.0",
  "sp-arithmetic",
  "sp-core",
  "sp-debug-derive",
@@ -8156,21 +8188,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.6",
+ "der 0.7.8",
 ]
 
 [[package]]
 name = "ss58-registry"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47a8ad42e5fc72d5b1eb104a5546937eaf39843499948bb666d6e93c62423b"
+checksum = "bfc443bad666016e012538782d9e3006213a7db43e9fb1dda91657dc06a6fa08"
 dependencies = [
  "Inflector",
  "num-format",
  "proc-macro2",
  "quote",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "unicode-xid",
 ]
 
@@ -8233,11 +8265,11 @@ dependencies = [
  "frame-metadata",
  "frame-support",
  "hex",
- "log 0.4.19",
+ "log 0.4.20",
  "maybe-async",
  "parity-scale-codec",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
@@ -8267,7 +8299,7 @@ dependencies = [
  "async-trait",
  "parking_lot 0.12.1",
  "sc-keystore",
- "serde_json 1.0.106",
+ "serde_json 1.0.108",
  "sp-application-crypto",
  "sp-core",
  "sp-keyring",
@@ -8281,7 +8313,7 @@ source = "git+https://github.com/encointer/substrate-fixed?tag=v0.5.9#a4fb461aae
 dependencies = [
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "typenum 1.16.0 (git+https://github.com/encointer/typenum?tag=v1.16.0)",
 ]
 
@@ -8321,9 +8353,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8343,6 +8375,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8350,14 +8403,14 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.7"
+version = "0.12.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
+checksum = "1d2faeef5759ab89935255b1a4cd98e0baf99d1085e37d36599c625dac49ae8e"
 
 [[package]]
 name = "teeracle-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "common-primitives",
  "sp-std",
@@ -8367,14 +8420,14 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "common-primitives",
  "derive_more",
- "log 0.4.19",
+ "log 0.4.20",
  "parity-scale-codec",
  "scale-info",
- "serde 1.0.188",
+ "serde 1.0.192",
  "sp-core",
  "sp-runtime",
  "sp-std",
@@ -8388,15 +8441,14 @@ checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.20",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -8441,11 +8493,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
- "thiserror-impl 1.0.40",
+ "thiserror-impl 1.0.44",
 ]
 
 [[package]]
@@ -8460,13 +8512,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -8502,8 +8554,8 @@ dependencies = [
  "pbkdf2 0.11.0",
  "rand 0.8.5",
  "rustc-hash",
- "sha2 0.10.6",
- "thiserror 1.0.40",
+ "sha2 0.10.7",
+ "thiserror 1.0.44",
  "unicode-normalization 0.1.22",
  "wasm-bindgen",
  "zeroize",
@@ -8535,11 +8587,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
- "autocfg 1.1.0",
+ "backtrace",
  "bytes 1.4.0",
  "libc",
  "mio 0.8.8",
@@ -8547,7 +8599,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -8560,7 +8612,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -8590,21 +8642,21 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
- "futures-core 0.3.28",
+ "futures-core 0.3.29",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
- "futures-util 0.3.28",
- "log 0.4.19",
+ "futures-util 0.3.29",
+ "log 0.4.20",
  "tokio",
- "tungstenite 0.18.0",
+ "tungstenite 0.20.1",
 ]
 
 [[package]]
@@ -8614,10 +8666,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes 1.4.0",
- "futures-core 0.3.28",
- "futures-io 0.3.28",
- "futures-sink 0.3.28",
- "log 0.4.19",
+ "futures-core 0.3.29",
+ "futures-io 0.3.29",
+ "futures-sink 0.3.29",
+ "log 0.4.20",
  "pin-project-lite",
  "tokio",
 ]
@@ -8629,8 +8681,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes 1.4.0",
- "futures-core 0.3.28",
- "futures-sink 0.3.28",
+ "futures-core 0.3.29",
+ "futures-sink 0.3.29",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -8638,11 +8690,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
  "serde_spanned",
  "toml_datetime",
  "toml_edit",
@@ -8650,21 +8702,21 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap 1.9.3",
- "serde 1.0.188",
+ "indexmap 2.0.0",
+ "serde 1.0.192",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -8683,7 +8735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
- "log 0.4.19",
+ "log 0.4.20",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8691,13 +8743,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -8717,7 +8769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
- "log 0.4.19",
+ "log 0.4.20",
  "tracing-core",
 ]
 
@@ -8727,7 +8779,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.188",
+ "serde 1.0.192",
  "tracing-core",
 ]
 
@@ -8741,11 +8793,11 @@ dependencies = [
  "chrono 0.4.26",
  "lazy_static",
  "matchers",
- "regex 1.9.5",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "regex 1.10.2",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "sharded-slab",
- "smallvec 1.10.0",
+ "smallvec 1.11.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -8761,9 +8813,9 @@ checksum = "767abe6ffed88a1889671a102c2861ae742726f52e0a5a425b92c9fbfa7e9c85"
 dependencies = [
  "hash-db 0.16.0",
  "hashbrown 0.13.2",
- "log 0.4.19",
+ "log 0.4.20",
  "rustc-hex",
- "smallvec 1.10.0",
+ "smallvec 1.11.0",
 ]
 
 [[package]]
@@ -8830,11 +8882,11 @@ dependencies = [
  "bytes 1.4.0",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.19",
+ "log 0.4.20",
  "rand 0.8.5",
  "rustls 0.19.1",
  "sha-1 0.9.8",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "url 2.5.0",
  "utf-8 0.7.6",
  "webpki 0.21.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8852,11 +8904,30 @@ dependencies = [
  "bytes 1.4.0",
  "http 0.2.9",
  "httparse 1.8.0",
- "log 0.4.19",
+ "log 0.4.20",
  "native-tls",
  "rand 0.8.5",
  "sha1 0.10.5",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
+ "url 2.5.0",
+ "utf-8 0.7.6",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+dependencies = [
+ "byteorder 1.4.3",
+ "bytes 1.4.0",
+ "data-encoding",
+ "http 0.2.9",
+ "httparse 1.8.0",
+ "log 0.4.20",
+ "rand 0.8.5",
+ "sha1 0.10.5",
+ "thiserror 1.0.44",
  "url 2.5.0",
  "utf-8 0.7.6",
 ]
@@ -8914,18 +8985,18 @@ dependencies = [
 [[package]]
 name = "unicase"
 version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+source = "git+https://github.com/mesalock-linux/unicase-sgx#0b0519348572927118af47af3da4da9ffdca8ec6"
 dependencies = [
+ "sgx_tstd",
  "version_check",
 ]
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
-source = "git+https://github.com/mesalock-linux/unicase-sgx#0b0519348572927118af47af3da4da9ffdca8ec6"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
- "sgx_tstd",
  "version_check",
 ]
 
@@ -8946,9 +9017,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -8996,6 +9067,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -9075,27 +9152,26 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log 0.4.19",
  "try-lock",
 ]
 
 [[package]]
 name = "warp"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
 dependencies = [
  "bytes 1.4.0",
- "futures-channel 0.3.28",
- "futures-util 0.3.28",
+ "futures-channel 0.3.29",
+ "futures-util 0.3.29",
  "headers",
  "http 0.2.9",
  "hyper",
- "log 0.4.19",
+ "log 0.4.20",
  "mime",
  "mime_guess",
  "multer",
@@ -9103,8 +9179,8 @@ dependencies = [
  "pin-project",
  "rustls-pemfile",
  "scoped-tls",
- "serde 1.0.188",
- "serde_json 1.0.106",
+ "serde 1.0.192",
+ "serde_json 1.0.108",
  "serde_urlencoded",
  "tokio",
  "tokio-stream",
@@ -9149,11 +9225,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "log 0.4.19",
+ "log 0.4.20",
  "once_cell 1.18.0",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -9187,7 +9263,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9209,7 +9285,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "wasm-opt-cxx-sys",
  "wasm-opt-sys",
 ]
@@ -9236,7 +9312,7 @@ dependencies = [
  "cc",
  "cxx",
  "cxx-build",
- "regex 1.9.5",
+ "regex 1.10.2",
 ]
 
 [[package]]
@@ -9269,7 +9345,7 @@ dependencies = [
  "libm",
  "memory_units",
  "num-rational 0.4.1",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -9293,12 +9369,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap 1.9.3",
  "libc",
- "log 0.4.19",
+ "log 0.4.20",
  "object 0.29.0",
  "once_cell 1.18.0",
  "paste",
  "psm",
- "serde 1.0.188",
+ "serde 1.0.192",
  "target-lexicon",
  "wasmparser",
  "wasmtime-environ",
@@ -9326,11 +9402,11 @@ dependencies = [
  "cranelift-entity",
  "gimli 0.26.2",
  "indexmap 1.9.3",
- "log 0.4.19",
+ "log 0.4.20",
  "object 0.29.0",
- "serde 1.0.188",
+ "serde 1.0.192",
  "target-lexicon",
- "thiserror 1.0.40",
+ "thiserror 1.0.44",
  "wasmparser",
  "wasmtime-types",
 ]
@@ -9347,10 +9423,10 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli 0.26.2",
- "log 0.4.19",
+ "log 0.4.20",
  "object 0.29.0",
  "rustc-demangle",
- "serde 1.0.188",
+ "serde 1.0.192",
  "target-lexicon",
  "wasmtime-environ",
  "wasmtime-jit-icache-coherence",
@@ -9389,13 +9465,13 @@ dependencies = [
  "cfg-if 1.0.0",
  "indexmap 1.9.3",
  "libc",
- "log 0.4.19",
+ "log 0.4.20",
  "mach",
  "memfd",
  "memoffset 0.6.5",
  "paste",
  "rand 0.8.5",
- "rustix 0.36.14",
+ "rustix 0.36.16",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -9409,8 +9485,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e5572c5727c1ee7e8f28717aaa8400e4d22dcbd714ea5457d85b5005206568"
 dependencies = [
  "cranelift-entity",
- "serde 1.0.188",
- "thiserror 1.0.40",
+ "serde 1.0.192",
+ "thiserror 1.0.44",
  "wasmparser",
 ]
 
@@ -9426,22 +9502,12 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.0"
-source = "git+https://github.com/scs/webpki-nostd.git?branch=master#22d1772c39ed9081c2815aadb30e7973f3c4e93f"
-dependencies = [
- "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.16.20 (git+https://github.com/Niederb/ring-xous.git?branch=0.16.20-cleanup)",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
- "ring 0.16.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -9451,7 +9517,7 @@ source = "git+https://github.com/mesalock-linux/webpki?branch=mesalock_sgx#8dbe6
 dependencies = [
  "ring 0.16.19",
  "sgx_tstd",
- "untrusted",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -9483,9 +9549,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40018623e2dba2602a9790faba8d33f2ebdebf4b86561b83928db735f8784728"
+checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -9540,7 +9606,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -9573,7 +9639,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -9593,9 +9659,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",
@@ -9692,11 +9758,11 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "25b5872fa2e10bd067ae946f927e726d7d603eaeb6e02fa6a350e0722d2b8c11"
 dependencies = [
- "memchr 2.6.3",
+ "memchr 2.6.4",
 ]
 
 [[package]]
@@ -9718,7 +9784,7 @@ dependencies = [
  "byteorder 1.4.3",
  "bytes 0.4.12",
  "httparse 1.8.0",
- "log 0.4.19",
+ "log 0.4.20",
  "mio 0.6.23",
  "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl",
@@ -9761,35 +9827,35 @@ dependencies = [
 
 [[package]]
 name = "xous"
-version = "0.9.44"
+version = "0.9.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30684dda3583f528d5b05bddc96527e1783255e867a5e81c10721d6abb9e169c"
+checksum = "c291e0efc56bc20b4c434ac239b8d6d49bf2ec3bf9cac991fdc0d702e2ff4b2d"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "xous-api-log"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6b15ea09891f09b02d763422dc99733c96e62d0f8ab476c6bc663c90b17e72"
+checksum = "797ff15cb41c855dfc21311da441e35cc583baa9ef238627ef33f05912d9367c"
 dependencies = [
- "log 0.4.19",
+ "log 0.4.20",
  "num-derive",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "xous",
  "xous-ipc",
 ]
 
 [[package]]
 name = "xous-api-names"
-version = "0.9.42"
+version = "0.9.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b470fbf177d58767fa001acfcb5294a88d3938d3935865ff6b8f1db40f1004e"
+checksum = "bf13daca16910140fe4067135dfb56ca406e6f8951f93b1f087281a21fc055b6"
 dependencies = [
- "log 0.4.19",
+ "log 0.4.20",
  "num-derive",
- "num-traits 0.2.15",
+ "num-traits 0.2.16",
  "rkyv",
  "xous",
  "xous-api-log",
@@ -9798,11 +9864,11 @@ dependencies = [
 
 [[package]]
 name = "xous-ipc"
-version = "0.9.44"
+version = "0.9.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d520fe08642d55a56f700b6d30c7a556f38818e7c3e5d9a0856dde0b79ed4d67"
+checksum = "9bc1dd2cd7306d496d9606796905d472ca51f7889423363c96c2296506963234"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "rkyv",
  "xous",
 ]
@@ -9852,23 +9918,23 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.12.3+zstd.1.5.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76eea132fb024e0e13fd9c2f5d5d595d8a967aa72382ac2f9d39fcc95afd0806"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.5+zstd.1.5.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56d9e60b4b1758206c238a10165fbcae3ca37b01744e394c463463f6529d23b"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,6 +3928,7 @@ dependencies = [
  "itp-sgx-externalities",
  "itp-test",
  "itp-types",
+ "itp-utils",
  "its-block-verification",
  "its-primitives",
  "its-state",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,9 @@ sgx_types = { version = "1.1.6", git = "https://github.com/apache/incubator-teac
 sgx_ucrypto = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 sgx_urts = { version = "1.1.6", git = "https://github.com/apache/incubator-teaclave-sgx-sdk", branch = "master" }
 
+[patch.crates-io]
+ring = { git = "https://github.com/betrusted-io/ring-xous", branch = "0.16.20-cleanup" }
+
 #[patch."https://github.com/integritee-network/integritee-node"]
 #my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network//integritee-node", branch = "ab/integrate-pallet-teerex-refactoring" }
 

--- a/app-libs/sgx-runtime/Cargo.toml
+++ b/app-libs/sgx-runtime/Cargo.toml
@@ -9,7 +9,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 
 # local dependencies
 itp-sgx-runtime-primitives = { path = "../../core-primitives/sgx-runtime-primitives", default-features = false }
@@ -43,7 +43,7 @@ sp-version = { default-features = false, git = "https://github.com/paritytech/su
 
 # Integritee dependencies
 pallet-evm = { default-features = false, optional = true, git = "https://github.com/integritee-network/frontier.git", branch = "bar/polkadot-v0.9.42" }
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 
 [features]
 default = ["std"]

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -31,7 +31,7 @@ sp-io = { default-features = false, features = ["disable_oom", "disable_panic_ha
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,12 +25,12 @@ thiserror = "1.0"
 urlencoding = "2.1.3"
 
 # scs / integritee
-my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
-pallet-enclave-bridge = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
+pallet-enclave-bridge = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 pallet-evm = { optional = true, git = "https://github.com/integritee-network/frontier.git", branch = "bar/polkadot-v0.9.42" }
-pallet-teerex = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+pallet-teerex = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 # `default-features = false` to remove the jsonrpsee dependency.
-enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 # disable unsupported jsonrpcsee
 substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-cli"
-version = "0.12.2"
+version = "0.12.6"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/cli/src/trusted_base_cli/commands/get_shard.rs
+++ b/cli/src/trusted_base_cli/commands/get_shard.rs
@@ -51,7 +51,7 @@ impl GetShardCommand {
 			})?;
 
 		if rpc_return_value.status == DirectRequestStatus::Error {
-			println!("[Error] {}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
+			error!("{}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
 			return Err(CliError::WorkerRpcApi { msg: "rpc error".to_string() })
 		}
 

--- a/cli/src/trusted_base_cli/commands/get_shard_vault.rs
+++ b/cli/src/trusted_base_cli/commands/get_shard_vault.rs
@@ -51,7 +51,7 @@ impl GetShardVaultCommand {
 			})?;
 
 		if rpc_return_value.status == DirectRequestStatus::Error {
-			println!("[Error] {}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
+			error!("{}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
 			return Err(CliError::WorkerRpcApi { msg: "rpc error".to_string() })
 		}
 

--- a/cli/src/trusted_command_utils.rs
+++ b/cli/src/trusted_command_utils.rs
@@ -144,7 +144,7 @@ pub(crate) fn get_pending_trusted_calls_for(
 	let rpc_return_value = RpcReturnValue::from_hex(&rpc_response.result).unwrap();
 
 	if rpc_return_value.status == DirectRequestStatus::Error {
-		println!("[Error] {}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
+		error!("{}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
 		direct_api.close().unwrap();
 		return vec![]
 	}

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -104,7 +104,7 @@ pub(crate) fn get_state<T: Decode + Debug>(
 		})?;
 
 	if rpc_return_value.status == DirectRequestStatus::Error {
-		println!("[Error] {}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
+		error!("{}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
 		return Err(TrustedOperationError::Default {
 			msg: "[Error] DirectRequestStatus::Error".to_string(),
 		})
@@ -281,7 +281,7 @@ fn send_direct_request<T: Decode + Debug>(
 						DirectRequestStatus::Error => {
 							debug!("request status is error");
 							if let Ok(value) = String::decode(&mut return_value.value.as_slice()) {
-								println!("[Error] {}", value);
+								error!("{}", value);
 							}
 							direct_api.close().unwrap();
 							return Err(TrustedOperationError::Default {
@@ -369,7 +369,7 @@ pub(crate) fn wait_until(
 								if let Ok(value) =
 									String::decode(&mut return_value.value.as_slice())
 								{
-									println!("[Error] {}", value);
+									error!("{}", value);
 								}
 								return None
 							},

--- a/core-primitives/enclave-api/Cargo.toml
+++ b/core-primitives/enclave-api/Cargo.toml
@@ -19,7 +19,7 @@ frame-support = { git = "https://github.com/paritytech/substrate.git", branch = 
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
-teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 
 itc-parentchain = { path = "../../core/parentchain/parentchain-crate" }
 itp-enclave-api-ffi = { path = "ffi" }

--- a/core-primitives/extrinsics-factory/src/lib.rs
+++ b/core-primitives/extrinsics-factory/src/lib.rs
@@ -70,7 +70,7 @@ where
 	genesis_hash: H256,
 	signer: Signer,
 	nonce_cache: Arc<NonceCache>,
-	node_metadata_repository: Arc<NodeMetadataRepository>,
+	pub node_metadata_repository: Arc<NodeMetadataRepository>,
 }
 
 impl<Signer, NonceCache, NodeMetadataRepository>

--- a/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/core-primitives/node-api/api-client-types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 # integritee-node
-my-node-runtime = { package = "integritee-node-runtime", optional = true, git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+my-node-runtime = { package = "integritee-node-runtime", optional = true, git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 
 # scs
 substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }

--- a/core-primitives/stf-executor/src/enclave_signer.rs
+++ b/core-primitives/stf-executor/src/enclave_signer.rs
@@ -46,7 +46,7 @@ pub struct StfEnclaveSigner<
 	G,
 > {
 	state_observer: Arc<StateObserver>,
-	ocall_api: Arc<OCallApi>,
+	pub ocall_api: Arc<OCallApi>,
 	shielding_key_repo: Arc<ShieldingKeyRepository>,
 	top_pool_author: Arc<TopPoolAuthor>,
 	_phantom: PhantomData<(Stf, TCS, G)>,

--- a/core-primitives/stf-state-observer/src/error.rs
+++ b/core-primitives/stf-state-observer/src/error.rs
@@ -26,7 +26,7 @@ use std::boxed::Box;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
 	#[error("Current state is empty (not set)")]
-	CurrentStateEmpty,
+	CurrentShardStateEmpty,
 	#[error("Could not acquire lock, lock is poisoned")]
 	LockPoisoning,
 	#[error(transparent)]

--- a/core-primitives/stf-state-observer/src/mock.rs
+++ b/core-primitives/stf-state-observer/src/mock.rs
@@ -59,7 +59,7 @@ where
 				debug!("State value: {:?}", state);
 				Ok(observation_func(state))
 			},
-			None => Err(Error::CurrentStateEmpty),
+			None => Err(Error::CurrentShardStateEmpty),
 		}
 	}
 }

--- a/core-primitives/stf-state-observer/src/state_observer.rs
+++ b/core-primitives/stf-state-observer/src/state_observer.rs
@@ -85,7 +85,7 @@ impl<StateType> ObserveState for StateObserver<StateType> {
 
 		match current_state_map_lock.get_mut(shard) {
 			Some(s) => Ok(observation_func(s)),
-			None => Err(Error::CurrentStateEmpty),
+			None => Err(Error::CurrentShardStateEmpty),
 		}
 	}
 }

--- a/core-primitives/stf-state-observer/src/state_observer.rs
+++ b/core-primitives/stf-state-observer/src/state_observer.rs
@@ -112,7 +112,7 @@ mod tests {
 
 		assert_matches!(
 			state_observer.observe_state(&shard(), |_| { () }),
-			Err(Error::CurrentStateEmpty)
+			Err(Error::CurrentShardStateEmpty)
 		);
 	}
 

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -26,8 +26,8 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 # integritee-node
-enclave-bridge-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
-teerex-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+enclave-bridge-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
+teerex-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 
 
 [features]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "${AESMD:-/dev/null}:/var/run/aesmd"
       - "${SGX_QCNL:-/dev/null}:/etc/sgx_default_qcnl.conf"
     environment:
-      - RUST_LOG=info,substrate_api_client=warn,ws=warn,mio=warn,ac_node_api=warn,sp_io=warn,tungstenite=warn
+      - RUST_LOG=info,substrate_api_client=warn,ws=warn,mio=warn,ac_node_api=warn,sp_io=warn,tungstenite=warn,integritee_service=debug,enclave_runtime=debug
     networks:
       - integritee-test-network
     healthcheck:
@@ -64,7 +64,7 @@ services:
       - "${AESMD:-/dev/null}:/var/run/aesmd"
       - "${SGX_QCNL:-/dev/null}:/etc/sgx_default_qcnl.conf"
     environment:
-      - RUST_LOG=info,substrate_api_client=warn,ws=warn,mio=warn,ac_node_api=warn,sp_io=warn,tungstenite=warn
+      - RUST_LOG=info,substrate_api_client=warn,ws=warn,mio=warn,ac_node_api=warn,sp_io=warn,tungstenite=warn,integritee_service=debug,enclave_runtime=debug
     networks:
       - integritee-test-network
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   "integritee-node-${VERSION}":
-    image: "${INTEGRITEE_NODE:-integritee/integritee-node:1.1.3}"
+    image: "${INTEGRITEE_NODE:-integritee/integritee-node:1.1.4}"
     hostname: integritee-node
     devices:
       - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - "${AESMD:-/dev/null}:/var/run/aesmd"
       - "${SGX_QCNL:-/dev/null}:/etc/sgx_default_qcnl.conf"
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,its_consensus_common=debug
+      - RUST_LOG=info,substrate_api_client=warn,ws=warn,mio=warn,ac_node_api=warn,sp_io=warn,tungstenite=warn
     networks:
       - integritee-test-network
     healthcheck:
@@ -64,7 +64,7 @@ services:
       - "${AESMD:-/dev/null}:/var/run/aesmd"
       - "${SGX_QCNL:-/dev/null}:/etc/sgx_default_qcnl.conf"
     environment:
-      - RUST_LOG=warn,ws=warn,sp_io=warn,substrate_api_client=warn,jsonrpsee_ws_client=warn,jsonrpsee_ws_server=warn,enclave_runtime=warn,integritee_service=warn,ita_stf=warn,its_consensus_common=debug
+      - RUST_LOG=info,substrate_api_client=warn,ws=warn,mio=warn,ac_node_api=warn,sp_io=warn,tungstenite=warn
     networks:
       - integritee-test-network
     healthcheck:

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "itp-settings",
  "itp-sgx-crypto",
  "itp-types",
+ "itp-utils",
  "its-block-verification",
  "its-primitives",
  "its-state",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "common-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "enclave-bridge-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "common-primitives",
  "log",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3619,9 +3619,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.7.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b569c32c806ec3abdf3b5869fb8bf1e0d275a7c1c9b0b05603d9464632649edf"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
@@ -3633,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4643,7 +4643,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.0-polkadot-v0.9.42#eaf611b79bc9d56b20c155150e99b549bf98436b"
+source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.12.6-polkadot-v0.9.42#94aa66fbe63d0d5bc848b9cf8f7a71fa34ef8ce8"
 dependencies = [
  "common-primitives",
  "derive_more",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -771,11 +771,12 @@ dependencies = [
 
 [[package]]
 name = "enclave-runtime"
-version = "0.12.2"
+version = "0.12.6"
 dependencies = [
  "array-bytes 6.1.0",
  "cid",
  "derive_more",
+ "enclave-bridge-primitives",
  "env_logger",
  "frame-support",
  "frame-system",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -87,7 +87,7 @@ base58 = { rev = "sgx_1.1.3", package = "rust-base58", default-features = false,
 
 cid = { default-features = false, git = "https://github.com/whalelephant/rust-cid", branch = "nstd" }
 multibase = { default-features = false, git = "https://github.com/whalelephant/rust-multibase", branch = "nstd" }
-teerex-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+teerex-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 
 # local deps
 ita-oracle = { path = "../app-libs/oracle", default-features = false, optional = true, features = ["sgx"] }

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runtime"
-version = "0.12.2"
+version = "0.12.6"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 
@@ -86,6 +86,7 @@ webpki = { git = "https://github.com/mesalock-linux/webpki", branch = "mesalock_
 base58 = { rev = "sgx_1.1.3", package = "rust-base58", default-features = false, features = ["mesalock_sgx"], git = "https://github.com/mesalock-linux/rust-base58-sgx" }
 
 cid = { default-features = false, git = "https://github.com/whalelephant/rust-cid", branch = "nstd" }
+enclave-bridge-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 multibase = { default-features = false, git = "https://github.com/whalelephant/rust-multibase", branch = "nstd" }
 teerex-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -53,9 +53,7 @@ use itc_parentchain::{block_import_dispatcher::DispatchBlockImport, primitives::
 use itp_component_container::ComponentGetter;
 
 use itp_import_queue::PushToQueue;
-use itp_node_api::metadata::{
-	NodeMetadata,
-};
+use itp_node_api::metadata::NodeMetadata;
 use itp_nonce_cache::{MutateNonce, Nonce};
 
 use itp_settings::worker_mode::{ProvideWorkerMode, WorkerMode, WorkerModeProvider};
@@ -63,10 +61,8 @@ use itp_sgx_crypto::key_repository::AccessPubkey;
 use itp_stf_interface::SHARD_CREATION_HEADER_KEY;
 use itp_stf_state_handler::{handle_state::HandleState, query_shard_state::QueryShardState};
 use itp_storage::{StorageProof, StorageProofChecker};
-use itp_types::{
-	parentchain::{Header}, ShardIdentifier, SignedBlock,
-};
-use itp_utils::{write_slice_and_whitespace_pad};
+use itp_types::{parentchain::Header, ShardIdentifier, SignedBlock};
+use itp_utils::write_slice_and_whitespace_pad;
 use log::*;
 use once_cell::sync::OnceCell;
 use sgx_types::sgx_status_t;

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -42,34 +42,31 @@ use crate::{
 	},
 	rpc::worker_api_direct::sidechain_io_handler,
 	utils::{
-		get_extrinsic_factory_from_integritee_solo_or_parachain,
 		get_node_metadata_repository_from_integritee_solo_or_parachain,
 		get_node_metadata_repository_from_target_a_solo_or_parachain,
-		get_node_metadata_repository_from_target_b_solo_or_parachain,
-		get_stf_enclave_signer_from_solo_or_parachain, utf8_str_from_raw, DecodeRaw,
+		get_node_metadata_repository_from_target_b_solo_or_parachain, utf8_str_from_raw, DecodeRaw,
 	},
 };
 use codec::{Decode, Encode};
 use core::ffi::c_int;
 use itc_parentchain::{block_import_dispatcher::DispatchBlockImport, primitives::ParentchainId};
 use itp_component_container::ComponentGetter;
-use itp_extrinsics_factory::CreateExtrinsics;
+
 use itp_import_queue::PushToQueue;
 use itp_node_api::metadata::{
-	pallet_enclave_bridge::EnclaveBridgeCallIndexes, provider::AccessNodeMetadata, NodeMetadata,
+	NodeMetadata,
 };
 use itp_nonce_cache::{MutateNonce, Nonce};
-use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
+
 use itp_settings::worker_mode::{ProvideWorkerMode, WorkerMode, WorkerModeProvider};
 use itp_sgx_crypto::key_repository::AccessPubkey;
 use itp_stf_interface::SHARD_CREATION_HEADER_KEY;
 use itp_stf_state_handler::{handle_state::HandleState, query_shard_state::QueryShardState};
 use itp_storage::{StorageProof, StorageProofChecker};
 use itp_types::{
-	parentchain::{AccountId, BlockNumber, Header},
-	OpaqueCall, ShardIdentifier, SignedBlock,
+	parentchain::{Header}, ShardIdentifier, SignedBlock,
 };
-use itp_utils::{hex::hex_encode, write_slice_and_whitespace_pad};
+use itp_utils::{write_slice_and_whitespace_pad};
 use log::*;
 use once_cell::sync::OnceCell;
 use sgx_types::sgx_status_t;

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -495,7 +495,7 @@ fn init_shard_creation_parentchain_header_internal(
 	state.state.insert(SHARD_CREATION_HEADER_KEY.into(), value.encode());
 	state_handler.write_after_mutation(state, state_lock, &shard)?;
 
-	shard_config::init_shard_config(shard);
+	shard_config::init_shard_config(shard)?;
 	Ok(())
 }
 

--- a/enclave-runtime/src/shard_config.rs
+++ b/enclave-runtime/src/shard_config.rs
@@ -16,47 +16,36 @@
 
 use crate::{
 	error::{Error, Result as EnclaveResult},
-	initialization::global_components::{
-		GLOBAL_OCALL_API_COMPONENT, GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT,
-		GLOBAL_STATE_HANDLER_COMPONENT,
-	},
 	utils::{
 		get_extrinsic_factory_from_integritee_solo_or_parachain,
-		get_extrinsic_factory_from_target_a_solo_or_parachain,
-		get_extrinsic_factory_from_target_b_solo_or_parachain,
-		get_node_metadata_repository_from_integritee_solo_or_parachain,
-		get_node_metadata_repository_from_target_a_solo_or_parachain,
-		get_node_metadata_repository_from_target_b_solo_or_parachain,
-		get_stf_enclave_signer_from_solo_or_parachain, DecodeRaw,
+		get_stf_enclave_signer_from_solo_or_parachain,
 	},
 };
-use codec::{Compact, Decode, Encode};
+use codec::{Encode};
 use enclave_bridge_primitives::ShardConfig;
-use itp_component_container::ComponentGetter;
+
 use itp_extrinsics_factory::CreateExtrinsics;
 use itp_node_api::{
-	api_client::{PairSignature, StaticExtrinsicSigner},
 	metadata::{
 		pallet_enclave_bridge::EnclaveBridgeCallIndexes,
-		pallet_proxy::PROXY_DEPOSIT,
-		provider::{AccessNodeMetadata, Error as MetadataProviderError},
+		provider::{AccessNodeMetadata},
 	},
 };
-use itp_node_api_metadata::pallet_proxy::ProxyCallIndexes;
-use itp_nonce_cache::NonceCache;
+
+
 use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
-use itp_sgx_crypto::key_repository::AccessKey;
-use itp_stf_interface::SHARD_VAULT_KEY;
-use itp_stf_state_handler::{handle_state::HandleState, query_shard_state::QueryShardState};
+
+
+
 use itp_types::{
-	parentchain::{AccountId, Address, BlockNumber, Header, ParentchainId, ProxyType},
+	parentchain::{AccountId, BlockNumber, ParentchainId},
 	OpaqueCall, ShardIdentifier,
 };
 use itp_utils::hex::hex_encode;
 use log::*;
-use sgx_types::sgx_status_t;
-use sp_core::crypto::{DeriveJunction, Pair};
-use std::{slice, sync::Arc, vec::Vec};
+
+
+
 use teerex_primitives::EnclaveFingerprint;
 
 pub(crate) fn init_shard_config(shard: ShardIdentifier) -> EnclaveResult<()> {

--- a/enclave-runtime/src/shard_config.rs
+++ b/enclave-runtime/src/shard_config.rs
@@ -1,0 +1,88 @@
+/*
+	Copyright 2021 Integritee AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+use crate::{
+	error::{Error, Result as EnclaveResult},
+	initialization::global_components::{
+		GLOBAL_OCALL_API_COMPONENT, GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT,
+		GLOBAL_STATE_HANDLER_COMPONENT,
+	},
+	utils::{
+		get_extrinsic_factory_from_integritee_solo_or_parachain,
+		get_extrinsic_factory_from_target_a_solo_or_parachain,
+		get_extrinsic_factory_from_target_b_solo_or_parachain,
+		get_node_metadata_repository_from_integritee_solo_or_parachain,
+		get_node_metadata_repository_from_target_a_solo_or_parachain,
+		get_node_metadata_repository_from_target_b_solo_or_parachain,
+		get_stf_enclave_signer_from_solo_or_parachain, DecodeRaw,
+	},
+};
+use codec::{Compact, Decode, Encode};
+use enclave_bridge_primitives::ShardConfig;
+use itp_component_container::ComponentGetter;
+use itp_extrinsics_factory::CreateExtrinsics;
+use itp_node_api::{
+	api_client::{PairSignature, StaticExtrinsicSigner},
+	metadata::{
+		pallet_enclave_bridge::EnclaveBridgeCallIndexes,
+		pallet_proxy::PROXY_DEPOSIT,
+		provider::{AccessNodeMetadata, Error as MetadataProviderError},
+	},
+};
+use itp_node_api_metadata::pallet_proxy::ProxyCallIndexes;
+use itp_nonce_cache::NonceCache;
+use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
+use itp_sgx_crypto::key_repository::AccessKey;
+use itp_stf_interface::SHARD_VAULT_KEY;
+use itp_stf_state_handler::{handle_state::HandleState, query_shard_state::QueryShardState};
+use itp_types::{
+	parentchain::{AccountId, Address, BlockNumber, Header, ParentchainId, ProxyType},
+	OpaqueCall, ShardIdentifier,
+};
+use itp_utils::hex::hex_encode;
+use log::*;
+use sgx_types::sgx_status_t;
+use sp_core::crypto::{DeriveJunction, Pair};
+use std::{slice, sync::Arc, vec::Vec};
+use teerex_primitives::EnclaveFingerprint;
+
+pub(crate) fn init_shard_config(shard: ShardIdentifier) -> EnclaveResult<()> {
+	trace!("Intializing shard config on integritee network");
+	let extrinsics_factory = get_extrinsic_factory_from_integritee_solo_or_parachain()?;
+	let enclave_signer = get_stf_enclave_signer_from_solo_or_parachain()?;
+	let mrenclave = enclave_signer.ocall_api.get_mrenclave_of_self()?;
+	let shard_config = ShardConfig::<AccountId>::new(EnclaveFingerprint::from(mrenclave.m));
+
+	let call = extrinsics_factory
+		.node_metadata_repository
+		.get_from_metadata(|m| m.update_shard_config_call_indexes())
+		.map_err(|e| Error::Other(e.into()))?
+		.map_err(|e| Error::Other(format!("{:?}", e).into()))?;
+
+	let opaque_call = OpaqueCall::from_tuple(&(call, shard, shard_config, BlockNumber::from(0u8)));
+	debug!("encoded call: {}", hex_encode(opaque_call.encode().as_slice()));
+	let xts = extrinsics_factory
+		.create_extrinsics(&[opaque_call], None)
+		.map_err(|e| Error::Other(e.into()))?;
+
+	info!("Initializing or touching shard config on integritee network. awaiting inclusion before continuing");
+	// this needs to be blocking because the parentchain handler may be re-initialized right after this and the extrinsic would be swallowed
+	enclave_signer
+		.ocall_api
+		.send_to_parentchain(xts, &ParentchainId::Integritee, true)
+		.map_err(|e| Error::Other(e.into()))?;
+	Ok(())
+}

--- a/enclave-runtime/src/shard_config.rs
+++ b/enclave-runtime/src/shard_config.rs
@@ -21,21 +21,15 @@ use crate::{
 		get_stf_enclave_signer_from_solo_or_parachain,
 	},
 };
-use codec::{Encode};
+use codec::Encode;
 use enclave_bridge_primitives::ShardConfig;
 
 use itp_extrinsics_factory::CreateExtrinsics;
-use itp_node_api::{
-	metadata::{
-		pallet_enclave_bridge::EnclaveBridgeCallIndexes,
-		provider::{AccessNodeMetadata},
-	},
+use itp_node_api::metadata::{
+	pallet_enclave_bridge::EnclaveBridgeCallIndexes, provider::AccessNodeMetadata,
 };
 
-
 use itp_ocall_api::{EnclaveAttestationOCallApi, EnclaveOnChainOCallApi};
-
-
 
 use itp_types::{
 	parentchain::{AccountId, BlockNumber, ParentchainId},
@@ -43,8 +37,6 @@ use itp_types::{
 };
 use itp_utils::hex::hex_encode;
 use log::*;
-
-
 
 use teerex_primitives::EnclaveFingerprint;
 

--- a/enclave-runtime/src/tls_ra/tls_ra_client.rs
+++ b/enclave-runtime/src/tls_ra/tls_ra_client.rs
@@ -248,6 +248,7 @@ pub unsafe extern "C" fn request_state_provisioning(
 		return e.into()
 	};
 
+	// fixme: this needs only be called in sidechain mode. no harm though
 	if let Err(e) = touch_shard(shard) {
 		error!("touch shard error: {:?}", e);
 		return sgx_status_t::SGX_ERROR_UNEXPECTED

--- a/enclave-runtime/src/tls_ra/tls_ra_client.rs
+++ b/enclave-runtime/src/tls_ra/tls_ra_client.rs
@@ -28,23 +28,19 @@ use crate::{
 	ocall::OcallApi,
 	shard_config::init_shard_config,
 	tls_ra::{seal_handler::SealStateAndKeys, ClientProvisioningRequest},
-	utils::{
-		get_extrinsic_factory_from_integritee_solo_or_parachain,
-		get_validator_accessor_from_integritee_solo_or_parachain,
-	},
 	GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT, GLOBAL_STATE_HANDLER_COMPONENT,
 };
 use codec::Encode;
-use itc_parentchain::light_client::{concurrent_access::ValidatorAccess, ExtrinsicSender};
+
 use itp_attestation_handler::{RemoteAttestationType, DEV_HOSTNAME};
 use itp_component_container::ComponentGetter;
-use itp_extrinsics_factory::CreateExtrinsics;
-use itp_node_api::metadata::provider::AccessNodeMetadata;
-use itp_node_api_metadata::pallet_sidechain::SidechainCallIndexes;
+
+
+
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_crypto::key_repository::AccessPubkey;
-use itp_types::{AccountId, OpaqueCall, ShardIdentifier, SidechainBlockNumber, H256};
-use itp_utils::hex::hex_encode;
+use itp_types::{AccountId, ShardIdentifier};
+
 use log::*;
 use rustls::{ClientConfig, ClientSession, Stream};
 use sgx_types::*;

--- a/enclave-runtime/src/tls_ra/tls_ra_client.rs
+++ b/enclave-runtime/src/tls_ra/tls_ra_client.rs
@@ -35,8 +35,6 @@ use codec::Encode;
 use itp_attestation_handler::{RemoteAttestationType, DEV_HOSTNAME};
 use itp_component_container::ComponentGetter;
 
-
-
 use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_sgx_crypto::key_repository::AccessPubkey;
 use itp_types::{AccountId, ShardIdentifier};

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-service"
-version = "0.12.2"
+version = "0.12.6"
 authors = ["Integritee AG <hello@integritee.network>"]
 build = "build.rs"
 edition = "2021"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -26,8 +26,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.6.1", features = ["full"] }
-warp = "0.3"
 url = "2.5.0"
+warp = "0.3"
 
 # ipfs
 ipfs-api = "0.11.0"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1.6.1", features = ["full"] }
 warp = "0.3"
-
+url = "2.5.0"
 
 # ipfs
 ipfs-api = "0.11.0"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -20,7 +20,7 @@ parking_lot = "0.12.1"
 parse_duration = "2.1.1"
 prometheus = { version = "0.13.0", features = ["process"] }
 regex = "1.9.5"
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -59,14 +59,14 @@ its-storage = { path = "../sidechain/storage" }
 
 # scs / integritee
 
-my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+my-node-runtime = { package = "integritee-node-runtime", git = "https://github.com/integritee-network/integritee-node.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 #my-node-runtime = { package = "integritee-runtime", git = "https://github.com/integritee-network/parachain.git", tag = "1.6.2" }
-sgx-verify = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+sgx-verify = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 # `default-features = false` to remove the jsonrpsee dependency.
-enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 # disable unsupported jsonrpcsee
 substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0" }
-teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.0-polkadot-v0.9.42" }
+teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.12.6-polkadot-v0.9.42" }
 
 # Substrate dependencies
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -542,6 +542,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 						&register_enclave_xt_header,
 					)
 					.unwrap();
+				debug!("shard config should be initialized on integritee network now");
 				true
 			},
 		};

--- a/service/src/tests/mocks/update_worker_peers_mock.rs
+++ b/service/src/tests/mocks/update_worker_peers_mock.rs
@@ -16,11 +16,12 @@
 */
 
 use crate::{worker::WorkerResult, worker_peers_updater::UpdateWorkerPeers};
+use itp_types::ShardIdentifier;
 
 pub struct UpdateWorkerPeersMock;
 
 impl UpdateWorkerPeers for UpdateWorkerPeersMock {
-	fn update_peers(&self) -> WorkerResult<()> {
+	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()> {
 		Ok(())
 	}
 }

--- a/service/src/worker_peers_updater.rs
+++ b/service/src/worker_peers_updater.rs
@@ -22,12 +22,13 @@ use mockall::predicate::*;
 use mockall::*;
 
 use crate::worker::{UpdatePeers, WorkerResult};
+use itp_types::ShardIdentifier;
 use std::sync::Arc;
 
 /// Updates the peers of the global worker.
 #[cfg_attr(test, automock)]
 pub trait UpdateWorkerPeers {
-	fn update_peers(&self) -> WorkerResult<()>;
+	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()>;
 }
 
 pub struct WorkerPeersUpdater<WorkerType> {
@@ -44,7 +45,7 @@ impl<WorkerType> UpdateWorkerPeers for WorkerPeersUpdater<WorkerType>
 where
 	WorkerType: UpdatePeers,
 {
-	fn update_peers(&self) -> WorkerResult<()> {
-		self.worker.update_peers()
+	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()> {
+		self.worker.update_peers(shard)
 	}
 }

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -20,6 +20,7 @@ itp-ocall-api = { path = "../../../core-primitives/ocall-api", default-features 
 itp-settings = { path = "../../../core-primitives/settings" }
 itp-sgx-crypto = { path = "../../../core-primitives/sgx/crypto", default-features = false }
 itp-types = { path = "../../../core-primitives/types", default-features = false }
+itp-utils = { path = "../../../core-primitives/utils", default-features = false }
 its-block-verification = { path = "../../block-verification", optional = true, default-features = false }
 its-primitives = { path = "../../primitives", default-features = false }
 its-state = { path = "../../state", default-features = false }
@@ -58,6 +59,7 @@ std = [
     "itp-sgx-crypto/std",
     "itp-sgx-externalities/std",
     "itp-types/std",
+    "itp-utils/std",
     "its-primitives/std",
     "its-block-verification/std",
     "its-state/std",

--- a/sidechain/primitives/Cargo.toml
+++ b/sidechain/primitives/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 itp-types = { path = "../../core-primitives/types", default-features = false }
-scale-info = { version = "2.0.1", default-features = false, features = ["derive"] }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.13", default-features = false }
 
 # substrate dependencies


### PR DESCRIPTION
closes #1524 
closes #1529

Instead of broadcasting sidechain blocks to all sovereign enclaves of any MRENCLAVE, this PR changes the behavior to restrict broadcast only to enclaves who have touched the shard before.

We hereby introduce `ShardConfig` for this, which also allows custom shards to be initiated by any enclave.
In the future, this can be extended to have more control over the validateer set for a shard.

I also sneaked in other minor things:
* reattempting shard vault creation, a first step towards #1530 
* use new node version with 6s blocktime