### PR TITLE
fix CI if uncached

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -43,7 +43,7 @@ ENV WORKHOME=/home/ubuntu/work
 ENV HOME=/home/ubuntu
 
 RUN rustup default stable
-RUN cargo install sccache --locked
+RUN cargo install --version 0.4.1 sccache --locked
 
 ENV SCCACHE_CACHE_SIZE="20G"
 ENV SCCACHE_DIR=$HOME/.cache/sccache


### PR DESCRIPTION
in the case where the docker building stage isn't cached on the builder, we need to pin sccache explicitly or it will complain about outdated rustc verison