### PR TITLE
aggregate account getters to AccountInfo and rpc `author_getFingerprint`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-cli"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "array-bytes 6.1.0",
  "base58",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-service"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/app-libs/stf/src/getter.rs
+++ b/app-libs/stf/src/getter.rs
@@ -109,9 +109,7 @@ pub enum PublicGetter {
 #[repr(u8)]
 #[allow(clippy::unnecessary_cast)]
 pub enum TrustedGetter {
-	free_balance(AccountId) = 0,
-	reserved_balance(AccountId) = 1,
-	nonce(AccountId) = 2,
+	account_info(AccountId) = 0,
 	#[cfg(feature = "evm")]
 	evm_nonce(AccountId) = 90,
 	#[cfg(feature = "evm")]
@@ -123,9 +121,7 @@ pub enum TrustedGetter {
 impl TrustedGetter {
 	pub fn sender_account(&self) -> &AccountId {
 		match self {
-			TrustedGetter::free_balance(sender_account) => sender_account,
-			TrustedGetter::reserved_balance(sender_account) => sender_account,
-			TrustedGetter::nonce(sender_account) => sender_account,
+			TrustedGetter::account_info(sender_account) => sender_account,
 			#[cfg(feature = "evm")]
 			TrustedGetter::evm_nonce(sender_account) => sender_account,
 			#[cfg(feature = "evm")]
@@ -184,25 +180,12 @@ impl ExecuteGetter for Getter {
 impl ExecuteGetter for TrustedGetterSigned {
 	fn execute(self) -> Option<Vec<u8>> {
 		match self.getter {
-			TrustedGetter::free_balance(who) => {
+			TrustedGetter::account_info(who) => {
 				let info = System::account(&who);
-				debug!("TrustedGetter free_balance");
+				debug!("TrustedGetter account_data");
 				debug!("AccountInfo for {} is {:?}", account_id_to_string(&who), info);
-				std::println!("⣿STF⣿ 🔍 TrustedGetter query: free balance for ⣿⣿⣿ is ⣿⣿⣿",);
-				Some(info.data.free.encode())
-			},
-			TrustedGetter::reserved_balance(who) => {
-				let info = System::account(&who);
-				debug!("TrustedGetter reserved_balance");
-				debug!("AccountInfo for {} is {:?}", account_id_to_string(&who), info);
-				debug!("Account reserved balance is {}", info.data.reserved);
-				Some(info.data.reserved.encode())
-			},
-			TrustedGetter::nonce(who) => {
-				let nonce = System::account_nonce(&who);
-				debug!("TrustedGetter nonce");
-				debug!("Account nonce is {}", nonce);
-				Some(nonce.encode())
+				std::println!("⣿STF⣿ 🔍 TrustedGetter query: account info for ⣿⣿⣿ is ⣿⣿⣿",);
+				Some(info.encode())
 			},
 			#[cfg(feature = "evm")]
 			TrustedGetter::evm_nonce(who) => {

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -24,6 +24,7 @@
 #![cfg_attr(all(not(target_env = "sgx"), not(feature = "std")), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
 
+extern crate alloc;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
@@ -34,6 +35,7 @@ pub use trusted_call::*;
 #[cfg(feature = "evm")]
 pub mod evm_helpers;
 pub mod getter;
+pub mod guess_the_number;
 pub mod hash;
 pub mod helpers;
 pub mod stf_sgx;

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -24,6 +24,7 @@ use std::vec::Vec;
 #[cfg(feature = "evm")]
 use crate::evm_helpers::{create_code_hash, evm_create2_address, evm_create_address};
 use crate::{
+	guess_the_number::GuessTheNumberTrustedCall,
 	helpers::{enclave_signer_account, ensure_enclave_signer_account, shard_vault, wrap_bytes},
 	Getter,
 };
@@ -33,8 +34,8 @@ use frame_support::{ensure, traits::UnfilteredDispatchable};
 use ita_sgx_runtime::{AddressMapping, HashedAddressMapping};
 pub use ita_sgx_runtime::{Balance, Index};
 use ita_sgx_runtime::{
-	GuessType, ParentchainInstanceIntegritee, ParentchainInstanceTargetA,
-	ParentchainInstanceTargetB, ParentchainIntegritee, Runtime, System,
+	ParentchainInstanceIntegritee, ParentchainInstanceTargetA, ParentchainInstanceTargetB,
+	ParentchainIntegritee, Runtime, System,
 };
 use itp_node_api::metadata::{provider::AccessNodeMetadata, NodeMetadataTrait};
 use itp_node_api_metadata::{
@@ -71,9 +72,7 @@ pub enum TrustedCall {
 	balance_transfer(AccountId, AccountId, Balance) = 2,
 	balance_unshield(AccountId, AccountId, Balance, ShardIdentifier) = 3, // (AccountIncognito, BeneficiaryPublicAccount, Amount, Shard)
 	balance_shield(AccountId, AccountId, Balance, ParentchainId) = 4, // (Root, AccountIncognito, Amount, origin parentchain)
-	guess_the_number_set_winnings(AccountId, Balance) = 50,
-	guess_the_number_push_by_one_day(AccountId) = 51,
-	guess_the_number(AccountId, GuessType) = 52,
+	guess_the_number(GuessTheNumberTrustedCall) = 50,
 	#[cfg(feature = "evm")]
 	evm_withdraw(AccountId, H160, Balance) = 90, // (Origin, Address EVM Account, Value)
 	// (Origin, Source, Target, Input, Value, Gas limit, Max fee per gas, Max priority fee per gas, Nonce, Access list)
@@ -139,9 +138,7 @@ impl TrustedCall {
 			Self::evm_create(sender_account, ..) => sender_account,
 			#[cfg(feature = "evm")]
 			Self::evm_create2(sender_account, ..) => sender_account,
-			Self::guess_the_number_set_winnings(sender_account, ..) => sender_account,
-			Self::guess_the_number_push_by_one_day(sender_account) => sender_account,
-			Self::guess_the_number(sender_account, ..) => sender_account,
+			Self::guess_the_number(call) => call.sender_account(),
 		}
 	}
 }
@@ -577,72 +574,19 @@ where
 				info!("Trying to create evm contract with address {:?}", contract_address);
 				Ok(())
 			},
-			TrustedCall::guess_the_number_set_winnings(sender, winnings) => {
-				// authorization happens in pallet itself, we just pass authentication
-				let origin = ita_sgx_runtime::RuntimeOrigin::signed(sender);
-				std::println!("⣿STF⣿ guess-the-number set winnings to {}", winnings);
-				ita_sgx_runtime::GuessTheNumberCall::<Runtime>::set_winnings { winnings }
-					.dispatch_bypass_filter(origin)
-					.map_err(|e| {
-						Self::Error::Dispatch(format!(
-							"GuessTheNumber Set winnings error: {:?}",
-							e.error
-						))
-					})?;
-				Ok::<(), Self::Error>(())
-			},
-			TrustedCall::guess_the_number_push_by_one_day(sender) => {
-				// authorization happens in pallet itself, we just pass authentication
-				let origin = ita_sgx_runtime::RuntimeOrigin::signed(sender);
-				std::println!("⣿STF⣿ guess-the-number push by one day");
-				ita_sgx_runtime::GuessTheNumberCall::<Runtime>::push_by_one_day {}
-					.dispatch_bypass_filter(origin)
-					.map_err(|e| {
-						Self::Error::Dispatch(format!(
-							"GuessTheNumber push by one day error: {:?}",
-							e.error
-						))
-					})?;
-				Ok::<(), Self::Error>(())
-			},
-			TrustedCall::guess_the_number(sender, guess) => {
-				let origin = ita_sgx_runtime::RuntimeOrigin::signed(sender);
-				std::println!("⣿STF⣿ guess-the-number: someone is attempting a guess");
-				// endow fee to enclave (self)
-				let fee_recipient: AccountId = enclave_signer_account();
-				// fixme: apply fees through standard frame process and tune it
-				let fee = crate::STF_GUESS_FEE;
-				info!("guess fee {}", fee);
-				ita_sgx_runtime::BalancesCall::<Runtime>::transfer {
-					dest: MultiAddress::Id(fee_recipient),
-					value: fee,
-				}
-				.dispatch_bypass_filter(origin.clone())
-				.map_err(|e| {
-					Self::Error::Dispatch(format!("GuessTheNumber fee error: {:?}", e.error))
-				})?;
-
-				ita_sgx_runtime::GuessTheNumberCall::<Runtime>::guess { guess }
-					.dispatch_bypass_filter(origin)
-					.map_err(|e| {
-						Self::Error::Dispatch(format!("GuessTheNumber guess error: {:?}", e.error))
-					})?;
-				Ok::<(), Self::Error>(())
-			},
+			TrustedCall::guess_the_number(call) => call.execute(calls, node_metadata_repo),
 		}?;
 		Ok(())
 	}
 
 	fn get_storage_hashes_to_update(self) -> Vec<Vec<u8>> {
-		let key_hashes = Vec::new();
+		let mut key_hashes = Vec::new();
 		match self.call {
 			TrustedCall::noop(..) => debug!("No storage updates needed..."),
-			#[cfg(any(feature = "test", test))]
-			TrustedCall::balance_set_balance(..) => debug!("No storage updates needed..."), // ROOT call to set some account balance to an arbitrary number
-			TrustedCall::balance_transfer(..) => debug!("No storage updates needed..."),
-			TrustedCall::balance_unshield(..) => debug!("No storage updates needed..."),
-			TrustedCall::balance_shield(..) => debug!("No storage updates needed..."),
-			TrustedCall::timestamp_set(..) => debug!("No storage updates needed..."),
+			TrustedCall::guess_the_number(call) =>
+				key_hashes.append(&mut <GuessTheNumberTrustedCall as ExecuteCall<
+					NodeMetadataRepository,
+				>>::get_storage_hashes_to_update(call)),
 			_ => debug!("No storage updates needed..."),
 		};
 		key_hashes

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-cli"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/cli/benchmark.sh
+++ b/cli/benchmark.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-while getopts ":m:p:A:u:V:C:" opt; do
+while getopts ":p:A:u:V:C:" opt; do
     case $opt in
-        m)
-            READMRENCLAVE=$OPTARG
-            ;;
         p)
             NPORT=$OPTARG
             ;;
@@ -40,16 +37,9 @@ echo "Using trusted-worker uri ${WORKER1URL}:${WORKER1PORT}"
 
 CLIENTWORKER1="${CLIENT_BIN} -p ${NPORT} -P ${WORKER1PORT} -u ${NODEURL} -U ${WORKER1URL}"
 
-if [ "$READMRENCLAVE" = "file" ]
-then
-    read -r MRENCLAVE <<< "$(cat ~/mrenclave.b58)"
-    echo "Reading MRENCLAVE from file: ${MRENCLAVE}"
-else
-    # this will always take the first MRENCLAVE found in the registry !!
-    read -r MRENCLAVE <<< "$($CLIENTWORKER1 list-workers | awk '/  MRENCLAVE: / { print $2; exit }')"
-    echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-fi
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENTWORKER1 trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 # needed when many clients are started
 ulimit -S -n 4096

--- a/cli/demo_direct_call.sh
+++ b/cli/demo_direct_call.sh
@@ -16,18 +16,15 @@
 # then run this script
 
 # usage:
-#  demo_direct_call.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN> -m file
+#  demo_direct_call.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN>
 #
 # TEST_BALANCE_RUN is either "first" or "second"
-# if -m file is set, the mrenclave will be read from file
 
-while getopts ":m:p:P:t:u:V:C:" opt; do
+
+while getopts ":p:P:t:u:V:C:" opt; do
     case $opt in
         t)
             TEST=$OPTARG
-            ;;
-        m)
-            READ_MRENCLAVE=$OPTARG
             ;;
         p)
             INTEGRITEE_RPC_PORT=$OPTARG
@@ -70,7 +67,9 @@ AMOUNTSHIELD=50000000000
 AMOUNTTRANSFER=40000000000
 
 CLIENT="${CLIENT_BIN} -p ${INTEGRITEE_RPC_PORT} -P ${WORKER_1_PORT} -u ${INTEGRITEE_RPC_URL} -U ${WORKER_1_URL}"
-read -r MRENCLAVE <<< "$($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')"
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENT trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 VAULT=$(${CLIENT} trusted get-shard-vault)
 echo "  Vault account = ${VAULT}"

--- a/cli/demo_shielding_unshielding.sh
+++ b/cli/demo_shielding_unshielding.sh
@@ -19,18 +19,15 @@ set -e
 # then run this script
 
 # usage:
-#  demo_shielding_unshielding.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN> -m file
+#  demo_shielding_unshielding.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN>
 #
 # TEST_BALANCE_RUN is either "first" or "second"
-# if -m file is set, the mrenclave will be read from file
 
-while getopts ":m:p:P:t:u:V:C:" opt; do
+
+while getopts ":p:P:t:u:V:C:" opt; do
     case $opt in
         t)
             TEST=$OPTARG
-            ;;
-        m)
-            READ_MRENCLAVE=$OPTARG
             ;;
         p)
             INTEGRITEE_RPC_PORT=$OPTARG
@@ -135,16 +132,9 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-if [ "$READ_MRENCLAVE" = "file" ]
-then
-    read MRENCLAVE <<< $(cat ~/mrenclave.b58)
-    echo "Reading MRENCLAVE from file: ${MRENCLAVE}"
-else
-    # this will always take the first MRENCLAVE found in the registry !!
-    read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
-    echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-fi
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENT trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 echo "* Create a new incognito account for Alice"
 ICGACCOUNTALICE=//AliceIncognito

--- a/cli/demo_shielding_unshielding_using_shard_vault.sh
+++ b/cli/demo_shielding_unshielding_using_shard_vault.sh
@@ -19,18 +19,15 @@ set -e
 # then run this script
 
 # usage:
-#  demo_shielding_unshielding.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN> -m file
+#  demo_shielding_unshielding.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN>
 #
 # TEST_BALANCE_RUN is either "first" or "second"
-# if -m file is set, the mrenclave will be read from file
 
-while getopts ":m:p:P:t:u:V:C:" opt; do
+
+while getopts ":p:P:t:u:V:C:" opt; do
     case $opt in
         t)
             TEST=$OPTARG
-            ;;
-        m)
-            READ_MRENCLAVE=$OPTARG
             ;;
         p)
             INTEGRITEE_RPC_PORT=$OPTARG
