### PR TITLE
move pallet parentchain into this repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,8 +5156,8 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.11.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.13.0-polkadot-v0.9.42#abf29acd41a0fca9cd7025b297b6a9fa272a122f"
 dependencies = [
+ "env_logger 0.9.3",
  "frame-support",
  "frame-system",
  "log 0.4.20",
@@ -5167,6 +5167,7 @@ dependencies = [
  "serde 1.0.193",
  "sp-core",
  "sp-io 7.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42)",
+ "sp-keyring",
  "sp-runtime",
  "sp-std",
 ]

--- a/app-libs/sgx-runtime/Cargo.toml
+++ b/app-libs/sgx-runtime/Cargo.toml
@@ -13,6 +13,7 @@ scale-info = { version = "2.10.0", default-features = false, features = ["derive
 
 # local dependencies
 itp-sgx-runtime-primitives = { path = "../../core-primitives/sgx-runtime-primitives", default-features = false }
+pallet-parentchain = { default-features = false, path = "pallets/parentchain" }
 
 # Substrate dependencies
 frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
@@ -30,7 +31,6 @@ sp-version = { default-features = false, git = "https://github.com/paritytech/su
 
 # Integritee dependencies
 pallet-evm = { default-features = false, optional = true, git = "https://github.com/integritee-network/frontier.git", branch = "bar/polkadot-v0.9.42" }
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 
 [features]
 default = ["std"]

--- a/app-libs/sgx-runtime/pallets/parentchain/Cargo.toml
+++ b/app-libs/sgx-runtime/pallets/parentchain/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "pallet-parentchain"
+description = "The remote attestation registry and verification pallet for integritee blockchains and parachains"
+version = "0.11.0"
+authors = ["Integritee AG <hello@integritee.network>"]
+homepage = "https://integritee.network/"
+repository = "https://github.com/integritee-network/pallets/"
+license = "Apache-2.0"
+edition = "2021"
+
+[dependencies]
+codec = { version = "3.0.0", default-features = false, features = ["derive"], package = "parity-scale-codec" }
+log = { version = "0.4.14", default-features = false }
+scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.13", features = ["derive"], optional = true }
+
+# substrate dependencies
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
+[dev-dependencies]
+env_logger = "0.9.0"
+sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "log/std",
+    "scale-info/std",
+    "serde",
+    # substrate dependencies
+    "frame-support/std",
+    "frame-system/std",
+    "pallet-balances/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+]
+
+try-runtime = ["frame-support/try-runtime"]

--- a/app-libs/sgx-runtime/pallets/parentchain/src/lib.rs
+++ b/app-libs/sgx-runtime/pallets/parentchain/src/lib.rs
@@ -1,0 +1,231 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+/// Index/Nonce type for parentchain runtime
+type ParentchainIndex = u32;
+/// Balance type for parentchain runtime
+type ParentchainBalance = u128;
+/// AccountData type for parentchain runtime
+type ParentchainAccountData = pallet_balances::AccountData<ParentchainBalance>;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use crate::{weights::WeightInfo, ParentchainAccountData, ParentchainIndex};
+	use frame_support::{pallet_prelude::*, sp_runtime::traits::Header};
+	use frame_system::{pallet_prelude::*, AccountInfo};
+	use sp_runtime::traits::{AtLeast32Bit, Scale};
+
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
+
+	/// Configuration trait.
+	#[pallet::config]
+	pub trait Config<I: 'static = ()>: frame_system::Config {
+		type RuntimeEvent: From<Event<Self, I>>
+			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
+		type WeightInfo: WeightInfo;
+
+		/// Type used for expressing timestamp.
+		type Moment: Parameter
+			+ Default
+			+ AtLeast32Bit
+			+ Scale<Self::BlockNumber, Output = Self::Moment>
+			+ Copy
+			+ MaxEncodedLen
+			+ scale_info::StaticTypeInfo;
+	}
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config<I>, I: 'static = ()> {
+		/// a parentchain block has been registered
+		SetBlock {
+			block_number: T::BlockNumber,
+			parent_hash: T::Hash,
+			block_hash: T::Hash,
+		},
+		SetCreationBlock {
+			block_number: T::BlockNumber,
+			block_hash: T::Hash,
+		},
+		ShardVaultInitialized {
+			account: T::AccountId,
+		},
+		AccountInfoForcedFor {
+			account: T::AccountId,
+		},
+		ParentchainGenesisInitialized {
+			hash: T::Hash,
+		},
+	}
+
+	#[pallet::error]
+	pub enum Error<T, I = ()> {
+		/// Sahrd vault has been previously initialized and can't be overwritten
+		ShardVaultAlreadyInitialized,
+		/// Parentchain genesis hash has already been initialized and can^t be overwritten
+		GenesisAlreadyInitialized,
+	}
+
+	/// The parentchain mirror of full account information for a particular account ID.
+	#[pallet::storage]
+	#[pallet::getter(fn account)]
+	pub type Account<T: Config<I>, I: 'static = ()> = StorageMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId,
+		AccountInfo<ParentchainIndex, ParentchainAccountData>,
+		ValueQuery,
+	>;
+
+	/// The current block number being processed. Set by `set_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn shard_vault)]
+	pub(super) type ShardVault<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::AccountId, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn parentchain_genesis_hash)]
+	pub(super) type ParentchainGenesisHash<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::Hash, OptionQuery>;
+
+	/// The current block number being processed. Set by `set_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn block_number)]
+	pub(super) type Number<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::BlockNumber, OptionQuery>;
+
+	/// The current block timestamp. Set by `set_now`.
+	/// this is not guaranteed by the pallet to be consistent with block_number or hash
+	#[pallet::storage]
+	#[pallet::getter(fn now)]
+	pub(super) type Now<T: Config<I>, I: 'static = ()> = StorageValue<_, T::Moment, OptionQuery>;
+
+	/// Hash of the previous block. Set by `set_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn parent_hash)]
+	pub(super) type ParentHash<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::Hash, OptionQuery>;
+
+	/// Hash of the last block. Set by `set_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn block_hash)]
+	pub(super) type BlockHash<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::Hash, OptionQuery>;
+
+	/// Hash of the shard creation block. Set by `set_creation_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn creation_block_hash)]
+	pub(super) type CreationBlockHash<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::Hash, OptionQuery>;
+
+	/// The creation block number. Set by `set_creation_block`.
+	#[pallet::storage]
+	#[pallet::getter(fn creation_block_number)]
+	pub(super) type CreationBlockNumber<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::BlockNumber, OptionQuery>;
+
+	/// The creation block timestamp. Set by `set_creation_timestamp`.
+	#[pallet::storage]
+	#[pallet::getter(fn creation_timestamp)]
+	pub(super) type CreationTimestamp<T: Config<I>, I: 'static = ()> =
+		StorageValue<_, T::Moment, OptionQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config<I>, I: 'static> Hooks<BlockNumberFor<T>> for Pallet<T, I> {}
+
+	#[pallet::call]
+	impl<T: Config<I>, I: 'static> Pallet<T, I> {
+		#[pallet::call_index(0)]
+		#[pallet::weight(T::WeightInfo::set_block())]
+		pub fn set_block(origin: OriginFor<T>, header: T::Header) -> DispatchResult {
+			ensure_root(origin)?;
+			<Number<T, I>>::put(header.number());
+			<ParentHash<T, I>>::put(header.parent_hash());
+			<BlockHash<T, I>>::put(header.hash());
+			Self::deposit_event(Event::SetBlock {
+				block_number: *header.number(),
+				parent_hash: *header.parent_hash(),
+				block_hash: header.hash(),
+			});
+			Ok(())
+		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight(T::WeightInfo::init_shard_vault())]
+		pub fn init_shard_vault(origin: OriginFor<T>, account: T::AccountId) -> DispatchResult {
+			ensure_root(origin)?;
+			ensure!(Self::shard_vault().is_none(), Error::<T, I>::ShardVaultAlreadyInitialized);
+			<ShardVault<T, I>>::put(account.clone());
+			Self::deposit_event(Event::ShardVaultInitialized { account });
+			Ok(())
+		}
+
+		#[pallet::call_index(2)]
+		#[pallet::weight(T::WeightInfo::init_parentchain_genesis_hash())]
+		pub fn init_parentchain_genesis_hash(
+			origin: OriginFor<T>,
+			genesis: T::Hash,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			ensure!(
+				Self::parentchain_genesis_hash().is_none(),
+				Error::<T, I>::GenesisAlreadyInitialized
+			);
+			<ParentchainGenesisHash<T, I>>::put(genesis);
+			Self::deposit_event(Event::ParentchainGenesisInitialized { hash: genesis });
+			Ok(())
+		}
+
+		#[pallet::call_index(3)]
+		#[pallet::weight(T::WeightInfo::force_account_info())]
+		pub fn force_account_info(
+			origin: OriginFor<T>,
+			account: T::AccountId,
+			account_info: AccountInfo<ParentchainIndex, ParentchainAccountData>,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			<crate::pallet::Account<T, I>>::insert(&account, account_info);
+			Self::deposit_event(crate::pallet::Event::AccountInfoForcedFor { account });
+			Ok(())
+		}
+
+		#[pallet::call_index(4)]
+		#[pallet::weight(T::WeightInfo::set_now())]
+		pub fn set_now(origin: OriginFor<T>, now: T::Moment) -> DispatchResult {
+			ensure_root(origin)?;
+			<Now<T, I>>::put(now);
+			Ok(())
+		}
+		#[pallet::call_index(5)]
+		#[pallet::weight(T::WeightInfo::set_creation_block())]
+		pub fn set_creation_block(origin: OriginFor<T>, header: T::Header) -> DispatchResult {
+			ensure_root(origin)?;
+			<CreationBlockNumber<T, I>>::put(header.number());
+			<CreationBlockHash<T, I>>::put(header.hash());
+			Self::deposit_event(Event::SetCreationBlock {
+				block_number: *header.number(),
+				block_hash: header.hash(),
+			});
+			Ok(())
+		}
+
+		#[pallet::call_index(6)]
+		#[pallet::weight(T::WeightInfo::set_creation_timestamp())]
+		pub fn set_creation_timestamp(origin: OriginFor<T>, creation: T::Moment) -> DispatchResult {
+			ensure_root(origin)?;
+			<CreationTimestamp<T, I>>::put(creation);
+			Ok(())
+		}
+	}
+}
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+pub mod weights;

