### PR TITLE
Support the `CheckMetadataHash` signed extension

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -257,7 +257,7 @@ jobs:
   integration-tests:
     runs-on: ${{ matrix.host }}
     if: ${{ always() }}
-    needs: [build-test, build-client]
+    needs: [ build-test, build-client ]
     env:
       WORKER_IMAGE_TAG: integritee-worker:dev
       CLIENT_IMAGE_TAG: integritee-cli:dev
@@ -290,11 +290,11 @@ jobs:
             demo_name: demo-shielding-unshielding-multiworker
             host: test-runner-sgx
             sgx_mode: HW
-#          - test: Teeracle
-#            flavor_id: teeracle
-#            demo_name: demo-teeracle
-#            host: test-runner-sgx
-#            sgx_mode: HW
+          #          - test: Teeracle
+          #            flavor_id: teeracle
+          #            demo_name: demo-teeracle
+          #            host: test-runner-sgx
+          #            sgx_mode: HW
           - test: Teeracle
             flavor_id: teeracle
             demo_name: demo-teeracle-generic
@@ -323,7 +323,7 @@ jobs:
           echo "PROJECT=${{ matrix.flavor_id }}-${{ matrix.demo_name }}" >> $GITHUB_ENV
           echo "VERSION=dev.$version" >> $GITHUB_ENV
           echo "WORKER_IMAGE_TAG=integritee-worker:dev.$version" >> $GITHUB_ENV
-          echo "INTEGRITEE_NODE=integritee-node:1.1.6.$version" >> $GITHUB_ENV
+          echo "INTEGRITEE_NODE=integritee-node:1.13.0.$version" >> $GITHUB_ENV
           echo "CLIENT_IMAGE_TAG=integritee-cli:dev.$version" >> $GITHUB_ENV
           if [[ ${{ matrix.sgx_mode }} == 'HW' ]]; then
              echo "SGX_PROVISION=/dev/sgx/provision" >> $GITHUB_ENV
@@ -368,8 +368,8 @@ jobs:
           fi
           docker tag integritee-worker-${{ env.IMAGE_SUFFIX }} ${{ env.WORKER_IMAGE_TAG }}
           docker tag integritee-cli-client-${{ env.IMAGE_SUFFIX }} ${{ env.CLIENT_IMAGE_TAG }}
-          docker pull integritee/integritee-node:1.1.6
-          docker tag integritee/integritee-node:1.1.6 ${{ env.INTEGRITEE_NODE }}
+          docker pull integritee/integritee-node:1.13.0
+          docker tag integritee/integritee-node:1.13.0 ${{ env.INTEGRITEE_NODE }}
           docker images --all
 
       ##

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "ac-primitives",
  "log 0.4.20",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -7709,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7747,7 +7747,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.9.1"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",

--- a/app-libs/parentchain-interface/Cargo.toml
+++ b/app-libs/parentchain-interface/Cargo.toml
@@ -25,7 +25,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 log = { version = "0.4", default-features = false }
 regex = { optional = true, version = "1.9.5" }
 
-substrate-api-client = { optional = true, default-features = false, features = ["std", "sync-api"], git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
+substrate-api-client = { optional = true, default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 # substrate dep
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,8 +36,8 @@ teeracle-primitives = { git = "https://github.com/integritee-network/pallets.git
 
 # `default-features = false` to remove the jsonrpsee dependency.
 # disable unsupported jsonrpcsee
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
-substrate-client-keystore = { git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-client-keystore = { git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 # substrate dependencies
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/core-primitives/extrinsics-factory/Cargo.toml
+++ b/core-primitives/extrinsics-factory/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 # local dependencies
 itp-node-api = { path = "../node-api", default-features = false }

--- a/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -13,7 +13,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "po
 
 # scs
 # `default-features = false` to remove the jsonrpsee dependency.
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 # local deps
 itp-api-client-types = { path = "../api-client-types" }

--- a/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/core-primitives/node-api/api-client-types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 itp-types = { default-features = false, path = "../../types" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 [features]
 default = ["std"]

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -17,7 +17,7 @@ itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-fe
 itp-utils = { path = "../../core-primitives/utils", default-features = false }
 
 # scs
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 # substrate-deps
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   "integritee-node-${VERSION}":
-    image: "${INTEGRITEE_NODE:-integritee/integritee-node:1.1.6}"
+    image: "${INTEGRITEE_NODE:-integritee/integritee-node:1.13.0}"
     hostname: integritee-node
     devices:
       - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"
@@ -15,7 +15,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 6
-    command: -lruntime=info -lteerex=debug --dev --rpc-methods unsafe --ws-external --rpc-external --ws-port 9912
+    command: -lruntime=info -lteerex=debug --dev --rpc-methods unsafe --rpc-external --rpc-port 9912
     #logging:
     #driver: local
   "integritee-worker-1-${VERSION}":

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "ac-primitives",
  "log",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -4404,7 +4404,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/brenzi/substrate-api-client.git?branch=polkadot-v0.9.42-tag-v0.14.0-retracted#d01bc07fe0c8a8db1451d0d5c8bf82493b274d80"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",

--- a/local-setup/config/benchmark.json
+++ b/local-setup/config/benchmark.json
@@ -7,13 +7,10 @@
         "--dev",
         "-lruntime=info",
         "-lteerex=debug",
-        "--ws-port",
-        "9944",
         "--port",
         "30390",
         "--rpc-port",
-        "9933",
-        "--ws-external",
+        "9944",
         "--rpc-external"
       ]
     }

--- a/local-setup/config/one-worker.json
+++ b/local-setup/config/one-worker.json
@@ -7,13 +7,10 @@
         "--dev",
         "-lruntime=info",
         "-lteerex=debug",
-        "--ws-port",
-        "9944",
         "--port",
         "30390",
         "--rpc-port",
-        "9933",
-        "--ws-external",
+        "9944",
         "--rpc-external"
       ]
     }

--- a/local-setup/config/three-nodes-one-worker.json
+++ b/local-setup/config/three-nodes-one-worker.json
@@ -7,13 +7,10 @@
         "--dev",
         "-lruntime=info",
         "-lteerex=debug",
-        "--ws-port",
-        "9944",
         "--port",
         "30390",
         "--rpc-port",
-        "9933",
-        "--ws-external",
+        "9944",
         "--rpc-external"
       ]
     },

--- a/local-setup/config/two-workers.json
+++ b/local-setup/config/two-workers.json
@@ -7,13 +7,10 @@
         "--dev",
         "-lruntime=info",
         "-lteerex=debug",
-        "--ws-port",
-        "9944",
         "--port",
         "30390",
         "--rpc-port",
-        "9933",
-        "--ws-external",
+        "9944",
         "--rpc-external"
       ]
     }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -65,7 +65,7 @@ sgx-verify = { git = "https://github.com/integritee-network/pallets.git", branch
 # `default-features = false` to remove the jsonrpsee dependency.
 enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 # disable unsupported jsonrpcsee
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/brenzi/substrate-api-client.git", branch = "polkadot-v0.9.42-tag-v0.14.0-retracted" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 
 # Substrate dependencies


### PR DESCRIPTION
Very simple PR that bumps the api-client and the integritee-test-node to a version supporting the `CheckMetadataHash` signed extension.

Note: This breaks the compatibility with nodes that don't have this signed extension. However, we deemed this to be reasonable, as probably every substrate chain wants this. Additionally, supporting a generic signed extension is on the roadmap for the future for the worker anyhow.