@@ -154,17 +151,9 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-if [ "$READ_MRENCLAVE" = "file" ]
-then
-    read MRENCLAVE <<< $(cat ~/mrenclave.b58)
-    echo "Reading MRENCLAVE from file: ${MRENCLAVE}"
-else
-    # this will always take the first MRENCLAVE found in the registry !!
-    read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
-    echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-fi
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
-
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENT trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 echo "* Create a new incognito account for Bob"
 ICGACCOUNTBOB=$(${CLIENT} trusted --mrenclave ${MRENCLAVE} new-account)

--- a/cli/demo_shielding_unshielding_using_shard_vault_on_target_a.sh
+++ b/cli/demo_shielding_unshielding_using_shard_vault_on_target_a.sh
@@ -19,18 +19,15 @@ set -e
 # then run this script
 
 # usage:
-#  demo_shielding_unshielding.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN> -m file
+#  demo_shielding_unshielding.sh -p <NODEPORT> -P <WORKERPORT> -t <TEST_BALANCE_RUN>
 #
 # TEST_BALANCE_RUN is either "first" or "second"
-# if -m file is set, the mrenclave will be read from file
 
-while getopts ":m:p:P:t:u:V:C:a:A:" opt; do
+
+while getopts ":p:P:t:u:V:C:a:A:" opt; do
     case $opt in
         t)
             TEST=$OPTARG