--- a/app-libs/sgx-runtime/pallets/parentchain/src/mock.rs
+++ b/app-libs/sgx-runtime/pallets/parentchain/src/mock.rs
@@ -1,0 +1,139 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate as pallet_parentchain;
+use frame_support::parameter_types;
+use frame_system as system;
+use pallet_parentchain::Config;
+use sp_core::H256;
+use sp_keyring::AccountKeyring;
+use sp_runtime::{
+	generic,
+	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
+};
+
+pub type Signature = sp_runtime::MultiSignature;
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
+
+pub type BlockNumber = u32;
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+pub type Block = generic::Block<Header, UncheckedExtrinsic>;
+pub type UncheckedExtrinsic =
+	generic::UncheckedExtrinsic<Address, RuntimeCall, Signature, SignedExtra>;
+
+pub type SignedExtra = (
+	frame_system::CheckSpecVersion<Test>,
+	frame_system::CheckTxVersion<Test>,
+	frame_system::CheckGenesis<Test>,
+	frame_system::CheckEra<Test>,
+	frame_system::CheckNonce<Test>,
+	frame_system::CheckWeight<Test>,
+);
+
+frame_support::construct_runtime!(
+	pub enum Test where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Config<T>, Event<T>},
+		ParentchainIntegritee: pallet_parentchain::<Instance1>::{Pallet, Call, Event<T>},
+		ParentchainTargetA: pallet_parentchain::<Instance2>::{Pallet, Call, Event<T>},
+	}
+);
+
+pub type ParentchainInstanceIntegritee = pallet_parentchain::Instance1;
+impl Config<ParentchainInstanceIntegritee> for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type Moment = u64;
+}
+
+pub type ParentchainInstanceTargetA = pallet_parentchain::Instance2;
+impl Config<crate::mock::ParentchainInstanceTargetA> for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = ();
+	type Moment = u64;
+}
+
+parameter_types! {
+	pub const BlockHashCount: u32 = 250;
+}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Index = u64;
+	type RuntimeCall = RuntimeCall;
+	type BlockNumber = BlockNumber;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ();
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+pub type Balance = u64;
+
+parameter_types! {
+	pub const ExistentialDeposit: u64 = 1;
+}
+
+impl pallet_balances::Config for Test {
+	type MaxLocks = ();
+	type Balance = u64;
+	type DustRemoval = ();
+	type RuntimeEvent = RuntimeEvent;
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = ();
+	type HoldIdentifier = ();
+	type FreezeIdentifier = ();
+	type MaxHolds = ();
+	type MaxFreezes = ();
+}
+
+// This function basically just builds a genesis storage key/value store according to
+// our desired mockup. RA from enclave compiled in debug mode is allowed
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	pallet_balances::GenesisConfig::<Test> {
+		balances: vec![(AccountKeyring::Alice.to_account_id(), 1 << 60)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+	let mut ext: sp_io::TestExternalities = t.into();
+	ext.execute_with(|| System::set_block_number(1));
+	ext
+}

--- a/app-libs/sgx-runtime/pallets/parentchain/src/tests.rs
+++ b/app-libs/sgx-runtime/pallets/parentchain/src/tests.rs
@@ -1,0 +1,222 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate::{mock::*, Error, Event as ParentchainEvent};
+use frame_support::{assert_err, assert_noop, assert_ok};
+use frame_system::AccountInfo;
+use pallet_balances::AccountData;
+use sp_core::H256;
+use sp_keyring::AccountKeyring;
+use sp_runtime::{
+	generic,
+	traits::{BlakeTwo256, Header as HeaderT},
+	DispatchError::BadOrigin,
+};
+
+pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
+
+#[test]
+fn verify_storage_works() {
+	let block_number = 3;
+	let parent_hash = H256::from_low_u64_be(420);
+
+	let header: Header = HeaderT::new(
+		block_number,
+		Default::default(),
+		Default::default(),
+		parent_hash,
+		Default::default(),
+	);
+	let hash = header.hash();
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(ParentchainIntegritee::set_block(RuntimeOrigin::root(), header));
+		assert_eq!(ParentchainIntegritee::block_number().unwrap(), block_number);
+		assert_eq!(ParentchainIntegritee::parent_hash().unwrap(), parent_hash);
+		assert_eq!(ParentchainIntegritee::block_hash().unwrap(), hash);
+
+		System::assert_last_event(RuntimeEvent::ParentchainIntegritee(
+			ParentchainEvent::SetBlock { block_number, parent_hash, block_hash: hash },
+		));
+	})
+}
+
+#[test]
+fn multi_pallet_instance_storage_works() {
+	let block_number = 3;
+	let parent_hash = H256::from_low_u64_be(420);
+
+	let header: Header = HeaderT::new(
+		block_number,
+		Default::default(),
+		Default::default(),
+		parent_hash,
+		Default::default(),
+	);
+	let hash = header.hash();
+
+	let block_number_a = 5;
+	let parent_hash_a = H256::from_low_u64_be(421);
+
+	let header_a: Header = HeaderT::new(
+		block_number_a,
+		Default::default(),
+		Default::default(),
+		parent_hash_a,
+		Default::default(),
+	);
+	let hash_a = header_a.hash();
+
+	new_test_ext().execute_with(|| {
+		assert_ok!(ParentchainIntegritee::set_block(RuntimeOrigin::root(), header));
+		assert_eq!(ParentchainIntegritee::block_number().unwrap(), block_number);
+		assert_eq!(ParentchainIntegritee::parent_hash().unwrap(), parent_hash);
+		assert_eq!(ParentchainIntegritee::block_hash().unwrap(), hash);
+
+		System::assert_last_event(RuntimeEvent::ParentchainIntegritee(
+			ParentchainEvent::SetBlock { block_number, parent_hash, block_hash: hash },
+		));
+
+		assert_ok!(ParentchainTargetA::set_block(RuntimeOrigin::root(), header_a));
+		assert_eq!(ParentchainTargetA::block_number().unwrap(), block_number_a);
+		assert_eq!(ParentchainTargetA::parent_hash().unwrap(), parent_hash_a);
+		assert_eq!(ParentchainTargetA::block_hash().unwrap(), hash_a);
+
+		System::assert_last_event(RuntimeEvent::ParentchainTargetA(ParentchainEvent::SetBlock {
+			block_number: block_number_a,
+			parent_hash: parent_hash_a,
+			block_hash: hash_a,
+		}));
+
+		// double check previous storage
+		assert_eq!(ParentchainIntegritee::block_number().unwrap(), block_number);
+		assert_eq!(ParentchainIntegritee::block_hash().unwrap(), hash);
+	})
+}
+
+#[test]
+fn non_root_account_errs() {
+	let header = HeaderT::new(
+		1,
+		Default::default(),
+		Default::default(),
+		[69; 32].into(),
+		Default::default(),
+	);
+
+	new_test_ext().execute_with(|| {
+		let root = AccountKeyring::Ferdie.to_account_id();
+		assert_err!(
+			ParentchainIntegritee::set_block(RuntimeOrigin::signed(root), header),
+			BadOrigin
+		);
+	})
+}
+
+#[test]
+fn init_shard_vault_works() {
+	new_test_ext().execute_with(|| {
+		let vault = AccountKeyring::Alice.to_account_id();
+		assert_ok!(ParentchainIntegritee::init_shard_vault(RuntimeOrigin::root(), vault.clone()));
+		assert_eq!(ParentchainIntegritee::shard_vault().unwrap(), vault);
+
+		System::assert_last_event(RuntimeEvent::ParentchainIntegritee(
+			ParentchainEvent::ShardVaultInitialized { account: vault.clone() },
+		));
+		assert_noop!(
+			ParentchainIntegritee::init_shard_vault(RuntimeOrigin::root(), vault.clone()),
+			Error::<Test, ParentchainInstanceIntegritee>::ShardVaultAlreadyInitialized
+		);
+	})
+}
+#[test]
+fn init_parentchain_genesis_hash_works() {
+	new_test_ext().execute_with(|| {
+		let genesis = H256::default();
+		assert_ok!(ParentchainIntegritee::init_parentchain_genesis_hash(
+			RuntimeOrigin::root(),
+			genesis
+		));
+		assert_eq!(ParentchainIntegritee::parentchain_genesis_hash().unwrap(), genesis);
+
+		System::assert_last_event(RuntimeEvent::ParentchainIntegritee(
+			ParentchainEvent::ParentchainGenesisInitialized { hash: genesis },
+		));
+		assert_noop!(
+			ParentchainIntegritee::init_parentchain_genesis_hash(RuntimeOrigin::root(), genesis),
+			Error::<Test, ParentchainInstanceIntegritee>::GenesisAlreadyInitialized
+		);
+	})
+}
+#[test]
+fn force_account_info_works() {
+	new_test_ext().execute_with(|| {
+		let vault = AccountKeyring::Alice.to_account_id();
+		let account_info = AccountInfo {
+			nonce: 42,
+			consumers: 1,
+			providers: 1,
+			sufficients: 1,
+			data: AccountData {
+				free: 123456789,
+				reserved: 23456,
+				frozen: 345,
+				flags: Default::default(),
+			},
+		};
+		assert_ok!(ParentchainIntegritee::force_account_info(
+			RuntimeOrigin::root(),
+			vault.clone(),
+			account_info.clone()
+		));
+		assert_eq!(ParentchainIntegritee::account(&vault), account_info);
+
+		System::assert_last_event(RuntimeEvent::ParentchainIntegritee(
+			ParentchainEvent::AccountInfoForcedFor { account: vault.clone() },
+		));
+	})
+}
+
+#[test]
+fn set_now_works() {
+	new_test_ext().execute_with(|| {
+		let now = 111u64;
+		assert_ok!(ParentchainIntegritee::set_now(RuntimeOrigin::root(), now));
+		assert_eq!(ParentchainIntegritee::now(), Some(now));
+	})
+}
+
+#[test]
+fn set_creation_timestamp_works() {
+	new_test_ext().execute_with(|| {
+		let now = 111u64;
+		assert_ok!(ParentchainIntegritee::set_creation_timestamp(RuntimeOrigin::root(), now));
+		assert_eq!(ParentchainIntegritee::creation_timestamp(), Some(now));
+	})
+}
+
+#[test]
+fn set_creation_block_works() {
+	let parent_hash = H256::from_low_u64_be(420);
+	let header =
+		Header::new(1, Default::default(), Default::default(), parent_hash, Default::default());
+	let hash = header.hash();
+	new_test_ext().execute_with(|| {
+		assert_ok!(ParentchainIntegritee::set_creation_block(RuntimeOrigin::root(), header));
+		assert_eq!(ParentchainIntegritee::creation_block_hash(), Some(hash));
+		assert_eq!(ParentchainIntegritee::creation_block_number(), Some(1));
+	})
+}

