### PR TITLE
more robust sidechain block import logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3776,6 +3776,7 @@ dependencies = [
  "fork-tree",
  "itc-parentchain-light-client",
  "itc-parentchain-test",
+ "itertools 0.10.5",
  "itp-extrinsics-factory",
  "itp-import-queue",
  "itp-node-api-metadata",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2468,6 +2468,7 @@ version = "0.9.0"
 dependencies = [
  "fork-tree",
  "itc-parentchain-light-client",
+ "itertools 0.10.5",
  "itp-extrinsics-factory",
  "itp-import-queue",
  "itp-node-api-metadata",

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -52,7 +52,7 @@ std = [
     "thiserror",
     # local
     "itc-parentchain-light-client/std",
-    "itertools/std",
+    "itertools/use_std",
     "itp-import-queue/std",
     "itp-extrinsics-factory/std",
     "itp-node-api-metadata/std",

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+itertools = { version = "0.10.1", default-features = false, features = ["use_alloc"] }
 log = { version = "0.4", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
-itertools = { version = "0.10.1", default-features = false, features = ["use_alloc"] }
 
 # local deps
 fork-tree = { path = "../../fork-tree", default-features = false }

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 log = { version = "0.4", default-features = false }
 thiserror = { version = "1.0.26", optional = true }
+itertools = { version = "0.10.1", default-features = false, features = ["use_alloc"] }
 
 # local deps
 fork-tree = { path = "../../fork-tree", default-features = false }
@@ -51,6 +52,7 @@ std = [
     "thiserror",
     # local
     "itc-parentchain-light-client/std",
+    "itertools/std",
     "itp-import-queue/std",
     "itp-extrinsics-factory/std",
     "itp-node-api-metadata/std",

--- a/sidechain/consensus/common/src/block_import_queue_worker.rs
+++ b/sidechain/consensus/common/src/block_import_queue_worker.rs
@@ -17,11 +17,15 @@
 
 use crate::{Error, Result, SyncBlockFromPeer};
 use core::marker::PhantomData;
-use itp_import_queue::PopFromQueue;
-use its_primitives::traits::{Block as BlockTrait, SignedBlock as SignedSidechainBlockTrait};
-use log::debug;
+use itertools::Itertools;
+use itp_import_queue::{PeekQueue, PopFromQueue};
+use itp_types::SidechainBlockNumber;
+use its_primitives::traits::{
+	Block as BlockTrait, Header, SignedBlock as SignedSidechainBlockTrait,
+};
+use log::{debug, trace};
 use sp_runtime::traits::Block as ParentchainBlockTrait;
-use std::{sync::Arc, time::Instant};
+use std::{sync::Arc, time::Instant, vec::Vec};
 
 /// Trait to trigger working the sidechain block import queue.
 pub trait ProcessBlockImportQueue<ParentchainBlockHeader> {
@@ -49,7 +53,7 @@ where
 	ParentchainBlock: ParentchainBlockTrait,
 	SignedSidechainBlock: SignedSidechainBlockTrait,
 	SignedSidechainBlock::Block: BlockTrait,
-	BlockImportQueue: PopFromQueue<ItemType = SignedSidechainBlock>,
+	BlockImportQueue: PopFromQueue<ItemType = SignedSidechainBlock> + PeekQueue,
 	PeerBlockSyncer: SyncBlockFromPeer<ParentchainBlock::Header, SignedSidechainBlock>,
 {
 	pub fn new(
@@ -85,7 +89,7 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 	ParentchainBlock: ParentchainBlockTrait,
 	SignedSidechainBlock: SignedSidechainBlockTrait,
 	SignedSidechainBlock::Block: BlockTrait,
-	BlockImportQueue: PopFromQueue<ItemType = SignedSidechainBlock>,
+	BlockImportQueue: PopFromQueue<ItemType = SignedSidechainBlock> + PeekQueue,
 	PeerBlockSyncer: SyncBlockFromPeer<ParentchainBlock::Header, SignedSidechainBlock>,
 {
 	fn process_queue(
@@ -96,25 +100,44 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 		let mut number_of_imported_blocks = 0usize;
 		let start_time = Instant::now();
 
-		loop {
-			match self.block_import_queue.pop_front() {
-				Ok(maybe_block) => match maybe_block {
-					Some(block) => {
-						latest_imported_parentchain_header = self
-							.peer_block_syncer
-							.sync_block(block, &latest_imported_parentchain_header)?;
-						number_of_imported_blocks += 1;
-					},
-					None => {
-						Self::record_timings(start_time, number_of_imported_blocks);
-						return Ok(latest_imported_parentchain_header)
-					},
-				},
-				Err(e) => {
-					Self::record_timings(start_time, number_of_imported_blocks);
-					return Err(Error::FailedToPopBlockImportQueue(e))
-				},
-			}
+		trace!(
+			"processing import queue with {:?} sidechain blocks",
+			self.block_import_queue.peek_queue_size()
+		);
+
+		if let Ok(candidates) = self.block_import_queue.pop_all() {
+			let mut sorted_candidates = candidates
+				.iter()
+				.map(|b| (b.block().header().block_number(), b))
+				.collect::<Vec<(SidechainBlockNumber, &SignedSidechainBlock)>>();
+			sorted_candidates.sort_by(|a, b| a.0.cmp(&b.0));
+			let imported_blocks: Vec<&SignedSidechainBlock> = sorted_candidates
+				.iter()
+				.group_by(|&a| a.0)
+				.into_iter()
+				.filter_map(|(block_number, competitors)| {
+					let mut competitors: Vec<&SignedSidechainBlock> =
+						competitors.map(|&c| c.1).collect();
+					// deterministic import order decreases chances for forks
+					competitors.sort_by(|a, b| a.block().hash().cmp(&b.block().hash()));
+					trace!("nr of competitors for block {}: {}", block_number, competitors.len());
+					let mut winner = None;
+					for block in competitors {
+						if let Ok(parentchain_header) = self.peer_block_syncer.import_or_sync_block(
+							block.clone(),
+							&latest_imported_parentchain_header,
+						) {
+							latest_imported_parentchain_header = parentchain_header;
+							winner = Some(block);
+							break
+						};
+					}
+					winner
+				})
+				.collect();
+			number_of_imported_blocks = imported_blocks.len();
 		}
+		Self::record_timings(start_time, number_of_imported_blocks);
+		return Ok(latest_imported_parentchain_header)
 	}
 }

--- a/sidechain/consensus/common/src/block_import_queue_worker.rs
+++ b/sidechain/consensus/common/src/block_import_queue_worker.rs
@@ -96,7 +96,6 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 		current_parentchain_header: &ParentchainBlock::Header,
 	) -> Result<ParentchainBlock::Header> {
 		let mut latest_imported_parentchain_header = current_parentchain_header.clone();
-		let mut number_of_imported_blocks = 0usize;
 		let start_time = Instant::now();
 
 		trace!(
@@ -104,7 +103,7 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 			self.block_import_queue.peek_queue_size()
 		);
 
-		number_of_imported_blocks = self
+		let number_of_imported_blocks = self
 			.block_import_queue
 			.pop_all()?
 			.iter()
@@ -124,9 +123,9 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 					self.peer_block_syncer
 						.import_or_sync_block(block.clone(), &latest_imported_parentchain_header)
 						.ok()
-						.and_then(|parentchain_header| {
+						.map(|parentchain_header| {
 							latest_imported_parentchain_header = parentchain_header;
-							Some(block)
+							block
 						})
 				})
 			})

--- a/sidechain/consensus/common/src/block_import_queue_worker.rs
+++ b/sidechain/consensus/common/src/block_import_queue_worker.rs
@@ -15,7 +15,7 @@
 
 */
 
-use crate::{Error, Result, SyncBlockFromPeer};
+use crate::{Result, SyncBlockFromPeer};
 use core::marker::PhantomData;
 use itertools::Itertools;
 use itp_import_queue::{PeekQueue, PopFromQueue};
@@ -111,7 +111,7 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 				.map(|b| (b.block().header().block_number(), b))
 				.collect::<Vec<(SidechainBlockNumber, &SignedSidechainBlock)>>();
 			sorted_candidates.sort_by(|a, b| a.0.cmp(&b.0));
-			let imported_blocks: Vec<&SignedSidechainBlock> = sorted_candidates
+			number_of_imported_blocks = sorted_candidates
 				.iter()
 				.group_by(|&a| a.0)
 				.into_iter()
@@ -134,10 +134,9 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 					}
 					winner
 				})
-				.collect();
-			number_of_imported_blocks = imported_blocks.len();
+				.count();
 		}
 		Self::record_timings(start_time, number_of_imported_blocks);
-		return Ok(latest_imported_parentchain_header)
+		Ok(latest_imported_parentchain_header)
 	}
 }

--- a/sidechain/consensus/common/src/block_import_queue_worker.rs
+++ b/sidechain/consensus/common/src/block_import_queue_worker.rs
@@ -110,7 +110,7 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 				.iter()
 				.map(|b| (b.block().header().block_number(), b))
 				.collect::<Vec<(SidechainBlockNumber, &SignedSidechainBlock)>>();
-			sorted_candidates.sort_by(|a, b| a.0.cmp(&b.0));
+			sorted_candidates.sort_by_key(|a| a.0);
 			number_of_imported_blocks = sorted_candidates
 				.iter()
 				.group_by(|&a| a.0)
@@ -119,7 +119,7 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 					let mut competitors: Vec<&SignedSidechainBlock> =
 						competitors.map(|&c| c.1).collect();
 					// deterministic import order decreases chances for forks
-					competitors.sort_by(|a, b| a.block().hash().cmp(&b.block().hash()));
+					competitors.sort_by_key(|a| a.block().hash());
 					trace!("nr of competitors for block {}: {}", block_number, competitors.len());
 					let mut winner = None;
 					for block in competitors {

--- a/sidechain/consensus/common/src/block_import_queue_worker.rs
+++ b/sidechain/consensus/common/src/block_import_queue_worker.rs
@@ -104,36 +104,34 @@ impl<ParentchainBlock, SignedSidechainBlock, BlockImportQueue, PeerBlockSyncer>
 			self.block_import_queue.peek_queue_size()
 		);
 
-		if let Ok(candidates) = self.block_import_queue.pop_all() {
-			number_of_imported_blocks = candidates
-				.iter()
-				.map(|b| (b.block().header().block_number(), b))
-				.sorted_by_key(|a| a.0)
-				.group_by(|&a| a.0)
-				.into_iter()
-				.filter_map(|(block_number, competitors)| {
-					let mut competitors: Vec<&SignedSidechainBlock> =
-						competitors.map(|c| c.1).collect();
-					// deterministic import order decreases chances for forks
-					competitors.sort_by_key(|a| a.block().hash());
-					trace!("nr of competitors for block {}: {}", block_number, competitors.len());
+		number_of_imported_blocks = self
+			.block_import_queue
+			.pop_all()?
+			.iter()
+			.map(|b| (b.block().header().block_number(), b))
+			.sorted_by_key(|a| a.0)
+			.group_by(|&a| a.0)
+			.into_iter()
+			.filter_map(|(block_number, competitors)| {
+				let mut competitors: Vec<&SignedSidechainBlock> =
+					competitors.map(|c| c.1).collect();
+				// deterministic import order decreases chances for forks
+				competitors.sort_by_key(|a| a.block().hash());
+				trace!("nr of competitors for block {}: {}", block_number, competitors.len());
 
-					// returns the first block satisfying the predicate
-					competitors.into_iter().find_map(|block| {
-						self.peer_block_syncer
-							.import_or_sync_block(
-								block.clone(),
-								&latest_imported_parentchain_header,
-							)
-							.ok()
-							.and_then(|parentchain_header| {
-								latest_imported_parentchain_header = parentchain_header;
-								Some(block)
-							})
-					})
+				// returns the first block satisfying the predicate
+				competitors.into_iter().find_map(|block| {
+					self.peer_block_syncer
+						.import_or_sync_block(block.clone(), &latest_imported_parentchain_header)
+						.ok()
+						.and_then(|parentchain_header| {
+							latest_imported_parentchain_header = parentchain_header;
+							Some(block)
+						})
 				})
-				.count();
-		}
+			})
+			.count();
+
 		Self::record_timings(start_time, number_of_imported_blocks);
 		Ok(latest_imported_parentchain_header)
 	}

--- a/sidechain/consensus/common/src/lib.rs
+++ b/sidechain/consensus/common/src/lib.rs
@@ -27,7 +27,6 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[macro_use]
 extern crate sgx_tstd as std;
 extern crate alloc;
-extern crate core;
 
 use its_primitives::traits::{ShardIdentifierFor, SignedBlock as SignedSidechainBlockTrait};
 use sp_runtime::traits::Block as ParentchainBlockTrait;

--- a/sidechain/consensus/common/src/lib.rs
+++ b/sidechain/consensus/common/src/lib.rs
@@ -26,6 +26,8 @@ compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the sam
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 #[macro_use]
 extern crate sgx_tstd as std;
+extern crate alloc;
+extern crate core;
 
 use its_primitives::traits::{ShardIdentifierFor, SignedBlock as SignedSidechainBlockTrait};
 use sp_runtime::traits::Block as ParentchainBlockTrait;

--- a/sidechain/consensus/slots/src/lib.rs
+++ b/sidechain/consensus/slots/src/lib.rs
@@ -296,7 +296,7 @@ pub trait SimpleSlotWorker<ParentchainBlock: ParentchainBlockTrait> {
 			},
 		};
 		trace!(
-			"on_slot: a posteriori latest Integritee block number: {:?}",
+			"on_slot: a posteriori latest Integritee block number (if there is a new one): {:?}",
 			last_imported_integritee_header.clone().map(|h| *h.number())
 		);
 


### PR DESCRIPTION
closes #1544 

* sort queue by sidechain block number
* group blocks with same number and sort them by hash (deterministic ordering less likely to produce forks - compared to "prefer self-authored block")
* attempt to import in order and ignore failures, just try next candidate

the goal here is: even if a fork happens, each fork should continue producing blocks. Only then can finality be established on L1 and orphans can reliably be identified