-            ;;
-        m)
-            READ_MRENCLAVE=$OPTARG
             ;;
         p)
             INTEGRITEE_RPC_PORT=$OPTARG
@@ -166,16 +163,9 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-if [ "$READ_MRENCLAVE" = "file" ]
-then
-    read MRENCLAVE <<< $(cat ~/mrenclave.b58)
-    echo "Reading MRENCLAVE from file: ${MRENCLAVE}"
-else
-    # this will always take the first MRENCLAVE found in the registry !!
-    read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
-    echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-fi
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENT trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 
 echo "* Create a new incognito account for Bob"

--- a/cli/demo_sidechain.sh
+++ b/cli/demo_sidechain.sh
@@ -20,16 +20,13 @@
 #
 # usage:
 #  export RUST_LOG_LOG=integritee-cli=info,ita_stf=info
-#  demo_sidechain.sh -p <NODEPORT> -A <WORKER_1_PORT> -B <WORKER_2_PORT> -m file
+#  demo_sidechain.sh -p <NODEPORT> -A <WORKER_1_PORT> -B <WORKER_2_PORT>
 #
 # TEST_BALANCE_RUN is either "first" or "second"
-# if -m file is set, the mrenclave will be read from file.
+.
 
-while getopts ":m:p:A:B:t:u:W:V:C:" opt; do
+while getopts ":p:A:B:t:u:W:V:C:" opt; do
     case $opt in
-        m)
-            READ_MRENCLAVE=$OPTARG
-            ;;
         p)
             INTEGRITEE_RPC_PORT=$OPTARG
             ;;
@@ -85,16 +82,9 @@ AMOUNTTRANSFER=$((2 * UNIT))
 CLIENTWORKER1="${CLIENT_BIN} -p ${INTEGRITEE_RPC_PORT} -P ${WORKER_1_PORT} -u ${INTEGRITEE_RPC_URL} -U ${WORKER_1_URL}"
 CLIENTWORKER2="${CLIENT_BIN} -p ${INTEGRITEE_RPC_PORT} -P ${WORKER_2_PORT} -u ${INTEGRITEE_RPC_URL} -U ${WORKER_2_URL}"
 