--- a/app-libs/sgx-runtime/pallets/parentchain/src/weights.rs
+++ b/app-libs/sgx-runtime/pallets/parentchain/src/weights.rs
@@ -1,0 +1,37 @@
+pub use frame_support::weights::{constants::RocksDbWeight, Weight};
+
+/// Weight functions needed for pallet_parentchain.
+pub trait WeightInfo {
+	fn set_block() -> Weight;
+	fn init_shard_vault() -> Weight;
+	fn init_parentchain_genesis_hash() -> Weight;
+	fn force_account_info() -> Weight;
+	fn set_now() -> Weight;
+	fn set_creation_block() -> Weight;
+	fn set_creation_timestamp() -> Weight;
+}
+
+/// Weights for pallet_parentchain using the Integritee parachain node and recommended hardware.
+impl WeightInfo for () {
+	fn set_block() -> Weight {
+		Weight::from_parts(10_000, 0u64)
+	}
+	fn init_shard_vault() -> Weight {
+		Weight::from_parts(10_000, 0u64)
+	}
+	fn init_parentchain_genesis_hash() -> Weight {
+		Weight::from_parts(10_000, 0u64)
+	}
+	fn force_account_info() -> Weight {
+		Weight::from_parts(10_000, 0u64)
+	}
+	fn set_now() -> Weight {
+		Weight::from_parts(10_000, 0u64)
+	}
+	fn set_creation_block() -> Weight {
+		Weight::from_parts(10_000, 0u64)
+	}
+	fn set_creation_timestamp() -> Weight {
+		Weight::from_parts(10_000, 0u64)
+	}
+}

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -26,13 +26,13 @@ itp-stf-primitives = { default-features = false, path = "../../core-primitives/s
 itp-storage = { default-features = false, path = "../../core-primitives/storage" }
 itp-types = { default-features = false, path = "../../core-primitives/types" }
 itp-utils = { default-features = false, path = "../../core-primitives/utils" }
+pallet-parentchain = { default-features = false, path = "../sgx-runtime/pallets/parentchain" }
 sp-io = { default-features = false, features = ["disable_oom", "disable_panic_handler", "disable_allocator"], path = "../../core-primitives/substrate-sgx/sp-io" }
 
 # Substrate dependencies
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 pallet-sudo = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2962,7 +2962,6 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.11.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.13.0-polkadot-v0.9.42#abf29acd41a0fca9cd7025b297b6a9fa272a122f"
 dependencies = [
  "frame-support",
  "frame-system",


### PR DESCRIPTION
To simplify maintenance accross of different polkadot SDK versions, moving pallet-parentchain into this repository is more consistent.

related: https://github.com/integritee-network/pallets/pull/268