-if [ "$READ_MRENCLAVE" = "file" ]
-then
-    read MRENCLAVE <<< $(cat ~/mrenclave.b58)
-    echo "Reading MRENCLAVE from file: ${MRENCLAVE}"
-else
-    # This will always take the first MRENCLAVE found in the registry !!
-    read MRENCLAVE <<< $($CLIENTWORKER1 list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
-    echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-fi
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENTWORKER1 trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 VAULT=$(${CLIENTWORKER1} trusted get-shard-vault)
 echo "  Vault account = ${VAULT}"

--- a/cli/demo_smart_contract.sh
+++ b/cli/demo_smart_contract.sh
@@ -62,10 +62,9 @@ echo "Using trusted-worker uri ${WORKER_URL}:${WORKER_PORT}"
 
 CLIENTWORKER="${CLIENT_BIN} -p ${INTEGRITEE_RPC_PORT} -P ${WORKER_PORT} -u ${INTEGRITEE_RPC_URL} -U ${WORKER_URL}"
 
-
-# this will always take the first MRENCLAVE found in the registry !!
-read -r MRENCLAVE <<< "$($CLIENTWORKER list-workers | awk '/  MRENCLAVE: / { print $2; exit }')"
-echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENTWORKER trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 ACCOUNTALICE=//Alice
 

--- a/cli/demo_teeracle_generic.sh
+++ b/cli/demo_teeracle_generic.sh
@@ -90,12 +90,9 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-# this will always take the first MRENCLAVE found in the registry !!
-read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
-echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
-echo ""
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENT trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 echo "Listen to OracleUpdated events for ${DURATION} seconds. There should be no trusted oracle source!"
 

--- a/cli/demo_teeracle_generic.sh
+++ b/cli/demo_teeracle_generic.sh
@@ -90,9 +90,12 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-# we simply believe the enclave here without verifying the teerex RA
-MRENCLAVE="$($CLIENT trusted get-fingerprint)"
-echo "Using MRENCLAVE: ${MRENCLAVE}"
+# this will always take the first MRENCLAVE found in the registry !!
+read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
+echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
+
+[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
+echo ""
 
 echo "Listen to OracleUpdated events for ${DURATION} seconds. There should be no trusted oracle source!"
 

--- a/cli/demo_teeracle_whitelist.sh
+++ b/cli/demo_teeracle_whitelist.sh
@@ -91,9 +91,12 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-# we simply believe the enclave here without verifying the teerex RA
-MRENCLAVE="$($CLIENT trusted get-fingerprint)"
-echo "Using MRENCLAVE: ${MRENCLAVE}"
+# this will always take the first MRENCLAVE found in the registry !!
+read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
+echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
+
+[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
+echo ""
 
 echo "Listen to ExchangeRateUpdated events for ${DURATION} blocks. There should be no trusted oracle source!"
 #${CLIENT} ${LISTEN_TO_EXCHANGE_RATE_EVENTS_CMD} ${DURATION}

--- a/cli/demo_teeracle_whitelist.sh
+++ b/cli/demo_teeracle_whitelist.sh
@@ -91,12 +91,9 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-# this will always take the first MRENCLAVE found in the registry !!
-read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
-echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
-echo ""
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENT trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 echo "Listen to ExchangeRateUpdated events for ${DURATION} blocks. There should be no trusted oracle source!"
 #${CLIENT} ${LISTEN_TO_EXCHANGE_RATE_EVENTS_CMD} ${DURATION}

--- a/cli/src/base_cli/mod.rs
+++ b/cli/src/base_cli/mod.rs
@@ -158,5 +158,5 @@ fn list_workers(cli: &Cli) -> CliResult {
 			enclave.fingerprint().0.to_base58()
 		})
 		.collect();
-	Ok(CliResultOk::MrEnclaveBase58 { mr_enclaves: fingerprints })
+	Ok(CliResultOk::FingerprintBase58 { fingerprints })
 }

--- a/cli/src/guess_the_number/commands/get_attempts.rs
+++ b/cli/src/guess_the_number/commands/get_attempts.rs
@@ -1,0 +1,46 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate::{
+	trusted_cli::TrustedCli, trusted_command_utils::get_pair_from_str,
+	trusted_operation::perform_trusted_operation, Cli, CliResult, CliResultOk,
+};
+use ita_stf::{
+	guess_the_number::GuessTheNumberTrustedGetter, Getter, TrustedCallSigned, TrustedGetter,
+};
+use itp_stf_primitives::types::{KeyPair, TrustedOperation};
+use sp_core::Pair;
+
+#[derive(Parser)]
+pub struct GetAttemptsCommand {
+	/// AccountId in ss58check format, mnemonic or hex seed
+	account: String,
+}
+
+impl GetAttemptsCommand {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
+		let who = get_pair_from_str(trusted_args, &self.account);
+		let top = TrustedOperation::<TrustedCallSigned, Getter>::get(Getter::trusted(
+			TrustedGetter::guess_the_number(GuessTheNumberTrustedGetter::attempts {
+				origin: who.public().into(),
+			})
+			.sign(&KeyPair::Sr25519(Box::new(who))),
+		));
+		let attempts = perform_trusted_operation::<u8>(cli, trusted_args, &top).unwrap();
+		println!("{}", attempts);
+		Ok(CliResultOk::GuessAttempts { value: attempts })
+	}
+}

--- a/cli/src/guess_the_number/commands/get_info.rs
+++ b/cli/src/guess_the_number/commands/get_info.rs
@@ -18,7 +18,10 @@ use crate::{
 	trusted_cli::TrustedCli, trusted_operation::perform_trusted_operation, Cli, CliResult,
 	CliResultOk,
 };
-use ita_stf::{Getter, GuessTheNumberInfo, PublicGetter, TrustedCallSigned};
+use ita_stf::{
+	guess_the_number::{GuessTheNumberInfo, GuessTheNumberPublicGetter},
+	Getter, PublicGetter, TrustedCallSigned,
+};
 use itp_stf_primitives::types::TrustedOperation;
 use sp_core::crypto::Ss58Codec;
 
@@ -28,7 +31,7 @@ pub struct GetInfoCommand {}
 impl GetInfoCommand {
 	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
 		let top = TrustedOperation::<TrustedCallSigned, Getter>::get(Getter::public(
-			PublicGetter::guess_the_number_info,
+			PublicGetter::guess_the_number(GuessTheNumberPublicGetter::guess_the_number_info),
 		));
 		let info: GuessTheNumberInfo = perform_trusted_operation(cli, trusted_args, &top).unwrap();
 		println!("{:?}", info);

--- a/cli/src/guess_the_number/commands/guess.rs
+++ b/cli/src/guess_the_number/commands/guess.rs
@@ -23,7 +23,9 @@ use crate::{
 	Cli, CliResult, CliResultOk,
 };
 
-use ita_stf::{Getter, Index, TrustedCall, TrustedCallSigned};
+use ita_stf::{
+	guess_the_number::GuessTheNumberTrustedCall, Getter, Index, TrustedCall, TrustedCallSigned,
+};
 use itp_stf_primitives::{
 	traits::TrustedCallSigning,
 	types::{KeyPair, TrustedOperation},
@@ -48,10 +50,11 @@ impl GuessCommand {
 
 		let (mrenclave, shard) = get_identifiers(trusted_args);
 		let nonce = get_layer_two_nonce!(signer, cli, trusted_args);
-		let top: TrustedOperation<TrustedCallSigned, Getter> =
-			TrustedCall::guess_the_number(signer.public().into(), self.guess)
-				.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
-				.into_trusted_operation(trusted_args.direct);
+		let top: TrustedOperation<TrustedCallSigned, Getter> = TrustedCall::guess_the_number(
+			GuessTheNumberTrustedCall::guess(signer.public().into(), self.guess),
+		)
+		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
+		.into_trusted_operation(trusted_args.direct);
 		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/guess_the_number/commands/mod.rs
+++ b/cli/src/guess_the_number/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod get_attempts;
 pub mod get_info;
 pub mod guess;
 pub mod push_by_one_day;

--- a/cli/src/guess_the_number/commands/push_by_one_day.rs
+++ b/cli/src/guess_the_number/commands/push_by_one_day.rs
@@ -23,7 +23,9 @@ use crate::{
 	Cli, CliResult, CliResultOk,
 };
 
-use ita_stf::{Getter, Index, TrustedCall, TrustedCallSigned};
+use ita_stf::{
+	guess_the_number::GuessTheNumberTrustedCall, Getter, Index, TrustedCall, TrustedCallSigned,
+};
 use itp_stf_primitives::{
 	traits::TrustedCallSigning,
 	types::{KeyPair, TrustedOperation},
@@ -46,10 +48,11 @@ impl PushByOneDayCommand {
 
 		let (mrenclave, shard) = get_identifiers(trusted_args);
 		let nonce = get_layer_two_nonce!(signer, cli, trusted_args);
-		let top: TrustedOperation<TrustedCallSigned, Getter> =
-			TrustedCall::guess_the_number_push_by_one_day(signer.public().into())
-				.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
-				.into_trusted_operation(trusted_args.direct);
+		let top: TrustedOperation<TrustedCallSigned, Getter> = TrustedCall::guess_the_number(
+			GuessTheNumberTrustedCall::push_by_one_day(signer.public().into()),
+		)
+		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
+		.into_trusted_operation(trusted_args.direct);
 		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/guess_the_number/commands/set_winnings.rs
+++ b/cli/src/guess_the_number/commands/set_winnings.rs
@@ -23,7 +23,9 @@ use crate::{
 	Cli, CliResult, CliResultOk,
 };
 use ita_parentchain_interface::integritee::Balance;
-use ita_stf::{Getter, Index, TrustedCall, TrustedCallSigned};
+use ita_stf::{
+	guess_the_number::GuessTheNumberTrustedCall, Getter, Index, TrustedCall, TrustedCallSigned,
+};
 use itp_stf_primitives::{
 	traits::TrustedCallSigning,
 	types::{KeyPair, TrustedOperation},
@@ -52,10 +54,11 @@ impl SetWinningsCommand {
 
 		let (mrenclave, shard) = get_identifiers(trusted_args);
 		let nonce = get_layer_two_nonce!(signer, cli, trusted_args);
-		let top: TrustedOperation<TrustedCallSigned, Getter> =
-			TrustedCall::guess_the_number_set_winnings(signer.public().into(), self.winnings)
-				.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
-				.into_trusted_operation(trusted_args.direct);
+		let top: TrustedOperation<TrustedCallSigned, Getter> = TrustedCall::guess_the_number(
+			GuessTheNumberTrustedCall::set_winnings(signer.public().into(), self.winnings),
+		)
+		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
+		.into_trusted_operation(trusted_args.direct);
 		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/guess_the_number/mod.rs
+++ b/cli/src/guess_the_number/mod.rs
@@ -15,7 +15,10 @@
 
 */
 
-use crate::{trusted_cli::TrustedCli, Cli, CliResult};
+use crate::{
+	guess_the_number::commands::get_attempts::GetAttemptsCommand, trusted_cli::TrustedCli, Cli,
+	CliResult,
+};
 use commands::{
 	get_info::GetInfoCommand, guess::GuessCommand, push_by_one_day::PushByOneDayCommand,
 	set_winnings::SetWinningsCommand,
@@ -33,6 +36,8 @@ pub enum GuessTheNumberCommand {
 	PushByOneDay(PushByOneDayCommand),
 	/// submit a guess as a player
 	Guess(GuessCommand),
+	/// how many times a player has already submitted a guess this round
+	GetAttempts(GetAttemptsCommand),
 }
 
 impl GuessTheNumberCommand {
@@ -42,6 +47,7 @@ impl GuessTheNumberCommand {
 			GuessTheNumberCommand::SetWinnings(cmd) => cmd.run(cli, trusted_cli),
 			GuessTheNumberCommand::PushByOneDay(cmd) => cmd.run(cli, trusted_cli),
 			GuessTheNumberCommand::Guess(cmd) => cmd.run(cli, trusted_cli),
+			GuessTheNumberCommand::GetAttempts(cmd) => cmd.run(cli, trusted_cli),
 		}
 	}
 }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -46,7 +46,7 @@ pub mod commands;
 
 use crate::commands::Commands;
 use clap::Parser;
-use ita_stf::{GuessTheNumberInfo, ParentchainsInfo};
+use ita_stf::{guess_the_number::GuessTheNumberInfo, ParentchainsInfo};
 use itp_node_api::api_client::Metadata;
 use sp_application_crypto::KeyTypeId;
 use sp_core::{H160, H256};
@@ -115,6 +115,9 @@ pub enum CliResultOk {
 	},
 	ParentchainsInfo {
 		info: ParentchainsInfo,
+	},
+	GuessAttempts {
+		value: u8,
 	},
 	GuessTheNumberPotInfo {
 		info: GuessTheNumberInfo,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -97,8 +97,8 @@ pub enum CliResultOk {
 	Balance {
 		balance: u128,
 	},
-	MrEnclaveBase58 {
-		mr_enclaves: Vec<String>,
+	FingerprintBase58 {
+		fingerprints: Vec<String>,
 	},
 	Metadata {
 		metadata: Metadata,

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -46,7 +46,7 @@ pub mod commands;
 
 use crate::commands::Commands;
 use clap::Parser;
-use ita_stf::GuessTheNumberInfo;
+use ita_stf::{GuessTheNumberInfo, ParentchainsInfo};
 use itp_node_api::api_client::Metadata;
 use sp_application_crypto::KeyTypeId;
 use sp_core::{H160, H256};
@@ -112,6 +112,9 @@ pub enum CliResultOk {
 	},
 	U32 {
 		value: u32,
+	},
+	ParentchainsInfo {
+		info: ParentchainsInfo,
 	},
 	GuessTheNumberPotInfo {
 		info: GuessTheNumberInfo,

--- a/cli/src/trusted_base_cli/commands/get_fingerprint.rs
+++ b/cli/src/trusted_base_cli/commands/get_fingerprint.rs
@@ -1,0 +1,64 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use crate::{
+	command_utils::get_worker_api_direct, trusted_cli::TrustedCli, Cli, CliError, CliResult,
+	CliResultOk,
+};
+use base58::ToBase58;
+use codec::{Decode, Encode};
+use itc_rpc_client::direct_client::DirectApi;
+use itp_rpc::{RpcRequest, RpcResponse, RpcReturnValue};
+use itp_types::{DirectRequestStatus, EnclaveFingerprint};
+use itp_utils::FromHexPrefixed;
+use log::*;
+
+#[derive(Parser)]
+pub struct GetFingerprintCommand {}
+
+impl GetFingerprintCommand {
+	pub(crate) fn run(&self, cli: &Cli, _trusted_args: &TrustedCli) -> CliResult {
+		let direct_api = get_worker_api_direct(cli);
+		let rpc_method = "author_getFingerprint".to_owned();
+		let jsonrpc_call: String = RpcRequest::compose_jsonrpc_call(rpc_method, vec![]).unwrap();
+		let rpc_response_str = direct_api.get(&jsonrpc_call).unwrap();
+		// Decode RPC response.
+		let rpc_response: RpcResponse = serde_json::from_str(&rpc_response_str)
+			.map_err(|err| CliError::WorkerRpcApi { msg: err.to_string() })?;
+		let rpc_return_value = RpcReturnValue::from_hex(&rpc_response.result)
+			// Replace with `inspect_err` once it's stable.
+			.map_err(|err| {
+				error!("Failed to decode RpcReturnValue: {:?}", err);
+				CliError::WorkerRpcApi { msg: "failed to decode RpcReturnValue".to_string() }
+			})?;
+
+		if rpc_return_value.status == DirectRequestStatus::Error {
+			error!("{}", String::decode(&mut rpc_return_value.value.as_slice()).unwrap());
+			return Err(CliError::WorkerRpcApi { msg: "rpc error".to_string() })
+		}
+
+		let fingerprint = EnclaveFingerprint::decode(&mut rpc_return_value.value.as_slice())
+			// Replace with `inspect_err` once it's stable.
+			.map_err(|err| {
+				error!("Failed to decode fingerprint: {:?}", err);
+				CliError::WorkerRpcApi { msg: err.to_string() }
+			})?;
+		let fingerprint_b58 = fingerprint.encode().to_base58();
+		println!("{}", fingerprint_b58);
+		Ok(CliResultOk::FingerprintBase58 { fingerprints: vec![fingerprint_b58] })
+	}
+}

--- a/cli/src/trusted_base_cli/commands/get_parentchains_info.rs
+++ b/cli/src/trusted_base_cli/commands/get_parentchains_info.rs
@@ -18,9 +18,8 @@ use crate::{
 	trusted_cli::TrustedCli, trusted_operation::perform_trusted_operation, Cli, CliResult,
 	CliResultOk,
 };
-use ita_stf::{Getter, GuessTheNumberInfo, ParentchainsInfo, PublicGetter, TrustedCallSigned};
+use ita_stf::{Getter, ParentchainsInfo, PublicGetter, TrustedCallSigned};
 use itp_stf_primitives::types::TrustedOperation;
-use sp_core::crypto::Ss58Codec;
 
 #[derive(Parser)]
 pub struct GetParentchainsInfoCommand {}

--- a/cli/src/trusted_base_cli/commands/get_parentchains_info.rs
+++ b/cli/src/trusted_base_cli/commands/get_parentchains_info.rs
@@ -1,0 +1,37 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate::{
+	trusted_cli::TrustedCli, trusted_operation::perform_trusted_operation, Cli, CliResult,
+	CliResultOk,
+};
+use ita_stf::{Getter, GuessTheNumberInfo, ParentchainsInfo, PublicGetter, TrustedCallSigned};
+use itp_stf_primitives::types::TrustedOperation;
+use sp_core::crypto::Ss58Codec;
+
+#[derive(Parser)]
+pub struct GetParentchainsInfoCommand {}
+
+impl GetParentchainsInfoCommand {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
+		let top = TrustedOperation::<TrustedCallSigned, Getter>::get(Getter::public(
+			PublicGetter::parentchains_info,
+		));
+		let info: ParentchainsInfo = perform_trusted_operation(cli, trusted_args, &top).unwrap();
+		println!("{:?}", info);
+		Ok(CliResultOk::ParentchainsInfo { info })
+	}
+}

--- a/cli/src/trusted_base_cli/commands/mod.rs
+++ b/cli/src/trusted_base_cli/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod balance;
+pub mod get_fingerprint;
+
 pub mod get_shard;
 pub mod get_shard_vault;
 pub mod get_total_issuance;

--- a/cli/src/trusted_base_cli/commands/mod.rs
+++ b/cli/src/trusted_base_cli/commands/mod.rs
@@ -1,9 +1,10 @@
 pub mod balance;
 pub mod get_fingerprint;
-
+pub mod get_parentchains_info;
 pub mod get_shard;
 pub mod get_shard_vault;
 pub mod get_total_issuance;
+
 pub mod nonce;
 pub mod transfer;
 pub mod unshield_funds;

--- a/cli/src/trusted_base_cli/mod.rs
+++ b/cli/src/trusted_base_cli/mod.rs
@@ -20,9 +20,9 @@ use crate::trusted_base_cli::commands::set_balance::SetBalanceCommand;
 use crate::{
 	trusted_base_cli::commands::{
 		balance::BalanceCommand, get_fingerprint::GetFingerprintCommand,
-		get_shard::GetShardCommand, get_shard_vault::GetShardVaultCommand,
-		get_total_issuance::GetTotalIssuanceCommand, nonce::NonceCommand,
-		transfer::TransferCommand, unshield_funds::UnshieldFundsCommand,
+		get_parentchains_info::GetParentchainsInfoCommand, get_shard::GetShardCommand,
+		get_shard_vault::GetShardVaultCommand, get_total_issuance::GetTotalIssuanceCommand,
+		nonce::NonceCommand, transfer::TransferCommand, unshield_funds::UnshieldFundsCommand,
 	},
 	trusted_cli::TrustedCli,
 	trusted_command_utils::get_keystore_path,
@@ -71,6 +71,9 @@ pub enum TrustedBaseCommand {
 
 	/// get total issuance of this shard's native token
 	GetTotalIssuance(GetTotalIssuanceCommand),
+
+	/// get info for all parentchains' sync status
+	GetParentchainsInfo(GetParentchainsInfoCommand),
 }
 
 impl TrustedBaseCommand {
@@ -85,6 +88,7 @@ impl TrustedBaseCommand {
 			TrustedBaseCommand::UnshieldFunds(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::Nonce(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetFingerprint(cmd) => cmd.run(cli, trusted_cli),
+			TrustedBaseCommand::GetParentchainsInfo(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetShard(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetShardVault(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetTotalIssuance(cmd) => cmd.run(cli, trusted_cli),

--- a/cli/src/trusted_base_cli/mod.rs
+++ b/cli/src/trusted_base_cli/mod.rs
@@ -19,7 +19,8 @@
 use crate::trusted_base_cli::commands::set_balance::SetBalanceCommand;
 use crate::{
 	trusted_base_cli::commands::{
-		balance::BalanceCommand, get_shard::GetShardCommand, get_shard_vault::GetShardVaultCommand,
+		balance::BalanceCommand, get_fingerprint::GetFingerprintCommand,
+		get_shard::GetShardCommand, get_shard_vault::GetShardVaultCommand,
 		get_total_issuance::GetTotalIssuanceCommand, nonce::NonceCommand,
 		transfer::TransferCommand, unshield_funds::UnshieldFundsCommand,
 	},
@@ -59,6 +60,9 @@ pub enum TrustedBaseCommand {
 	/// in top pool in consideration
 	Nonce(NonceCommand),
 
+	/// get fingerprint (AKA MRENCLAVE) for this worker
+	GetFingerprint(GetFingerprintCommand),
+
 	/// get shard for this worker
 	GetShard(GetShardCommand),
 
@@ -80,6 +84,7 @@ impl TrustedBaseCommand {
 			TrustedBaseCommand::Balance(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::UnshieldFunds(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::Nonce(cmd) => cmd.run(cli, trusted_cli),
+			TrustedBaseCommand::GetFingerprint(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetShard(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetShardVault(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetTotalIssuance(cmd) => cmd.run(cli, trusted_cli),

--- a/cli/src/trusted_command_utils.rs
+++ b/cli/src/trusted_command_utils.rs
@@ -23,7 +23,6 @@ use crate::{
 };
 use base58::{FromBase58, ToBase58};
 use codec::{Decode, Encode};
-use ita_parentchain_interface::integritee::Balance;
 use ita_stf::{Getter, TrustedCallSigned, TrustedGetter};
 use itc_rpc_client::direct_client::DirectApi;
 use itp_rpc::{RpcRequest, RpcResponse, RpcReturnValue};

--- a/cli/test_auto_shielding_with_transfer_bob.sh
+++ b/cli/test_auto_shielding_with_transfer_bob.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Verifies that auto shielding transfers sent to vault account: //Alice are verified from sender //Bob
 #
 
-while getopts ":m:p:A:u:V:w:x:y:z:C:" opt; do
+while getopts ":p:A:u:V:w:x:y:z:C:" opt; do
     case $opt in
         p)
             INTEGRITEE_RPC_PORT=$OPTARG
@@ -109,11 +109,9 @@ echo "* Query on-chain enclave registry:"
 ${CLIENT} list-workers
 echo ""
 
-# this will always take the first MRENCLAVE found in the registry !!
-read MRENCLAVE <<< $($CLIENT list-workers | awk '/  MRENCLAVE: / { print $2; exit }')
-echo "Reading MRENCLAVE from worker list: ${MRENCLAVE}"
-
-[[ -z $MRENCLAVE ]] && { echo "MRENCLAVE is empty. cannot continue" ; exit 1; }
+# we simply believe the enclave here without verifying the teerex RA
+MRENCLAVE="$($CLIENT trusted get-fingerprint)"
+echo "Using MRENCLAVE: ${MRENCLAVE}"
 
 VAULTACCOUNT=//Alice
 ## Sender account to shield for

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runtime"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "array-bytes 6.2.2",
  "cid",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runtime"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/enclave-runtime/src/rpc/common_api.rs
+++ b/enclave-runtime/src/rpc/common_api.rs
@@ -115,7 +115,7 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey>(
 	io_handler.add_sync_method("author_getFingerprint", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getFingerprint");
 		let mrenclave = get_stf_enclave_signer_from_solo_or_parachain()
-			.and_then(|enclave_signer| {
+			.map(|enclave_signer| {
 				Ok(enclave_signer.ocall_api.get_mrenclave_of_self().unwrap_or_default())
 			})
 			.unwrap_or_default();

--- a/enclave-runtime/src/rpc/common_api.rs
+++ b/enclave-runtime/src/rpc/common_api.rs
@@ -116,7 +116,7 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey>(
 		debug!("worker_api_direct rpc was called: author_getFingerprint");
 		let mrenclave = get_stf_enclave_signer_from_solo_or_parachain()
 			.map(|enclave_signer| {
-				Ok(enclave_signer.ocall_api.get_mrenclave_of_self().unwrap_or_default())
+				enclave_signer.ocall_api.get_mrenclave_of_self().unwrap_or_default()
 			})
 			.unwrap_or_default();
 		let fingerprint = EnclaveFingerprint::from(mrenclave.m);

--- a/enclave-runtime/src/rpc/common_api.rs
+++ b/enclave-runtime/src/rpc/common_api.rs
@@ -30,12 +30,13 @@ use core::result::Result;
 use ita_sgx_runtime::Runtime;
 use ita_stf::{Getter, TrustedCallSigned};
 use itc_parentchain::light_client::{concurrent_access::ValidatorAccess, ExtrinsicSender};
+use itp_ocall_api::EnclaveAttestationOCallApi;
 use itp_primitives_cache::{GetPrimitives, GLOBAL_PRIMITIVES_CACHE};
 use itp_rpc::RpcReturnValue;
 use itp_sgx_crypto::key_repository::AccessPubkey;
 use itp_stf_executor::{getter_executor::ExecuteGetter, traits::StfShardVaultQuery};
 use itp_top_pool_author::traits::AuthorApi;
-use itp_types::{DirectRequestStatus, Request, ShardIdentifier, H256};
+use itp_types::{DirectRequestStatus, EnclaveFingerprint, Request, ShardIdentifier, H256};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
 use its_rpc_handler::direct_top_pool_api::add_top_pool_direct_rpc_methods;
 use jsonrpc_core::{serde_json::json, IoHandler, Params, Value};
@@ -108,6 +109,18 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey>(
 		debug!("worker_api_direct rpc was called: author_getShard");
 		let shard = top_pool_author.list_handled_shards().first().copied().unwrap_or_default();
 		let json_value = RpcReturnValue::new(shard.encode(), false, DirectRequestStatus::Ok);
+		Ok(json!(json_value.to_hex()))
+	});
+
+	io_handler.add_sync_method("author_getFingerprint", move |_: Params| {
+		debug!("worker_api_direct rpc was called: author_getFingerprint");
+		let mrenclave = get_stf_enclave_signer_from_solo_or_parachain()
+			.and_then(|enclave_signer| {
+				Ok(enclave_signer.ocall_api.get_mrenclave_of_self().unwrap_or_default())
+			})
+			.unwrap_or_default();
+		let fingerprint = EnclaveFingerprint::from(mrenclave.m);
+		let json_value = RpcReturnValue::new(fingerprint.encode(), false, DirectRequestStatus::Ok);
 		Ok(json!(json_value.to_hex()))
 	});
 

--- a/enclave-runtime/src/test/direct_rpc_tests.rs
+++ b/enclave-runtime/src/test/direct_rpc_tests.rs
@@ -58,7 +58,7 @@ pub fn get_state_request_works() {
 	let rpc_handler = Arc::new(RpcWsHandler::new(io_handler, watch_extractor, connection_registry));
 
 	let getter = Getter::trusted(TrustedGetterSigned::new(
-		TrustedGetter::nonce(AccountId::new([0u8; 32])),
+		TrustedGetter::account_info(AccountId::new([0u8; 32])),
 		MultiSignature::Ed25519(Signature::from_raw([0u8; 64])),
 	));
 

--- a/enclave-runtime/src/test/state_getter_tests.rs
+++ b/enclave-runtime/src/test/state_getter_tests.rs
@@ -20,10 +20,11 @@ use codec::Decode;
 use ita_sgx_runtime::Runtime;
 use ita_stf::{
 	test_genesis::{endowed_account, test_genesis_setup, ENDOWED_ACC_FUNDS},
-	Balance, Getter, Stf, TrustedCallSigned, TrustedGetter,
+	Getter, Stf, TrustedCallSigned, TrustedGetter,
 };
 use itp_sgx_externalities::SgxExternalities;
 use itp_stf_executor::state_getter::{GetState, StfStateGetter};
+use itp_types::AccountInfo;
 use sp_core::Pair;
 
 type TestState = SgxExternalities;
@@ -32,14 +33,15 @@ type TestStfStateGetter = StfStateGetter<TestStf>;
 
 pub fn state_getter_works() {
 	let sender = endowed_account();
-	let signed_getter = TrustedGetter::free_balance(sender.public().into()).sign(&sender.into());
+	let signed_getter = TrustedGetter::account_info(sender.public().into()).sign(&sender.into());
 	let mut state = test_state();
 
-	let encoded_balance = TestStfStateGetter::get_state(signed_getter.into(), &mut state)
+	let encoded_info = TestStfStateGetter::get_state(signed_getter.into(), &mut state)
 		.unwrap()
 		.unwrap();
 
-	let balance = Balance::decode(&mut encoded_balance.as_slice()).unwrap();
+	let info = AccountInfo::decode(&mut encoded_info.as_slice()).unwrap();
+	let balance = info.data.free;
 
 	assert_eq!(balance, ENDOWED_ACC_FUNDS);
 }

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -261,7 +261,7 @@ fn test_submit_trusted_getter_to_top_pool() {
 
 	let sender = funded_pair();
 
-	let signed_getter = TrustedGetter::free_balance(sender.public().into()).sign(&sender.into());
+	let signed_getter = TrustedGetter::account_info(sender.public().into()).sign(&sender.into());
 
 	// when
 	submit_operation_to_top_pool(
@@ -288,7 +288,7 @@ fn test_differentiate_getter_and_call_works() {
 	// create accounts
 	let sender = funded_pair();
 
-	let signed_getter = TrustedGetter::free_balance(sender.public().into()).sign(&sender.into());
+	let signed_getter = TrustedGetter::account_info(sender.public().into()).sign(&sender.into());
 
 	let signed_call =
 		TrustedCall::balance_set_balance(sender.public().into(), sender.public().into(), 42, 42)

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-service"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["Integritee AG <hello@integritee.network>"]
 build = "build.rs"
 edition = "2021"


### PR DESCRIPTION
Motivation: individual getters for balance and nonce are awkward when using an interactive signer because each needs to be signed separately

* This also adds a new rpc method `author_getFingerprint` and cli command `trusted get-fingerprint` to simplify dynamic setup in UI (currently we're hard-coding fingerprint and shard). Use this carefully: We still want to verify the RA in teerex on client side!
* refactor guess-the-number calls and getters as nested structure for abstraction
* add parentchains_info public getter for status checks