### PR TITLE
more prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,6 +3462,7 @@ dependencies = [
  "itp-stf-primitives",
  "itp-stf-state-handler",
  "itp-stf-state-observer",
+ "itp-storage",
  "itp-test",
  "itp-time-utils",
  "itp-top-pool",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,6 +3453,7 @@ version = "0.9.0"
 dependencies = [
  "hex",
  "itc-parentchain-test",
+ "itp-enclave-metrics",
  "itp-node-api",
  "itp-ocall-api",
  "itp-sgx-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,6 +3235,7 @@ dependencies = [
 name = "itp-enclave-metrics"
 version = "0.9.0"
 dependencies = [
+ "itp-types",
  "parity-scale-codec",
  "sgx_tstd",
  "substrate-fixed",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,7 +3848,9 @@ dependencies = [
 name = "its-rpc-handler"
 version = "0.9.0"
 dependencies = [
+ "itp-enclave-metrics",
  "itp-import-queue",
+ "itp-ocall-api",
  "itp-rpc",
  "itp-stf-primitives",
  "itp-top-pool-author",

--- a/app-libs/oracle/src/metrics_exporter.rs
+++ b/app-libs/oracle/src/metrics_exporter.rs
@@ -19,7 +19,7 @@ use crate::types::{ExchangeRate, TradingPair};
 use itp_enclave_metrics::{EnclaveMetric, ExchangeRateOracleMetric, OracleMetric};
 use itp_ocall_api::EnclaveMetricsOCallApi;
 use log::error;
-use std::{string::String, sync::Arc, time::Instant};
+use std::{string::String, sync::Arc, time::Instant, vec, vec::Vec};
 
 /// Trait to export metrics for any Teeracle.
 pub trait ExportMetrics<MetricsInfo> {

--- a/app-libs/stf/src/stf_sgx.rs
+++ b/app-libs/stf/src/stf_sgx.rs
@@ -171,6 +171,7 @@ where
 	}
 	fn on_finalize(_state: &mut State) -> Result<(), Self::Error> {
 		trace!("on_finalize called");
+
 		Ok(())
 	}
 }

--- a/core-primitives/enclave-metrics/Cargo.toml
+++ b/core-primitives/enclave-metrics/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 # sgx
+itp-types = { path = "../types", default-features = false }
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
-
 # no-std dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "full"] }
 substrate-fixed = { default-features = false, git = "https://github.com/encointer/substrate-fixed", tag = "v0.5.9" }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -26,7 +26,7 @@ extern crate sgx_tstd as std;
 
 use codec::{Decode, Encode};
 use core::time::Duration;
-use itp_types::ShardIdentifier;
+use itp_types::{parentchain::ParentchainId, ShardIdentifier};
 use std::string::String;
 use substrate_fixed::types::U32F32;
 
@@ -43,13 +43,10 @@ pub enum EnclaveMetric {
 	RpcTrustedCallsIncrement,
 	SidechainAuraSlotRemainingTimes(String, Duration),
 	StfStateUpdateExecutionDuration(Duration),
-	StfStateUpdateExecutedCallsSuccessfulCount(u32),
-	StfStateUpdateExecutedCallsFailedCount(u32),
+	StfStateUpdateExecutedCallsCount(bool, u32),
 	StfStateSizeSet(ShardIdentifier, u32),
 	StfRuntimeTotalIssuanceSet(f64),
-	StfRuntimeParentchainIntegriteeProcessedBlockNumberSet(u32),
-	StfRuntimeParentchainTargetAProcessedBlockNumberSet(u32),
-	StfRuntimeParentchainTargetBProcessedBlockNumberSet(u32),
+	StfRuntimeParentchainProcessedBlockNumberSet(ParentchainId, u32),
 	ExchangeRateOracle(ExchangeRateOracleMetric),
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -26,6 +26,7 @@ extern crate sgx_tstd as std;
 
 use codec::{Decode, Encode};
 use core::time::Duration;
+use itp_types::ShardIdentifier;
 use std::string::String;
 use substrate_fixed::types::U32F32;
 
@@ -44,6 +45,7 @@ pub enum EnclaveMetric {
 	StfStateUpdateExecutionDuration(Duration),
 	StfStateUpdateExecutedCallsSuccessfulCount(u32),
 	StfStateUpdateExecutedCallsFailedCount(u32),
+	StfStateSizeSet(ShardIdentifier, u32),
 	StfRuntimeTotalIssuanceSet(f64),
 	StfRuntimeParentchainIntegriteeProcessedBlockNumberSet(u32),
 	StfRuntimeParentchainTargetAProcessedBlockNumberSet(u32),

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -37,8 +37,6 @@ pub type ExchangeRate = U32F32;
 pub enum EnclaveMetric {
 	SetSidechainBlockHeight(u64),
 	TopPoolSizeSet(u64),
-	TopPoolSizeIncrement,
-	TopPoolSizeDecrement,
 	RpcRequestsIncrement,
 	RpcTrustedCallsIncrement,
 	SidechainAuraSlotRemainingTimes(String, Duration),

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -40,6 +40,7 @@ pub enum EnclaveMetric {
 	TopPoolSizeDecrement,
 	RpcRequestsIncrement,
 	RpcTrustedCallsIncrement,
+	SidechainAuraSlotRemainingTimes(String, Duration),
 	StfStateUpdateExecutionDuration(Duration),
 	StfStateUpdateExecutedCallsSuccessfulCount(u32),
 	StfStateUpdateExecutedCallsFailedCount(u32),

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -40,7 +40,9 @@ pub enum EnclaveMetric {
 	TopPoolSizeDecrement,
 	RpcRequestsIncrement,
 	RpcTrustedCallsIncrement,
-	StfStateUpodateExecutionDuration(Duration),
+	StfStateUpdateExecutionDuration(Duration),
+	StfStateUpdateExecutedCallsSuccessfulCount(u32),
+	StfStateUpdateExecutedCallsFailedCount(u32),
 	ExchangeRateOracle(ExchangeRateOracleMetric),
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -30,7 +30,7 @@ use substrate_fixed::types::U32F32;
 // FIXME: Copied from ita-oracle because of cyclic deps. Should be removed after integritee-network/pallets#71
 pub type ExchangeRate = U32F32;
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode, Debug, Clone)]
 pub enum EnclaveMetric {
 	SetSidechainBlockHeight(u64),
 	TopPoolSizeSet(u64),
@@ -42,7 +42,7 @@ pub enum EnclaveMetric {
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode, Debug, Clone)]
 pub enum ExchangeRateOracleMetric {
 	/// Exchange Rate from CoinGecko - (Source, TradingPair, ExchangeRate)
 	ExchangeRate(String, String, ExchangeRate),
@@ -52,7 +52,7 @@ pub enum ExchangeRateOracleMetric {
 	NumberRequestsIncrement(String),
 }
 
-#[derive(Encode, Decode, Debug)]
+#[derive(Encode, Decode, Debug, Clone)]
 pub enum OracleMetric<MetricsInfo> {
 	OracleSpecificMetric(MetricsInfo),
 	ResponseTime(String, u128),

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -20,10 +20,12 @@
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
 
+extern crate core;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
 use codec::{Decode, Encode};
+use core::time::Duration;
 use std::string::String;
 use substrate_fixed::types::U32F32;
 
@@ -38,6 +40,7 @@ pub enum EnclaveMetric {
 	TopPoolSizeDecrement,
 	RpcRequestsIncrement,
 	RpcTrustedCallsIncrement,
+	StfStateUpodateExecutionDuration(Duration),
 	ExchangeRateOracle(ExchangeRateOracleMetric),
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -43,7 +43,10 @@ pub enum EnclaveMetric {
 	StfStateUpdateExecutionDuration(Duration),
 	StfStateUpdateExecutedCallsSuccessfulCount(u32),
 	StfStateUpdateExecutedCallsFailedCount(u32),
-	StfTotalIssuanceSet(f64),
+	StfRuntimeTotalIssuanceSet(f64),
+	StfRuntimeParentchainIntegriteeProcessedBlockNumberSet(u32),
+	StfRuntimeParentchainTargetAProcessedBlockNumberSet(u32),
+	StfRuntimeParentchainTargetBProcessedBlockNumberSet(u32),
 	ExchangeRateOracle(ExchangeRateOracleMetric),
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -20,13 +20,15 @@
 #[cfg(all(feature = "std", feature = "sgx"))]
 compile_error!("feature \"std\" and feature \"sgx\" cannot be enabled at the same time");
 
-extern crate core;
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
 use codec::{Decode, Encode};
 use core::time::Duration;
-use itp_types::{parentchain::ParentchainId, ShardIdentifier};
+use itp_types::{
+	parentchain::{BlockNumber, ParentchainId},
+	ShardIdentifier,
+};
 use std::string::String;
 use substrate_fixed::types::U32F32;
 
@@ -41,10 +43,10 @@ pub enum EnclaveMetric {
 	RpcTrustedCallsIncrement,
 	SidechainAuraSlotRemainingTimes(String, Duration),
 	StfStateUpdateExecutionDuration(Duration),
-	StfStateUpdateExecutedCallsCount(bool, u32),
-	StfStateSizeSet(ShardIdentifier, u32),
+	StfStateUpdateExecutedCallsCount(bool, u64),
+	StfStateSizeSet(ShardIdentifier, u64),
 	StfRuntimeTotalIssuanceSet(f64),
-	StfRuntimeParentchainProcessedBlockNumberSet(ParentchainId, u32),
+	StfRuntimeParentchainProcessedBlockNumberSet(ParentchainId, BlockNumber),
 	ExchangeRateOracle(ExchangeRateOracleMetric),
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -38,7 +38,7 @@ pub type ExchangeRate = U32F32;
 #[derive(Encode, Decode, Debug, Clone)]
 pub enum EnclaveMetric {
 	SetSidechainBlockHeight(u64),
-	TopPoolSizeSet(u64),
+	TopPoolAPrioriSizeSet(u64),
 	RpcRequestsIncrement,
 	RpcTrustedCallsIncrement,
 	SidechainAuraSlotRemainingTimes(String, Duration),

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -36,6 +36,8 @@ pub enum EnclaveMetric {
 	TopPoolSizeSet(u64),
 	TopPoolSizeIncrement,
 	TopPoolSizeDecrement,
+	RpcRequestsIncrement,
+	RpcTrustedCallsIncrement,
 	ExchangeRateOracle(ExchangeRateOracleMetric),
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }

--- a/core-primitives/enclave-metrics/src/lib.rs
+++ b/core-primitives/enclave-metrics/src/lib.rs
@@ -43,6 +43,7 @@ pub enum EnclaveMetric {
 	StfStateUpdateExecutionDuration(Duration),
 	StfStateUpdateExecutedCallsSuccessfulCount(u32),
 	StfStateUpdateExecutedCallsFailedCount(u32),
+	StfTotalIssuanceSet(f64),
 	ExchangeRateOracle(ExchangeRateOracleMetric),
 	// OracleMetric(OracleMetric<MetricsInfo>),
 }

--- a/core-primitives/node-api/api-client-extensions/src/lib.rs
+++ b/core-primitives/node-api/api-client-extensions/src/lib.rs
@@ -21,6 +21,7 @@ pub use substrate_api_client::{api::Error as ApiClientError, rpc::TungsteniteRpc
 
 pub mod account;
 pub mod chain;
+pub mod pallet_sidechain;
 pub mod pallet_teeracle;
 pub mod pallet_teerex;
 

--- a/core-primitives/node-api/api-client-extensions/src/pallet_sidechain.rs
+++ b/core-primitives/node-api/api-client-extensions/src/pallet_sidechain.rs
@@ -1,0 +1,31 @@
+use crate::ApiResult;
+use itp_api_client_types::{traits::GetStorage, Api, Config, Request};
+use itp_types::{parentchain::SidechainBlockConfirmation, ShardIdentifier};
+
+pub const SIDECHAIN: &str = "Sidechain";
+
+pub trait PalletSidechainApi {
+	type Hash;
+
+	fn latest_sidechain_block_confirmation(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Self::Hash>,
+	) -> ApiResult<Option<SidechainBlockConfirmation>>;
+}
+
+impl<RuntimeConfig, Client> PalletSidechainApi for Api<RuntimeConfig, Client>
+where
+	RuntimeConfig: Config,
+	Client: Request,
+{
+	type Hash = RuntimeConfig::Hash;
+
+	fn latest_sidechain_block_confirmation(
+		&self,
+		shard: &ShardIdentifier,
+		at_block: Option<Self::Hash>,
+	) -> ApiResult<Option<SidechainBlockConfirmation>> {
+		self.get_storage_map(SIDECHAIN, "LatestSidechainBlockConfirmation", shard, at_block)
+	}
+}

--- a/core-primitives/ocall-api/src/lib.rs
+++ b/core-primitives/ocall-api/src/lib.rs
@@ -119,7 +119,7 @@ pub trait EnclaveOnChainOCallApi: Clone + Send + Sync {
 
 /// Trait for sending metric updates.
 pub trait EnclaveMetricsOCallApi: Clone + Send + Sync {
-	fn update_metric<Metric: Encode>(&self, metric: Metric) -> SgxResult<()>;
+	fn update_metrics<Metric: Encode>(&self, metric: Vec<Metric>) -> SgxResult<()>;
 }
 
 pub trait EnclaveSidechainOCallApi: Clone + Send + Sync {

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -21,6 +21,7 @@ itp-stf-interface = { path = "../stf-interface", default-features = false }
 itp-stf-primitives = { path = "../stf-primitives", default-features = false }
 itp-stf-state-handler = { path = "../stf-state-handler", default-features = false }
 itp-stf-state-observer = { path = "../stf-state-observer", default-features = false }
+itp-storage = { path = "../storage", default-features = false }
 itp-time-utils = { path = "../time-utils", default-features = false }
 itp-top-pool-author = { path = "../top-pool-author", default-features = false }
 itp-types = { path = "../types", default-features = false }

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -12,6 +12,7 @@ sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sd
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
 
 # local dependencies
+itp-enclave-metrics = { path = "../enclave-metrics", default-features = false }
 itp-node-api = { path = "../node-api", default-features = false }
 itp-ocall-api = { path = "../ocall-api", default-features = false }
 itp-sgx-crypto = { path = "../sgx/crypto", default-features = false }

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -355,17 +355,15 @@ where
 
 		let state_size_bytes = state.size();
 		let runtime_metrics = gather_runtime_metrics(&state);
-		let pending_tops = trusted_calls.len().saturating_sub(executed_and_failed_calls.len());
-		let propsing_duration = duration_now() - started_at;
 		let successful_call_count =
 			executed_and_failed_calls.iter().filter(|call| call.is_success()).count();
 		let failed_call_count = executed_and_failed_calls.len() - successful_call_count;
 		self.ocall_api
 			.update_metrics(vec![
-				EnclaveMetric::StfStateUpdateExecutionDuration(propsing_duration),
+				EnclaveMetric::StfStateUpdateExecutionDuration(duration_now() - started_at),
 				EnclaveMetric::StfStateUpdateExecutedCallsCount(true, successful_call_count as u64),
 				EnclaveMetric::StfStateUpdateExecutedCallsCount(false, failed_call_count as u64),
-				EnclaveMetric::TopPoolSizeSet(pending_tops as u64),
+				EnclaveMetric::TopPoolAPrioriSizeSet(trusted_calls.len() as u64),
 				EnclaveMetric::StfStateSizeSet(*shard, state_size_bytes as u64),
 				EnclaveMetric::StfRuntimeTotalIssuanceSet(runtime_metrics.total_issuance),
 				EnclaveMetric::StfRuntimeParentchainProcessedBlockNumberSet(

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -353,10 +353,17 @@ where
 		});
 
 		let propsing_duration = duration_now() - started_at;
+		let successful_call_count =
+			executed_and_failed_calls.iter().filter(|call| call.is_success()).count();
+		let failed_call_count = executed_and_failed_calls.len() - successful_call_count;
 		self.ocall_api
-			.update_metrics(vec![EnclaveMetric::StfStateUpodateExecutionDuration(
-				propsing_duration,
-			)])
+			.update_metrics(vec![
+				EnclaveMetric::StfStateUpdateExecutionDuration(propsing_duration),
+				EnclaveMetric::StfStateUpdateExecutedCallsSuccessfulCount(
+					successful_call_count as u32,
+				),
+				EnclaveMetric::StfStateUpdateExecutedCallsFailedCount(failed_call_count as u32),
+			])
 			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		Ok(BatchExecutionResult {
 			executed_operations: executed_and_failed_calls,

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -353,6 +353,7 @@ where
 			error!("on_finalize failed: {:?}", e);
 		});
 
+		let state_size_bytes = state.size();
 		let runtime_metrics = gather_runtime_metrics(&state);
 
 		let propsing_duration = duration_now() - started_at;
@@ -366,6 +367,7 @@ where
 					successful_call_count as u32,
 				),
 				EnclaveMetric::StfStateUpdateExecutedCallsFailedCount(failed_call_count as u32),
+				EnclaveMetric::StfStateSizeSet(*shard, state_size_bytes as u32),
 				EnclaveMetric::StfRuntimeTotalIssuanceSet(runtime_metrics.total_issuance),
 				EnclaveMetric::StfRuntimeParentchainIntegriteeProcessedBlockNumberSet(
 					runtime_metrics.parentchain_integritee_processed_block_number,

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -363,10 +363,10 @@ where
 		self.ocall_api
 			.update_metrics(vec![
 				EnclaveMetric::StfStateUpdateExecutionDuration(propsing_duration),
-				EnclaveMetric::StfStateUpdateExecutedCallsCount(true, successful_call_count as u32),
-				EnclaveMetric::StfStateUpdateExecutedCallsCount(false, failed_call_count as u32),
+				EnclaveMetric::StfStateUpdateExecutedCallsCount(true, successful_call_count as u64),
+				EnclaveMetric::StfStateUpdateExecutedCallsCount(false, failed_call_count as u64),
 				EnclaveMetric::TopPoolSizeSet(pending_tops as u64),
-				EnclaveMetric::StfStateSizeSet(*shard, state_size_bytes as u32),
+				EnclaveMetric::StfStateSizeSet(*shard, state_size_bytes as u64),
 				EnclaveMetric::StfRuntimeTotalIssuanceSet(runtime_metrics.total_issuance),
 				EnclaveMetric::StfRuntimeParentchainProcessedBlockNumberSet(
 					ParentchainId::Integritee,

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -363,19 +363,20 @@ where
 		self.ocall_api
 			.update_metrics(vec![
 				EnclaveMetric::StfStateUpdateExecutionDuration(propsing_duration),
-				EnclaveMetric::StfStateUpdateExecutedCallsSuccessfulCount(
-					successful_call_count as u32,
-				),
-				EnclaveMetric::StfStateUpdateExecutedCallsFailedCount(failed_call_count as u32),
+				EnclaveMetric::StfStateUpdateExecutedCallsCount(true, successful_call_count as u32),
+				EnclaveMetric::StfStateUpdateExecutedCallsCount(false, failed_call_count as u32),
 				EnclaveMetric::StfStateSizeSet(*shard, state_size_bytes as u32),
 				EnclaveMetric::StfRuntimeTotalIssuanceSet(runtime_metrics.total_issuance),
-				EnclaveMetric::StfRuntimeParentchainIntegriteeProcessedBlockNumberSet(
+				EnclaveMetric::StfRuntimeParentchainProcessedBlockNumberSet(
+					ParentchainId::Integritee,
 					runtime_metrics.parentchain_integritee_processed_block_number,
 				),
-				EnclaveMetric::StfRuntimeParentchainTargetAProcessedBlockNumberSet(
+				EnclaveMetric::StfRuntimeParentchainProcessedBlockNumberSet(
+					ParentchainId::TargetA,
 					runtime_metrics.parentchain_target_a_processed_block_number,
 				),
-				EnclaveMetric::StfRuntimeParentchainTargetBProcessedBlockNumberSet(
+				EnclaveMetric::StfRuntimeParentchainProcessedBlockNumberSet(
+					ParentchainId::TargetB,
 					runtime_metrics.parentchain_target_b_processed_block_number,
 				),
 			])

--- a/core-primitives/stf-executor/src/executor.rs
+++ b/core-primitives/stf-executor/src/executor.rs
@@ -355,7 +355,7 @@ where
 
 		let state_size_bytes = state.size();
 		let runtime_metrics = gather_runtime_metrics(&state);
-
+		let pending_tops = trusted_calls.len().saturating_sub(executed_and_failed_calls.len());
 		let propsing_duration = duration_now() - started_at;
 		let successful_call_count =
 			executed_and_failed_calls.iter().filter(|call| call.is_success()).count();
@@ -365,6 +365,7 @@ where
 				EnclaveMetric::StfStateUpdateExecutionDuration(propsing_duration),
 				EnclaveMetric::StfStateUpdateExecutedCallsCount(true, successful_call_count as u32),
 				EnclaveMetric::StfStateUpdateExecutedCallsCount(false, failed_call_count as u32),
+				EnclaveMetric::TopPoolSizeSet(pending_tops as u64),
 				EnclaveMetric::StfStateSizeSet(*shard, state_size_bytes as u32),
 				EnclaveMetric::StfRuntimeTotalIssuanceSet(runtime_metrics.total_issuance),
 				EnclaveMetric::StfRuntimeParentchainProcessedBlockNumberSet(

--- a/core-primitives/substrate-sgx/externalities/src/lib.rs
+++ b/core-primitives/substrate-sgx/externalities/src/lib.rs
@@ -105,6 +105,9 @@ pub trait SgxExternalitiesTrait {
 
 	fn get(&self, k: &[u8]) -> Option<&Vec<u8>>;
 
+	/// get the state size in encoded bytes
+	fn size(&self) -> usize;
+
 	fn contains_key(&self, k: &[u8]) -> bool;
 
 	/// Get the next key in state after the given one (excluded) in lexicographic order.
@@ -160,6 +163,10 @@ where
 
 	fn get(&self, key: &[u8]) -> Option<&Vec<u8>> {
 		self.state.get(key)
+	}
+
+	fn size(&self) -> usize {
+		self.state.encoded_size()
 	}
 
 	fn contains_key(&self, key: &[u8]) -> bool {

--- a/core-primitives/test/src/mock/metrics_ocall_mock.rs
+++ b/core-primitives/test/src/mock/metrics_ocall_mock.rs
@@ -47,8 +47,8 @@ impl MetricsOCallMock {
 }
 
 impl EnclaveMetricsOCallApi for MetricsOCallMock {
-	fn update_metric<Metric: Encode>(&self, metric: Metric) -> SgxResult<()> {
-		self.metric_updates.write().unwrap().push(metric.encode());
+	fn update_metrics<Metric: Encode>(&self, metrics: Vec<Metric>) -> SgxResult<()> {
+		self.metric_updates.write().unwrap().push(metrics.encode());
 		Ok(())
 	}
 }

--- a/core-primitives/test/src/mock/onchain_mock.rs
+++ b/core-primitives/test/src/mock/onchain_mock.rs
@@ -170,7 +170,7 @@ impl EnclaveSidechainOCallApi for OnchainMock {
 }
 
 impl EnclaveMetricsOCallApi for OnchainMock {
-	fn update_metric<Metric: Encode>(&self, _metric: Metric) -> SgxResult<()> {
+	fn update_metrics<Metric: Encode>(&self, _metrics: Vec<Metric>) -> SgxResult<()> {
 		Ok(())
 	}
 }

--- a/core-primitives/top-pool-author/src/author.rs
+++ b/core-primitives/top-pool-author/src/author.rs
@@ -48,7 +48,7 @@ use jsonrpc_core::{
 };
 use log::*;
 use sp_runtime::generic;
-use std::{boxed::Box, sync::Arc, vec::Vec};
+use std::{boxed::Box, sync::Arc, vec, vec::Vec};
 
 /// Define type of TOP filter that is used in the Author
 #[cfg(feature = "sidechain")]
@@ -190,7 +190,7 @@ where
 		let best_block_hash = Default::default();
 
 		// Update metric
-		if let Err(e) = self.ocall_api.update_metric(EnclaveMetric::TopPoolSizeIncrement) {
+		if let Err(e) = self.ocall_api.update_metrics(vec![EnclaveMetric::TopPoolSizeIncrement]) {
 			warn!("Failed to update metric for top pool size: {:?}", e);
 		}
 
@@ -256,7 +256,7 @@ where
 		debug!("removing {:?} from top pool", hash);
 
 		// Update metric
-		if let Err(e) = self.ocall_api.update_metric(EnclaveMetric::TopPoolSizeDecrement) {
+		if let Err(e) = self.ocall_api.update_metrics(vec![EnclaveMetric::TopPoolSizeDecrement]) {
 			warn!("Failed to update metric for top pool size: {:?}", e);
 		}
 

--- a/core-primitives/top-pool-author/src/author_tests.rs
+++ b/core-primitives/top-pool-author/src/author_tests.rs
@@ -46,7 +46,6 @@ type TestAuthor<Filter> = Author<
 	Filter,
 	HandleStateMock,
 	KeyRepositoryMock<ShieldingCryptoMock>,
-	MetricsOCallMock,
 	TrustedCallSignedMock,
 	GetterMock,
 >;
@@ -140,13 +139,7 @@ fn create_author_with_filter<F: Filter<Value = TrustedOperationMock>>(
 	let ocall_mock = Arc::new(MetricsOCallMock::default());
 
 	(
-		Author::new(
-			top_pool.clone(),
-			filter,
-			Arc::new(state_facade),
-			shielding_key_repo,
-			ocall_mock,
-		),
+		Author::new(top_pool.clone(), filter, Arc::new(state_facade), shielding_key_repo),
 		top_pool,
 		encryption_key,
 	)

--- a/core-primitives/types/src/parentchain.rs
+++ b/core-primitives/types/src/parentchain.rs
@@ -59,10 +59,11 @@ pub type BlockHash = sp_core::H256;
 /// Alias to 512-bit hash when used in the context of a transaction signature on the chain.
 pub type Signature = MultiSignature;
 
-#[derive(Encode, Decode, Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Encode, Decode, Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ParentchainId {
 	/// The Integritee Parentchain, the trust root of the enclave and serving finality to sidechains.
+	#[default]
 	Integritee,
 	/// A target chain containing custom business logic.
 	TargetA,

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2187,6 +2187,7 @@ version = "0.9.0"
 dependencies = [
  "hex",
  "itc-parentchain-test",
+ "itp-enclave-metrics",
  "itp-node-api",
  "itp-ocall-api",
  "itp-sgx-crypto",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1994,6 +1994,7 @@ dependencies = [
 name = "itp-enclave-metrics"
 version = "0.9.0"
 dependencies = [
+ "itp-types",
  "parity-scale-codec",
  "sgx_tstd",
  "substrate-fixed",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -795,6 +795,7 @@ dependencies = [
  "itc-tls-websocket-server",
  "itp-attestation-handler",
  "itp-component-container",
+ "itp-enclave-metrics",
  "itp-extrinsics-factory",
  "itp-import-queue",
  "itp-node-api",
@@ -2523,7 +2524,9 @@ dependencies = [
 name = "its-rpc-handler"
 version = "0.9.0"
 dependencies = [
+ "itp-enclave-metrics",
  "itp-import-queue",
+ "itp-ocall-api",
  "itp-rpc",
  "itp-stf-primitives",
  "itp-top-pool-author",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2196,6 +2196,7 @@ dependencies = [
  "itp-stf-primitives",
  "itp-stf-state-handler",
  "itp-stf-state-observer",
+ "itp-storage",
  "itp-test",
  "itp-time-utils",
  "itp-top-pool-author",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -105,6 +105,7 @@ itc-parentchain-test = { path = "../core/parentchain/test", default-features = f
 itc-tls-websocket-server = { path = "../core/tls-websocket-server", default-features = false, features = ["sgx"] }
 itp-attestation-handler = { path = "../core-primitives/attestation-handler", default-features = false, features = ["sgx"] }
 itp-component-container = { path = "../core-primitives/component-container", default-features = false, features = ["sgx"] }
+itp-enclave-metrics = { path = "../core-primitives/enclave-metrics", default-features = false, features = ["sgx"] }
 itp-extrinsics-factory = { path = "../core-primitives/extrinsics-factory", default-features = false, features = ["sgx"] }
 itp-import-queue = { path = "../core-primitives/import-queue", default-features = false, features = ["sgx"] }
 itp-node-api = { path = "../core-primitives/node-api", default-features = false, features = ["sgx"] }

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -240,8 +240,8 @@ enclave {
 			[out, size = resp_size] uint8_t * response, uint32_t resp_size
 		);
 
-		sgx_status_t ocall_update_metric(
-			[in, size = metric_size] uint8_t * metric, uint32_t metric_size
+		sgx_status_t ocall_update_metrics(
+			[in, size = metrics_size] uint8_t * metrics, uint32_t metrics_size
 		);
 
 		sgx_status_t ocall_propose_sidechain_blocks(

--- a/enclave-runtime/src/initialization/global_components.rs
+++ b/enclave-runtime/src/initialization/global_components.rs
@@ -296,7 +296,6 @@ pub type EnclaveTopPoolAuthor = Author<
 	AuthorTopFilter<EnclaveTrustedCallSigned, EnclaveGetter>,
 	EnclaveStateHandler,
 	EnclaveShieldingKeyRepository,
-	EnclaveOCallApi,
 	EnclaveTrustedCallSigned,
 	EnclaveGetter,
 >;

--- a/enclave-runtime/src/initialization/mod.rs
+++ b/enclave-runtime/src/initialization/mod.rs
@@ -21,19 +21,18 @@ use crate::{
 	error::{Error, Result as EnclaveResult},
 	initialization::global_components::{
 		EnclaveBlockImportConfirmationHandler, EnclaveGetterExecutor, EnclaveLightClientSeal,
-		EnclaveOCallApi, EnclaveRpcConnectionRegistry, EnclaveRpcResponder,
-		EnclaveShieldingKeyRepository, EnclaveSidechainApi, EnclaveSidechainBlockImportQueueWorker,
-		EnclaveSidechainBlockImporter, EnclaveSidechainBlockSyncer, EnclaveStateFileIo,
-		EnclaveStateHandler, EnclaveStateInitializer, EnclaveStateObserver,
-		EnclaveStateSnapshotRepository, EnclaveStfEnclaveSigner, EnclaveTopPool,
-		EnclaveTopPoolAuthor, GLOBAL_ATTESTATION_HANDLER_COMPONENT,
-		GLOBAL_INTEGRITEE_PARENTCHAIN_LIGHT_CLIENT_SEAL, GLOBAL_OCALL_API_COMPONENT,
-		GLOBAL_RPC_WS_HANDLER_COMPONENT, GLOBAL_SHIELDING_KEY_REPOSITORY_COMPONENT,
-		GLOBAL_SIDECHAIN_BLOCK_COMPOSER_COMPONENT, GLOBAL_SIDECHAIN_BLOCK_SYNCER_COMPONENT,
-		GLOBAL_SIDECHAIN_IMPORT_QUEUE_COMPONENT, GLOBAL_SIDECHAIN_IMPORT_QUEUE_WORKER_COMPONENT,
-		GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT, GLOBAL_STATE_HANDLER_COMPONENT,
-		GLOBAL_STATE_KEY_REPOSITORY_COMPONENT, GLOBAL_STATE_OBSERVER_COMPONENT,
-		GLOBAL_TARGET_A_PARENTCHAIN_LIGHT_CLIENT_SEAL,
+		EnclaveRpcConnectionRegistry, EnclaveRpcResponder, EnclaveShieldingKeyRepository,
+		EnclaveSidechainApi, EnclaveSidechainBlockImportQueueWorker, EnclaveSidechainBlockImporter,
+		EnclaveSidechainBlockSyncer, EnclaveStateFileIo, EnclaveStateHandler,
+		EnclaveStateInitializer, EnclaveStateObserver, EnclaveStateSnapshotRepository,
+		EnclaveStfEnclaveSigner, EnclaveTopPool, EnclaveTopPoolAuthor,
+		GLOBAL_ATTESTATION_HANDLER_COMPONENT, GLOBAL_INTEGRITEE_PARENTCHAIN_LIGHT_CLIENT_SEAL,
+		GLOBAL_OCALL_API_COMPONENT, GLOBAL_RPC_WS_HANDLER_COMPONENT,
+		GLOBAL_SHIELDING_KEY_REPOSITORY_COMPONENT, GLOBAL_SIDECHAIN_BLOCK_COMPOSER_COMPONENT,
+		GLOBAL_SIDECHAIN_BLOCK_SYNCER_COMPONENT, GLOBAL_SIDECHAIN_IMPORT_QUEUE_COMPONENT,
+		GLOBAL_SIDECHAIN_IMPORT_QUEUE_WORKER_COMPONENT, GLOBAL_SIGNING_KEY_REPOSITORY_COMPONENT,
+		GLOBAL_STATE_HANDLER_COMPONENT, GLOBAL_STATE_KEY_REPOSITORY_COMPONENT,
+		GLOBAL_STATE_OBSERVER_COMPONENT, GLOBAL_TARGET_A_PARENTCHAIN_LIGHT_CLIENT_SEAL,
 		GLOBAL_TARGET_B_PARENTCHAIN_LIGHT_CLIENT_SEAL, GLOBAL_TOP_POOL_AUTHOR_COMPONENT,
 		GLOBAL_WEB_SOCKET_SERVER_COMPONENT,
 	},
@@ -170,7 +169,6 @@ pub(crate) fn init_enclave(
 	let top_pool_author = create_top_pool_author(
 		connection_registry.clone(),
 		state_handler,
-		ocall_api.clone(),
 		shielding_key_repository.clone(),
 	);
 	GLOBAL_TOP_POOL_AUTHOR_COMPONENT.initialize(top_pool_author.clone());
@@ -309,7 +307,6 @@ pub(crate) fn init_shard(shard: ShardIdentifier) -> EnclaveResult<()> {
 pub fn create_top_pool_author(
 	connection_registry: Arc<EnclaveRpcConnectionRegistry>,
 	state_handler: Arc<EnclaveStateHandler>,
-	ocall_api: Arc<EnclaveOCallApi>,
 	shielding_key_repository: Arc<EnclaveShieldingKeyRepository>,
 ) -> Arc<EnclaveTopPoolAuthor> {
 	let response_channel = Arc::new(RpcResponseChannel::default());
@@ -324,6 +321,5 @@ pub fn create_top_pool_author(
 		AuthorTopFilter::<TrustedCallSigned, Getter>::new(),
 		state_handler,
 		shielding_key_repository,
-		ocall_api,
 	))
 }

--- a/enclave-runtime/src/initialization/mod.rs
+++ b/enclave-runtime/src/initialization/mod.rs
@@ -178,7 +178,13 @@ pub(crate) fn init_enclave(
 	let getter_executor = Arc::new(EnclaveGetterExecutor::new(state_observer));
 
 	let mut io_handler = IoHandler::new();
-	add_common_api(&mut io_handler, top_pool_author, getter_executor, shielding_key_repository);
+	add_common_api(
+		&mut io_handler,
+		top_pool_author,
+		getter_executor,
+		shielding_key_repository,
+		ocall_api.clone(),
+	);
 
 	#[cfg(feature = "sidechain")]
 	{

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -28,7 +28,6 @@
 #[cfg(not(target_env = "sgx"))]
 #[macro_use]
 extern crate sgx_tstd as std;
-extern crate alloc;
 
 use crate::{
 	error::{Error, Result},

--- a/enclave-runtime/src/lib.rs
+++ b/enclave-runtime/src/lib.rs
@@ -28,6 +28,7 @@
 #[cfg(not(target_env = "sgx"))]
 #[macro_use]
 extern crate sgx_tstd as std;
+extern crate alloc;
 
 use crate::{
 	error::{Error, Result},

--- a/enclave-runtime/src/ocall/ffi.rs
+++ b/enclave-runtime/src/ocall/ffi.rs
@@ -77,7 +77,7 @@ extern "C" {
 		resp_size: u32,
 	) -> sgx_status_t;
 
-	pub fn ocall_update_metric(
+	pub fn ocall_update_metrics(
 		ret_val: *mut sgx_status_t,
 		metric_ptr: *const u8,
 		metric_size: u32,

--- a/enclave-runtime/src/ocall/metrics_ocall.rs
+++ b/enclave-runtime/src/ocall/metrics_ocall.rs
@@ -15,11 +15,11 @@
 
 */
 use crate::ocall::{ffi, OcallApi};
-use alloc::vec::Vec;
 use codec::Encode;
 use frame_support::ensure;
 use itp_ocall_api::EnclaveMetricsOCallApi;
 use sgx_types::{sgx_status_t, SgxResult};
+use std::vec::Vec;
 
 impl EnclaveMetricsOCallApi for OcallApi {
 	fn update_metrics<Metric: Encode>(&self, metrics: Vec<Metric>) -> SgxResult<()> {

--- a/enclave-runtime/src/ocall/metrics_ocall.rs
+++ b/enclave-runtime/src/ocall/metrics_ocall.rs
@@ -14,23 +14,23 @@
 	limitations under the License.
 
 */
-
 use crate::ocall::{ffi, OcallApi};
+use alloc::vec::Vec;
 use codec::Encode;
 use frame_support::ensure;
 use itp_ocall_api::EnclaveMetricsOCallApi;
 use sgx_types::{sgx_status_t, SgxResult};
 
 impl EnclaveMetricsOCallApi for OcallApi {
-	fn update_metric<Metric: Encode>(&self, metric: Metric) -> SgxResult<()> {
+	fn update_metrics<Metric: Encode>(&self, metrics: Vec<Metric>) -> SgxResult<()> {
 		let mut rt: sgx_status_t = sgx_status_t::SGX_ERROR_UNEXPECTED;
-		let metric_encoded = metric.encode();
+		let metrics_encoded = metrics.encode();
 
 		let res = unsafe {
-			ffi::ocall_update_metric(
+			ffi::ocall_update_metrics(
 				&mut rt as *mut sgx_status_t,
-				metric_encoded.as_ptr(),
-				metric_encoded.len() as u32,
+				metrics_encoded.as_ptr(),
+				metrics_encoded.len() as u32,
 			)
 		};
 

--- a/enclave-runtime/src/rpc/common_api.rs
+++ b/enclave-runtime/src/rpc/common_api.rs
@@ -68,7 +68,7 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 	io_handler.add_sync_method("author_getShieldingKey", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getShieldingKey");
 		ocall_api
-			.update_metric(EnclaveMetric::RpcRequestsIncrement)
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
 			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let rsa_pubkey = match shielding_key.retrieve_pubkey() {
 			Ok(key) => key,

--- a/enclave-runtime/src/rpc/common_api.rs
+++ b/enclave-runtime/src/rpc/common_api.rs
@@ -65,9 +65,10 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 {
 	add_top_pool_direct_rpc_methods(top_pool_author.clone(), io_handler, ocall_api.clone());
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_getShieldingKey", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getShieldingKey");
-		ocall_api
+		local_ocall_api
 			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
 			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let rsa_pubkey = match shielding_key.retrieve_pubkey() {
@@ -92,8 +93,12 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 	});
 
 	let local_top_pool_author = top_pool_author.clone();
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_getShardVault", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getShardVault");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let shard =
 			local_top_pool_author.list_handled_shards().first().copied().unwrap_or_default();
 		if let Ok(stf_enclave_signer) = get_stf_enclave_signer_from_solo_or_parachain() {
@@ -112,15 +117,23 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 		}
 	});
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_getShard", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getShard");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let shard = top_pool_author.list_handled_shards().first().copied().unwrap_or_default();
 		let json_value = RpcReturnValue::new(shard.encode(), false, DirectRequestStatus::Ok);
 		Ok(json!(json_value.to_hex()))
 	});
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_getFingerprint", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getFingerprint");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let mrenclave = get_stf_enclave_signer_from_solo_or_parachain()
 			.map(|enclave_signer| {
 				enclave_signer.ocall_api.get_mrenclave_of_self().unwrap_or_default()
@@ -131,8 +144,12 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 		Ok(json!(json_value.to_hex()))
 	});
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_getMuRaUrl", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getMuRaUrl");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let url = match GLOBAL_PRIMITIVES_CACHE.get_mu_ra_url() {
 			Ok(url) => url,
 			Err(status) => {
@@ -145,8 +162,12 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 		Ok(json!(json_value.to_hex()))
 	});
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_getUntrustedUrl", move |_: Params| {
 		debug!("worker_api_direct rpc was called: author_getUntrustedUrl");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let url = match GLOBAL_PRIMITIVES_CACHE.get_untrusted_worker_url() {
 			Ok(url) => url,
 			Err(status) => {
@@ -159,27 +180,43 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 		Ok(json!(json_value.to_hex()))
 	});
 
-	io_handler.add_sync_method("chain_subscribeAllHeads", |_: Params| {
+	let local_ocall_api = ocall_api.clone();
+	io_handler.add_sync_method("chain_subscribeAllHeads", move |_: Params| {
 		debug!("worker_api_direct rpc was called: chain_subscribeAllHeads");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
 	});
 
-	io_handler.add_sync_method("state_getMetadata", |_: Params| {
-		debug!("worker_api_direct rpc was called: tate_getMetadata");
+	let local_ocall_api = ocall_api.clone();
+	io_handler.add_sync_method("state_getMetadata", move |_: Params| {
+		debug!("worker_api_direct rpc was called: state_getMetadata");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let metadata = Runtime::metadata();
 		let json_value = RpcReturnValue::new(metadata.into(), false, DirectRequestStatus::Ok);
 		Ok(json!(json_value.to_hex()))
 	});
 
-	io_handler.add_sync_method("state_getRuntimeVersion", |_: Params| {
+	let local_ocall_api = ocall_api.clone();
+	io_handler.add_sync_method("state_getRuntimeVersion", move |_: Params| {
 		debug!("worker_api_direct rpc was called: state_getRuntimeVersion");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
 	});
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("state_executeGetter", move |params: Params| {
 		debug!("worker_api_direct rpc was called: state_executeGetter");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let json_value = match execute_getter_inner(getter_executor.as_ref(), params) {
 			Ok(state_getter_value) => RpcReturnValue {
 				do_watch: false,
@@ -192,8 +229,12 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 		Ok(json!(json_value))
 	});
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("attesteer_forwardDcapQuote", move |params: Params| {
 		debug!("worker_api_direct rpc was called: attesteer_forwardDcapQuote");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let json_value = match forward_dcap_quote_inner(params) {
 			Ok(val) => RpcReturnValue {
 				do_watch: false,
@@ -207,8 +248,12 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 		Ok(json!(json_value))
 	});
 
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("attesteer_forwardIasAttestationReport", move |params: Params| {
 		debug!("worker_api_direct rpc was called: attesteer_forwardIasAttestationReport");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let json_value = match attesteer_forward_ias_attestation_report_inner(params) {
 			Ok(val) => RpcReturnValue {
 				do_watch: false,
@@ -221,21 +266,32 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 
 		Ok(json!(json_value))
 	});
-
-	io_handler.add_sync_method("system_health", |_: Params| {
+	let local_ocall_api = ocall_api.clone();
+	io_handler.add_sync_method("system_health", move |_: Params| {
 		debug!("worker_api_direct rpc was called: system_health");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
 	});
 
-	io_handler.add_sync_method("system_name", |_: Params| {
+	let local_ocall_api = ocall_api.clone();
+	io_handler.add_sync_method("system_name", move |_: Params| {
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		debug!("worker_api_direct rpc was called: system_name");
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
 	});
 
-	io_handler.add_sync_method("system_version", |_: Params| {
+	let local_ocall_api = ocall_api.clone();
+	io_handler.add_sync_method("system_version", move |_: Params| {
 		debug!("worker_api_direct rpc was called: system_version");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let parsed = "world";
 		Ok(Value::String(format!("hello, {}", parsed)))
 	});

--- a/enclave-runtime/src/rpc/common_api.rs
+++ b/enclave-runtime/src/rpc/common_api.rs
@@ -286,7 +286,7 @@ pub fn add_common_api<Author, GetterExecutor, AccessShieldingKey, OCallApi>(
 		Ok(Value::String(format!("hello, {}", parsed)))
 	});
 
-	let local_ocall_api = ocall_api.clone();
+	let local_ocall_api = ocall_api;
 	io_handler.add_sync_method("system_version", move |_: Params| {
 		debug!("worker_api_direct rpc was called: system_version");
 		local_ocall_api

--- a/enclave-runtime/src/test/direct_rpc_tests.rs
+++ b/enclave-runtime/src/test/direct_rpc_tests.rs
@@ -29,6 +29,7 @@ use itp_sgx_crypto::get_rsa3072_repository;
 use itp_sgx_temp_dir::TempDir;
 use itp_stf_executor::{getter_executor::GetterExecutor, mocks::GetStateMock};
 use itp_stf_state_observer::mock::ObserveStateMock;
+use itp_test::mock::onchain_mock::OnchainMock;
 use itp_top_pool_author::mocks::AuthorApiMock;
 use itp_types::{AccountId, DirectRequestStatus, Request, ShardIdentifier};
 use itp_utils::{FromHexPrefixed, ToHexPrefixed};
@@ -51,9 +52,15 @@ pub fn get_state_request_works() {
 	let getter_executor =
 		Arc::new(GetterExecutor::<_, GetStateMock<TestState>, Getter>::new(state_observer));
 	let top_pool_author = Arc::new(AuthorApiMock::default());
-
+	let ocall_api = Arc::new(OnchainMock::default());
 	let mut io_handler = IoHandler::new();
-	add_common_api(&mut io_handler, top_pool_author, getter_executor, Arc::new(rsa_repository));
+	add_common_api(
+		&mut io_handler,
+		top_pool_author,
+		getter_executor,
+		Arc::new(rsa_repository),
+		ocall_api,
+	);
 
 	let rpc_handler = Arc::new(RpcWsHandler::new(io_handler, watch_extractor, connection_registry));
 

--- a/enclave-runtime/src/test/fixtures/test_setup.rs
+++ b/enclave-runtime/src/test/fixtures/test_setup.rs
@@ -29,8 +29,7 @@ use itp_sgx_externalities::SgxExternalities;
 use itp_stf_executor::executor::StfExecutor;
 use itp_stf_primitives::types::{ShardIdentifier, TrustedOperation};
 use itp_test::mock::{
-	handle_state_mock::HandleStateMock, metrics_ocall_mock::MetricsOCallMock,
-	shielding_crypto_mock::ShieldingCryptoMock,
+	handle_state_mock::HandleStateMock, shielding_crypto_mock::ShieldingCryptoMock,
 };
 use itp_top_pool::{basic_pool::BasicPool, pool::ExtrinsicHash};
 use itp_top_pool_author::{api::SidechainApi, author::Author, top_filter::AllowAllTopsFilter};
@@ -50,7 +49,6 @@ pub type TestTopPoolAuthor = Author<
 	AllowAllTopsFilter<TrustedCallSigned, Getter>,
 	HandleStateMock,
 	TestShieldingKeyRepo,
-	MetricsOCallMock,
 	TrustedCallSigned,
 	Getter,
 >;
@@ -98,7 +96,6 @@ pub fn test_setup() -> (
 			AllowAllTopsFilter::<TrustedCallSigned, Getter>::new(),
 			state_handler.clone(),
 			shielding_key_repo,
-			Arc::new(MetricsOCallMock::default()),
 		)),
 		state,
 		shard,

--- a/enclave-runtime/src/test/mocks/types.rs
+++ b/enclave-runtime/src/test/mocks/types.rs
@@ -27,10 +27,7 @@ use itp_sgx_crypto::{mocks::KeyRepositoryMock, Aes};
 use itp_sgx_externalities::SgxExternalities;
 use itp_stf_executor::executor::StfExecutor;
 use itp_stf_primitives::types::TrustedOperation;
-use itp_test::mock::{
-	handle_state_mock::HandleStateMock, metrics_ocall_mock::MetricsOCallMock,
-	onchain_mock::OnchainMock,
-};
+use itp_test::mock::{handle_state_mock::HandleStateMock, onchain_mock::OnchainMock};
 use itp_top_pool::basic_pool::BasicPool;
 use itp_top_pool_author::{api::SidechainApi, author::Author, top_filter::AllowAllTopsFilter};
 use itp_types::{Block as ParentchainBlock, SignedBlock as SignedParentchainBlock};
@@ -84,7 +81,6 @@ pub type TestTopPoolAuthor = Author<
 	AllowAllTopsFilter<TrustedCallSigned, Getter>,
 	TestStateHandler,
 	TestShieldingKeyRepo,
-	MetricsOCallMock,
 	TrustedCallSigned,
 	Getter,
 >;

--- a/enclave-runtime/src/test/sidechain_aura_tests.rs
+++ b/enclave-runtime/src/test/sidechain_aura_tests.rs
@@ -46,7 +46,7 @@ use itp_sgx_externalities::SgxExternalitiesDiffType;
 use itp_stf_interface::system_pallet::{SystemPalletAccountInterface, SystemPalletEventInterface};
 use itp_stf_primitives::types::{StatePayload, TrustedOperation};
 use itp_stf_state_handler::handle_state::HandleState;
-use itp_test::mock::{handle_state_mock::HandleStateMock, metrics_ocall_mock::MetricsOCallMock};
+use itp_test::mock::handle_state_mock::HandleStateMock;
 use itp_time_utils::duration_now;
 use itp_top_pool_author::{top_filter::AllowAllTopsFilter, traits::AuthorApi};
 use itp_types::{AccountId, Block as ParentchainBlock, ShardIdentifier};
@@ -104,7 +104,6 @@ pub fn produce_sidechain_block_and_import_it() {
 		AllowAllTopsFilter::<TrustedCallSigned, Getter>::new(),
 		state_handler.clone(),
 		shielding_key_repo,
-		Arc::new(MetricsOCallMock::default()),
 	));
 	let parentchain_block_import_trigger = Arc::new(TestParentchainBlockImportTrigger::default());
 	let block_importer = Arc::new(TestBlockImporter::new(

--- a/enclave-runtime/src/test/sidechain_event_tests.rs
+++ b/enclave-runtime/src/test/sidechain_event_tests.rs
@@ -38,7 +38,6 @@ use itp_settings::{
 use itp_sgx_externalities::SgxExternalitiesTrait;
 use itp_stf_interface::system_pallet::SystemPalletEventInterface;
 use itp_stf_state_handler::handle_state::HandleState;
-use itp_test::mock::metrics_ocall_mock::MetricsOCallMock;
 use itp_time_utils::duration_now;
 use itp_top_pool_author::top_filter::AllowAllTopsFilter;
 use itp_types::Block as ParentchainBlock;
@@ -92,7 +91,6 @@ pub fn ensure_events_get_reset_upon_block_proposal() {
 		AllowAllTopsFilter::<TrustedCallSigned, Getter>::new(),
 		state_handler.clone(),
 		shielding_key_repo,
-		Arc::new(MetricsOCallMock::default()),
 	));
 	let parentchain_block_import_trigger = Arc::new(TestParentchainBlockImportTrigger::default());
 	let block_importer = Arc::new(TestBlockImporter::new(

--- a/enclave-runtime/src/test/top_pool_tests.rs
+++ b/enclave-runtime/src/test/top_pool_tests.rs
@@ -53,7 +53,6 @@ use itp_sgx_crypto::ShieldingCryptoEncrypt;
 use itp_stf_executor::enclave_signer::StfEnclaveSigner;
 use itp_stf_primitives::{traits::TrustedCallVerification, types::TrustedOperation};
 use itp_stf_state_observer::mock::ObserveStateMock;
-use itp_test::mock::metrics_ocall_mock::MetricsOCallMock;
 use itp_top_pool_author::{top_filter::AllowAllTopsFilter, traits::AuthorApi};
 use itp_types::{
 	parentchain::{Address, ParentchainId},
@@ -86,7 +85,6 @@ pub fn process_indirect_call_in_top_pool() {
 		AllowAllTopsFilter::<TrustedCallSigned, Getter>::new(),
 		state_handler,
 		shielding_key_repo,
-		Arc::new(MetricsOCallMock::default()),
 	));
 
 	let encrypted_indirect_call =
@@ -119,7 +117,6 @@ pub fn submit_shielding_call_to_top_pool() {
 		AllowAllTopsFilter::<TrustedCallSigned, Getter>::new(),
 		state_handler,
 		shielding_key_repo.clone(),
-		Arc::new(MetricsOCallMock::default()),
 	));
 
 	let enclave_signer =

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -33,7 +33,7 @@ use sp_runtime::{MultiAddress, Saturating};
 use std::{fmt::Display, thread, time::Duration};
 use substrate_api_client::{
 	ac_compose_macros::compose_extrinsic, ac_primitives::Bytes, extrinsic::BalancesExtrinsics,
-	GetBalance, GetStorage, GetTransactionPayment, SubmitAndWatch, XtStatus,
+	GetBalance, GetStorage, GetTransactionPayment, SubmitAndWatch, SystemApi, XtStatus,
 };
 use teerex_primitives::SgxAttestationMethod;
 
@@ -73,6 +73,7 @@ pub trait ParentchainAccountInfo {
 	fn free_balance(&self) -> ServiceResult<Balance>;
 	fn parentchain_id(&self) -> ServiceResult<ParentchainId>;
 	fn account_and_role(&self) -> ServiceResult<AccountAndRole>;
+	fn decimals(&self) -> ServiceResult<u64>;
 }
 
 pub struct ParentchainAccountInfoProvider {
@@ -94,6 +95,15 @@ impl ParentchainAccountInfo for ParentchainAccountInfoProvider {
 
 	fn account_and_role(&self) -> ServiceResult<AccountAndRole> {
 		Ok(self.account_and_role.clone())
+	}
+
+	fn decimals(&self) -> ServiceResult<u64> {
+		let properties = self.node_api.get_system_properties()?;
+		properties
+			.get("tokenDecimals")
+			.ok_or(Error::MissingDecimals)?
+			.as_u64()
+			.ok_or(Error::MissingDecimals)
 	}
 }
 

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -103,7 +103,7 @@ impl ParentchainAccountInfo for ParentchainAccountInfoProvider {
 			.get("tokenDecimals")
 			.ok_or(Error::MissingDecimals)?
 			.as_u64()
-			.ok_or(Error::MissingDecimals)
+			.ok_or(Error::ConversionError)
 	}
 }
 

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -50,6 +50,8 @@ pub enum Error {
 	MissingGenesisHeader,
 	#[error("Could not find decimals of the parentchain in metadata")]
 	MissingDecimals,
+	#[error("Could not convert type within expected boundaries")]
+	ConversionError,
 	#[error("Could not find last finalized block of the parentchain")]
 	MissingLastFinalizedBlock,
 	#[error("Could not find block in parentchain")]

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -48,6 +48,8 @@ pub enum Error {
 	EmptyChunk,
 	#[error("Could not find genesis header of the parentchain")]
 	MissingGenesisHeader,
+	#[error("Could not find decimals of the parentchain in metadata")]
+	MissingDecimals,
 	#[error("Could not find last finalized block of the parentchain")]
 	MissingLastFinalizedBlock,
 	#[error("Could not find block in parentchain")]

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -489,12 +489,9 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		.expect("our enclave should be registered at this point");
 	trace!("verified that our enclave is registered: {:?}", my_enclave);
 
-	let (we_are_primary_validateer, re_init_parentchain_needed) = match integritee_rpc_api
-		.primary_worker_for_shard(shard, None)
-		.unwrap()
-	{
-		Some(primary_enclave) =>
-			match primary_enclave.instance_signer() {
+	let (we_are_primary_validateer, re_init_parentchain_needed) =
+		match integritee_rpc_api.primary_worker_for_shard(shard, None).unwrap() {
+			Some(primary_enclave) => match primary_enclave.instance_signer() {
 				AnySigner::Known(MultiSigner::Ed25519(primary)) =>
 					if primary.encode() == tee_accountid.encode() {
 						println!("We are primary worker on this shard and we have been previously running.");
@@ -529,24 +526,24 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 					);
 				},
 			},
-		None => {
-			println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
-			enclave.init_shard(shard.encode()).unwrap();
-			if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
-				enclave
-					.init_shard_creation_parentchain_header(
-						shard,
-						&ParentchainId::Integritee,
-						&register_enclave_xt_header,
-					)
-					.unwrap();
-				debug!("shard config should be initialized on integritee network now");
-				(true, true)
-			} else {
-				(true, false)
-			}
-		},
-	};
+			None => {
+				println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
+				enclave.init_shard(shard.encode()).unwrap();
+				if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
+					enclave
+						.init_shard_creation_parentchain_header(
+							shard,
+							&ParentchainId::Integritee,
+							&register_enclave_xt_header,
+						)
+						.unwrap();
+					debug!("shard config should be initialized on integritee network now");
+					(true, true)
+				} else {
+					(true, false)
+				}
+			},
+		};
 	debug!("getting shard creation: {:?}", enclave.get_shard_creation_info(shard));
 	initialization_handler.registered_on_parentchain();
 
@@ -929,7 +926,7 @@ fn spawn_worker_for_shard_polling<InitializationHandler>(
 					"[+] Found `WorkerForShard` on parentchain state: {:?}",
 					enclave.instance_signer()
 				);
-				break;
+				break
 			}
 			thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
 		}

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -68,7 +68,7 @@ use itp_enclave_api::Enclave;
 use crate::{
 	account_funding::{shard_vault_initial_funds, AccountAndRole},
 	error::ServiceResult,
-	prometheus_metrics::HandleMetrics,
+	prometheus_metrics::{set_static_metrics, HandleMetrics},
 };
 use enclave_bridge_primitives::ShardIdentifier;
 use itc_parentchain::primitives::ParentchainId;
@@ -331,7 +331,7 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	let mrenclave = enclave.get_fingerprint().unwrap();
 	println!("MRENCLAVE={}", mrenclave.0.to_base58());
 	println!("MRENCLAVE in hex {:?}", hex::encode(mrenclave));
-
+	set_static_metrics(VERSION, mrenclave.0.to_base58().as_str());
 	// ------------------------------------------------------------------------
 	// let new workers call us for key provisioning
 	println!("MU-RA server listening on {}", config.mu_ra_url());

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -68,6 +68,7 @@ use itp_enclave_api::Enclave;
 use crate::{
 	account_funding::{shard_vault_initial_funds, AccountAndRole},
 	error::ServiceResult,
+	prometheus_metrics::HandleMetrics,
 };
 use enclave_bridge_primitives::ShardIdentifier;
 use itc_parentchain::primitives::ParentchainId;
@@ -922,7 +923,7 @@ fn spawn_worker_for_shard_polling<InitializationHandler>(
 					"[+] Found `WorkerForShard` on parentchain state: {:?}",
 					enclave.instance_signer()
 				);
-				break
+				break;
 			}
 			thread::sleep(Duration::from_secs(POLL_INTERVAL_SECS));
 		}

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -69,6 +69,7 @@ use crate::{
 	account_funding::{shard_vault_initial_funds, AccountAndRole},
 	error::ServiceResult,
 	prometheus_metrics::{set_static_metrics, HandleMetrics},
+	sidechain_setup::ParentchainIntegriteeSidechainInfoProvider,
 };
 use enclave_bridge_primitives::ShardIdentifier;
 use itc_parentchain::primitives::ParentchainId;
@@ -711,8 +712,13 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 				AccountAndRole::EnclaveSigner(tee_accountid.clone()),
 			)))
 		});
+		let sidechain_info_provider = Arc::new(ParentchainIntegriteeSidechainInfoProvider::new(
+			integritee_rpc_api.clone(),
+			*shard,
+		));
 
-		let metrics_handler = Arc::new(MetricsHandler::new(account_info_providers));
+		let metrics_handler =
+			Arc::new(MetricsHandler::new(account_info_providers, sidechain_info_provider));
 		let metrics_server_port = config
 			.try_parse_metrics_server_port()
 			.expect("metrics server port to be a valid port number");

--- a/service/src/ocall_bridge/bridge_api.rs
+++ b/service/src/ocall_bridge/bridge_api.rs
@@ -220,7 +220,7 @@ pub trait WorkerOnChainBridge {
 /// Trait for updating metrics from inside the enclave.
 #[cfg_attr(test, automock)]
 pub trait MetricsBridge {
-	fn update_metric(&self, metric_encoded: Vec<u8>) -> OCallBridgeResult<()>;
+	fn update_metrics(&self, metrics_encoded: Vec<u8>) -> OCallBridgeResult<()>;
 }
 
 /// Trait for all the OCalls related to sidechain operations

--- a/service/src/ocall_bridge/ffi/mod.rs
+++ b/service/src/ocall_bridge/ffi/mod.rs
@@ -31,5 +31,5 @@ pub mod ipfs;
 pub mod propose_sidechain_blocks;
 pub mod send_to_parentchain;
 pub mod store_sidechain_blocks;
-pub mod update_metric;
+pub mod update_metrics;
 pub mod worker_request;

--- a/service/src/ocall_bridge/ffi/update_metrics.rs
+++ b/service/src/ocall_bridge/ffi/update_metrics.rs
@@ -25,25 +25,25 @@ use std::{slice, sync::Arc};
 ///
 /// FFI are always unsafe
 #[no_mangle]
-pub unsafe extern "C" fn ocall_update_metric(
-	metric_ptr: *const u8,
-	metric_size: u32,
+pub unsafe extern "C" fn ocall_update_metrics(
+	metrics_ptr: *const u8,
+	metrics_size: u32,
 ) -> sgx_status_t {
-	update_metric(metric_ptr, metric_size, Bridge::get_metrics_api())
+	update_metrics(metrics_ptr, metrics_size, Bridge::get_metrics_api())
 }
 
-fn update_metric(
-	metric_ptr: *const u8,
-	metric_size: u32,
+fn update_metrics(
+	metrics_ptr: *const u8,
+	metrics_size: u32,
 	oc_api: Arc<dyn MetricsBridge>,
 ) -> sgx_status_t {
-	let metric_encoded: Vec<u8> =
-		unsafe { Vec::from(slice::from_raw_parts(metric_ptr, metric_size as usize)) };
+	let metrics_encoded: Vec<u8> =
+		unsafe { Vec::from(slice::from_raw_parts(metrics_ptr, metrics_size as usize)) };
 
-	match oc_api.update_metric(metric_encoded) {
+	match oc_api.update_metrics(metrics_encoded) {
 		Ok(_) => sgx_status_t::SGX_SUCCESS,
 		Err(e) => {
-			error!("update_metric o-call failed: {:?}", e);
+			error!("update_metrics o-call failed: {:?}", e);
 			sgx_status_t::SGX_ERROR_UNEXPECTED
 		},
 	}

--- a/service/src/ocall_bridge/metrics_ocall.rs
+++ b/service/src/ocall_bridge/metrics_ocall.rs
@@ -38,14 +38,16 @@ impl<MetricsReceiver> MetricsBridge for MetricsOCall<MetricsReceiver>
 where
 	MetricsReceiver: ReceiveEnclaveMetrics,
 {
-	fn update_metric(&self, metric_encoded: Vec<u8>) -> OCallBridgeResult<()> {
-		let metric: EnclaveMetric =
-			Decode::decode(&mut metric_encoded.as_slice()).map_err(|e| {
-				OCallBridgeError::UpdateMetric(format!("Failed to decode metric: {:?}", e))
+	fn update_metrics(&self, metrics_encoded: Vec<u8>) -> OCallBridgeResult<()> {
+		let metrics: Vec<EnclaveMetric> =
+			Decode::decode(&mut metrics_encoded.as_slice()).map_err(|e| {
+				OCallBridgeError::UpdateMetric(format!("Failed to decode metrics: {:?}", e))
 			})?;
-
-		self.receiver.receive_enclave_metric(metric).map_err(|e| {
-			OCallBridgeError::UpdateMetric(format!("Failed to receive enclave metric: {:?}", e))
-		})
+		for metric in metrics.iter() {
+			self.receiver.receive_enclave_metric(metric.clone()).map_err(|e| {
+				OCallBridgeError::UpdateMetric(format!("Failed to receive enclave metric: {:?}", e))
+			})?
+		}
+		Ok(())
 	}
 }

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -199,7 +199,7 @@ where
 			(self.sidechain.last_finalized_block_number(), self.sidechain.shard())
 		{
 			ENCLAVE_SIDECHAIN_LAST_FINALIZED_BLOCK_NUMBER
-				.with_label_values([format!("{}", shard.0.to_base58()).as_str()].as_slice())
+				.with_label_values([shard.0.to_base58().as_str()].as_slice())
 				.set(last_finalized_block_number as i64);
 		} else {
 			error!("failed to update prometheus metric for sidechain data");

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -89,8 +89,8 @@ lazy_static! {
 		.buckets(DURATION_HISTOGRAM_BUCKETS.into()))
 			.unwrap();
 	static ref ENCLAVE_STF_STATE_UPDATE_EXECUTED_CALLS_COUNT: HistogramVec =
-		register_histogram_vec!(HistogramOpts::new("integritee_worker_enclave_stf_state_update_executed_calls_successful_count", "Enclave STF: how many calls have successfully been executed per update proposal")
-		.buckets(COUNT_HISTOGRAM_BUCKETS.into()), &["success"])
+		register_histogram_vec!(HistogramOpts::new("integritee_worker_enclave_stf_state_update_attempted_calls_count", "Enclave STF: how many calls have been attempted to execute and what was the result? per update proposal")
+		.buckets(COUNT_HISTOGRAM_BUCKETS.into()), &["result"])
 			.unwrap();
 	static ref ENCLAVE_STF_STATE_SIZE: IntGaugeVec =
 		register_int_gauge_vec!("integritee_worker_enclave_stf_state_size_bytes", "Enclave STF state size in Bytes", &["shard"])
@@ -99,7 +99,7 @@ lazy_static! {
 		register_gauge!("integritee_worker_enclave_stf_runtime_total_issuance", "Enclave stf total issuance assuming its native token")
 			.unwrap();
 	static ref ENCLAVE_STF_RUNTIME_PARENTCHAIN_PROCESSED_BLOCK_NUMBER: IntGaugeVec =
-		register_int_gauge_vec!("integritee_worker_enclave_stf_runtime_parentchain_processed_block_number", "Enclave stf. Last processed parentchain block", &["parentchain_id"])
+		register_int_gauge_vec!("integritee_worker_enclave_stf_runtime_parentchain_processed_block_number", "Enclave stf. Last processed parentchain block per parentchain", &["parentchain_id"])
 			.unwrap();
 	static ref ENCLAVE_LABELS: IntGaugeVec =
 		register_int_gauge_vec!("integritee_worker_enclave_labels", "Enclave labels for version and fingerprint AKA MRENCLAVE", &["version", "fingerprint"])

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -81,8 +81,17 @@ lazy_static! {
 		register_histogram!(HistogramOpts::new("integritee_worker_enclave_stf_state_update_executed_calls_failed_count", "Enclave STF: how many calls have failed during execution per update proposal")
 		.buckets(COUNT_HISTOGRAM_BUCKETS.into()))
 			.unwrap();
-	static ref ENCLAVE_STF_TOTAL_ISSUANCE: Gauge =
-		register_gauge!("integritee_worker_enclave_stf_total_issuance", "Enclave stf total issuance assuming its native token")
+	static ref ENCLAVE_STF_RUNTIME_TOTAL_ISSUANCE: Gauge =
+		register_gauge!("integritee_worker_enclave_stf_runtime_total_issuance", "Enclave stf total issuance assuming its native token")
+			.unwrap();
+	static ref ENCLAVE_STF_RUNTIME_PARENTCHAIN_INTEGRITEE_PROCESSED_BLOCK_NUMBER: IntGauge =
+		register_int_gauge!("integritee_worker_enclave_stf_runtime_parentchain_integritee_processed_block_number", "Enclave stf. Last processed parentchain block for Integritee")
+			.unwrap();
+	static ref ENCLAVE_STF_RUNTIME_PARENTCHAIN_TARGET_A_PROCESSED_BLOCK_NUMBER: IntGauge =
+		register_int_gauge!("integritee_worker_enclave_stf_runtime_parentchain_target_a_processed_block_number", "Enclave stf. Last processed parentchain block for Target A")
+			.unwrap();
+	static ref ENCLAVE_STF_RUNTIME_PARENTCHAIN_TARGET_B_PROCESSED_BLOCK_NUMBER: IntGauge =
+		register_int_gauge!("integritee_worker_enclave_stf_runtime_parentchain_target_b_processed_block_number", "Enclave stf. Last processed parentchain block for Target B")
 			.unwrap();
 	static ref ENCLAVE_FINGERPRINT: IntCounter =
 		register_int_counter!("integritee_worker_enclave_fingerprint", "Enclave fingerprint AKA MRENCLAVE")
@@ -205,7 +214,15 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 				ENCLAVE_STF_STATE_UPDATE_EXECUTED_CALLS_SUCCESSFUL_COUNT.observe(count.into()),
 			EnclaveMetric::StfStateUpdateExecutedCallsFailedCount(count) =>
 				ENCLAVE_STF_STATE_UPDATE_EXECUTED_CALLS_FAILED_COUNT.observe(count.into()),
-			EnclaveMetric::StfTotalIssuanceSet(balance) => ENCLAVE_STF_TOTAL_ISSUANCE.set(balance),
+			EnclaveMetric::StfRuntimeTotalIssuanceSet(balance) =>
+				ENCLAVE_STF_RUNTIME_TOTAL_ISSUANCE.set(balance),
+			EnclaveMetric::StfRuntimeParentchainIntegriteeProcessedBlockNumberSet(bn) =>
+				ENCLAVE_STF_RUNTIME_PARENTCHAIN_INTEGRITEE_PROCESSED_BLOCK_NUMBER.set(bn.into()),
+			EnclaveMetric::StfRuntimeParentchainTargetAProcessedBlockNumberSet(bn) =>
+				ENCLAVE_STF_RUNTIME_PARENTCHAIN_TARGET_A_PROCESSED_BLOCK_NUMBER.set(bn.into()),
+			EnclaveMetric::StfRuntimeParentchainTargetBProcessedBlockNumberSet(bn) =>
+				ENCLAVE_STF_RUNTIME_PARENTCHAIN_TARGET_B_PROCESSED_BLOCK_NUMBER.set(bn.into()),
+
 			#[cfg(feature = "teeracle")]
 			EnclaveMetric::ExchangeRateOracle(m) => update_teeracle_metrics(m)?,
 			#[cfg(not(feature = "teeracle"))]

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -77,6 +77,9 @@ lazy_static! {
 		register_histogram_vec!(HistogramOpts::new("integritee_worker_enclave_sidechain_aura_remaining_durations", "Enclave Sidechain AURA durations: remaining time in slot for different stages")
 		.buckets(SLOT_TIME_HISTOGRAM_BUCKETS.into()), &["stage"])
 			.unwrap();
+	static ref ENCLAVE_SIDECHAIN_PEER_COUNT: IntGauge =
+		register_int_gauge!("integritee_worker_enclave_sidechain_peer_count", "Enclave Sidechain peer validateer count")
+			.unwrap();
 	static ref ENCLAVE_STF_STATE_UPDATE_EXECUTION_DURATION: Histogram =
 		register_histogram!(HistogramOpts::new("integritee_worker_enclave_stf_state_update_execution_duration", "Enclave STF: state update execution duration from before on_initialize to after on_finalize")
 		.buckets(DURATION_HISTOGRAM_BUCKETS.into()))
@@ -267,6 +270,11 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 pub fn set_static_metrics(version: &str, fingerprint_b58: &str) {
 	ENCLAVE_LABELS.with_label_values([version, fingerprint_b58].as_slice()).set(0)
 }
+
+pub fn set_sidechain_peer_count_metric(count: u32) {
+	ENCLAVE_SIDECHAIN_PEER_COUNT.set(count as i64)
+}
+
 // Data structure that matches with REST API JSON
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -172,9 +172,12 @@ where
 
 	async fn update_metrics(&self) {
 		for wallet in &self.wallets {
-			if let (Ok(balance), Ok(parentchain_id), Ok(account_and_role)) =
-				(wallet.free_balance(), wallet.parentchain_id(), wallet.account_and_role())
-			{
+			if let (Ok(balance), Ok(parentchain_id), Ok(account_and_role), Ok(decimals)) = (
+				wallet.free_balance(),
+				wallet.parentchain_id(),
+				wallet.account_and_role(),
+				wallet.decimals(),
+			) {
 				ACCOUNT_FREE_BALANCE
 					.with_label_values(
 						[
@@ -183,7 +186,7 @@ where
 						]
 						.as_slice(),
 					)
-					.set(balance as f64)
+					.set(balance as f64 / (10.0f64.powf(decimals as f64)));
 			} else {
 				error!("failed to update prometheus metric for a wallet");
 			}

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -60,8 +60,8 @@ lazy_static! {
 	static ref ENCLAVE_RPC_REQUESTS: IntCounter =
 		register_int_counter!("integritee_worker_enclave_rpc_requests", "Enclave RPC requests")
 			.unwrap();
-	static ref ENCLAVE_RPC_DIRECT_TC_RECEIVED: IntCounter =
-		register_int_counter!("integritee_worker_enclave_rpc_direct_tc_received", "Enclave RPC: how many direct trusted calls have been received")
+	static ref ENCLAVE_RPC_TC_RECEIVED: IntCounter =
+		register_int_counter!("integritee_worker_enclave_rpc_tc_received", "Enclave RPC: how many trusted calls have been received via rpc")
 			.unwrap();
 }
 
@@ -183,7 +183,7 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 				ENCLAVE_RPC_REQUESTS.inc();
 			},
 			EnclaveMetric::RpcTrustedCallsIncrement => {
-				ENCLAVE_RPC_DIRECT_TC_RECEIVED.inc();
+				ENCLAVE_RPC_TC_RECEIVED.inc();
 			},
 			#[cfg(feature = "teeracle")]
 			EnclaveMetric::ExchangeRateOracle(m) => update_teeracle_metrics(m)?,

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -69,8 +69,8 @@ lazy_static! {
 	static ref ACCOUNT_FREE_BALANCE: GaugeVec =
 		register_gauge_vec!("integritee_worker_account_free_balance", "Free balance of an account on a parentchain with a role (lossy f64)", &["parentchain","role"])
 			.unwrap();
-	static ref ENCLAVE_TOP_POOL_SIZE: IntGauge =
-		register_int_gauge!("integritee_worker_enclave_top_pool_size", "pending TOPs in pool")
+	static ref ENCLAVE_TOP_POOL_A_PRIORI_SIZE: IntGauge =
+		register_int_gauge!("integritee_worker_enclave_top_pool_a_priori_size", "pending TOPs in pool before executing the block")
 			.unwrap();
 	static ref ENCLAVE_RPC_REQUESTS: IntCounter =
 		register_int_counter!("integritee_worker_enclave_rpc_requests", "Enclave RPC requests")
@@ -252,7 +252,8 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 		match metric {
 			EnclaveMetric::SetSidechainBlockHeight(h) =>
 				ENCLAVE_SIDECHAIN_BLOCK_HEIGHT.set(h.try_into().unwrap_or(i64::MAX)),
-			EnclaveMetric::TopPoolSizeSet(pool_size) => ENCLAVE_TOP_POOL_SIZE.set(pool_size as i64),
+			EnclaveMetric::TopPoolAPrioriSizeSet(pool_size) =>
+				ENCLAVE_TOP_POOL_A_PRIORI_SIZE.set(pool_size as i64),
 			EnclaveMetric::RpcTrustedCallsIncrement => ENCLAVE_RPC_TC_RECEIVED.inc(),
 			EnclaveMetric::RpcRequestsIncrement => ENCLAVE_RPC_REQUESTS.inc(),
 			EnclaveMetric::SidechainAuraSlotRemainingTimes(label, duration) =>

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -38,7 +38,9 @@ use itc_rest_client::{
 use itp_enclave_metrics::EnclaveMetric;
 use lazy_static::lazy_static;
 use log::*;
-use prometheus::{proto::MetricFamily, register_int_gauge, IntGauge};
+use prometheus::{
+	proto::MetricFamily, register_int_counter, register_int_gauge, IntCounter, IntGauge,
+};
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
 use warp::{Filter, Rejection, Reply};
@@ -54,6 +56,12 @@ lazy_static! {
 			.unwrap();
 	static ref ENCLAVE_SIDECHAIN_TOP_POOL_SIZE: IntGauge =
 		register_int_gauge!("integritee_worker_enclave_sidechain_top_pool_size", "Enclave sidechain top pool size")
+			.unwrap();
+	static ref ENCLAVE_RPC_REQUESTS: IntCounter =
+		register_int_counter!("integritee_worker_enclave_rpc_requests", "Enclave RPC requests")
+			.unwrap();
+	static ref ENCLAVE_RPC_DIRECT_TC_RECEIVED: IntCounter =
+		register_int_counter!("integritee_worker_enclave_rpc_direct_tc_received", "Enclave RPC: how many direct trusted calls have been received")
 			.unwrap();
 }
 
@@ -170,6 +178,12 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 			},
 			EnclaveMetric::TopPoolSizeDecrement => {
 				ENCLAVE_SIDECHAIN_TOP_POOL_SIZE.dec();
+			},
+			EnclaveMetric::RpcRequestsIncrement => {
+				ENCLAVE_RPC_REQUESTS.inc();
+			},
+			EnclaveMetric::RpcTrustedCallsIncrement => {
+				ENCLAVE_RPC_DIRECT_TC_RECEIVED.inc();
 			},
 			#[cfg(feature = "teeracle")]
 			EnclaveMetric::ExchangeRateOracle(m) => update_teeracle_metrics(m)?,

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -39,8 +39,8 @@ use itp_enclave_metrics::EnclaveMetric;
 use lazy_static::lazy_static;
 use log::*;
 use prometheus::{
-	proto::MetricFamily, register_histogram, register_int_counter, register_int_gauge, Histogram,
-	HistogramOpts, IntCounter, IntGauge,
+	proto::MetricFamily, register_gauge, register_histogram, register_int_counter,
+	register_int_gauge, Gauge, Histogram, HistogramOpts, IntCounter, IntGauge,
 };
 use serde::{Deserialize, Serialize};
 use std::{net::SocketAddr, sync::Arc};
@@ -80,6 +80,9 @@ lazy_static! {
 	static ref ENCLAVE_STF_STATE_UPDATE_EXECUTED_CALLS_FAILED_COUNT: Histogram =
 		register_histogram!(HistogramOpts::new("integritee_worker_enclave_stf_state_update_executed_calls_failed_count", "Enclave STF: how many calls have failed during execution per update proposal")
 		.buckets(COUNT_HISTOGRAM_BUCKETS.into()))
+			.unwrap();
+	static ref ENCLAVE_STF_TOTAL_ISSUANCE: Gauge =
+		register_gauge!("integritee_worker_enclave_stf_total_issuance", "Enclave stf total issuance assuming its native token")
 			.unwrap();
 	static ref ENCLAVE_FINGERPRINT: IntCounter =
 		register_int_counter!("integritee_worker_enclave_fingerprint", "Enclave fingerprint AKA MRENCLAVE")
@@ -202,6 +205,7 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 				ENCLAVE_STF_STATE_UPDATE_EXECUTED_CALLS_SUCCESSFUL_COUNT.observe(count.into()),
 			EnclaveMetric::StfStateUpdateExecutedCallsFailedCount(count) =>
 				ENCLAVE_STF_STATE_UPDATE_EXECUTED_CALLS_FAILED_COUNT.observe(count.into()),
+			EnclaveMetric::StfTotalIssuanceSet(balance) => ENCLAVE_STF_TOTAL_ISSUANCE.set(balance),
 			#[cfg(feature = "teeracle")]
 			EnclaveMetric::ExchangeRateOracle(m) => update_teeracle_metrics(m)?,
 			#[cfg(not(feature = "teeracle"))]

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -57,25 +57,24 @@ const COUNT_HISTOGRAM_BUCKETS: [f64; 12] =
 	[0.5, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0];
 
 lazy_static! {
-	/// Register all the prometheus metrics we want to monitor (aside from the default process ones).
-
+	// Register all the prometheus metrics we want to monitor (aside from the default process ones).
 	static ref ACCOUNT_FREE_BALANCE: GaugeVec =
 		register_gauge_vec!("integritee_worker_account_free_balance", "Free balance of an account on a parentchain with a role (lossy f64)", &["parentchain","role"])
 			.unwrap();
-	static ref ENCLAVE_SIDECHAIN_BLOCK_HEIGHT: IntGauge =
-		register_int_gauge!("integritee_worker_enclave_sidechain_block_height", "Enclave sidechain block height")
-			.unwrap();
-	static ref ENCLAVE_SIDECHAIN_TOP_POOL_SIZE: IntGauge =
-		register_int_gauge!("integritee_worker_enclave_sidechain_top_pool_size", "Enclave sidechain top pool size")
-			.unwrap();
-	static ref ENCLAVE_SIDECHAIN_LAST_FINALIZED_BLOCK_NUMBER: IntGaugeVec =
-		register_int_gauge_vec!("integritee_worker_enclave_sidechain_last_finalized_block_number", "Enclave sidechain last finalized block number (on L1)", &["shard"])
+	static ref ENCLAVE_TOP_POOL_SIZE: IntGauge =
+		register_int_gauge!("integritee_worker_enclave_top_pool_size", "pending TOPs in pool")
 			.unwrap();
 	static ref ENCLAVE_RPC_REQUESTS: IntCounter =
 		register_int_counter!("integritee_worker_enclave_rpc_requests", "Enclave RPC requests")
 			.unwrap();
 	static ref ENCLAVE_RPC_TC_RECEIVED: IntCounter =
 		register_int_counter!("integritee_worker_enclave_rpc_tc_received", "Enclave RPC: how many trusted calls have been received via rpc")
+			.unwrap();
+	static ref ENCLAVE_SIDECHAIN_BLOCK_HEIGHT: IntGauge =
+		register_int_gauge!("integritee_worker_enclave_sidechain_block_height", "Enclave sidechain block height")
+			.unwrap();
+	static ref ENCLAVE_SIDECHAIN_LAST_FINALIZED_BLOCK_NUMBER: IntGaugeVec =
+		register_int_gauge_vec!("integritee_worker_enclave_sidechain_last_finalized_block_number", "Enclave sidechain last finalized block number (on L1)", &["shard"])
 			.unwrap();
 	static ref ENCLAVE_SIDECHAIN_AURA_REMAINING_DURATIONS: HistogramVec =
 		register_histogram_vec!(HistogramOpts::new("integritee_worker_enclave_sidechain_aura_remaining_durations", "Enclave Sidechain AURA durations: remaining time in slot for different stages")
@@ -238,12 +237,9 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 		match metric {
 			EnclaveMetric::SetSidechainBlockHeight(h) =>
 				ENCLAVE_SIDECHAIN_BLOCK_HEIGHT.set(h as i64),
-			EnclaveMetric::TopPoolSizeSet(pool_size) =>
-				ENCLAVE_SIDECHAIN_TOP_POOL_SIZE.set(pool_size as i64),
-			EnclaveMetric::TopPoolSizeIncrement => ENCLAVE_SIDECHAIN_TOP_POOL_SIZE.inc(),
-			EnclaveMetric::TopPoolSizeDecrement => ENCLAVE_SIDECHAIN_TOP_POOL_SIZE.dec(),
-			EnclaveMetric::RpcRequestsIncrement => ENCLAVE_RPC_REQUESTS.inc(),
+			EnclaveMetric::TopPoolSizeSet(pool_size) => ENCLAVE_TOP_POOL_SIZE.set(pool_size as i64),
 			EnclaveMetric::RpcTrustedCallsIncrement => ENCLAVE_RPC_TC_RECEIVED.inc(),
+			EnclaveMetric::RpcRequestsIncrement => ENCLAVE_RPC_REQUESTS.inc(),
 			EnclaveMetric::SidechainAuraSlotRemainingTimes(label, duration) =>
 				ENCLAVE_SIDECHAIN_AURA_REMAINING_DURATIONS
 					.with_label_values([label.as_str()].as_slice())

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -37,6 +37,7 @@ use itc_rest_client::{
 	RestGet, RestPath,
 };
 use itp_enclave_metrics::EnclaveMetric;
+use itp_types::EnclaveFingerprint;
 use lazy_static::lazy_static;
 use log::*;
 use prometheus::{
@@ -103,8 +104,8 @@ lazy_static! {
 	static ref ENCLAVE_STF_RUNTIME_PARENTCHAIN_TARGET_B_PROCESSED_BLOCK_NUMBER: IntGauge =
 		register_int_gauge!("integritee_worker_enclave_stf_runtime_parentchain_target_b_processed_block_number", "Enclave stf. Last processed parentchain block for Target B")
 			.unwrap();
-	static ref ENCLAVE_FINGERPRINT: IntCounter =
-		register_int_counter!("integritee_worker_enclave_fingerprint", "Enclave fingerprint AKA MRENCLAVE")
+	static ref ENCLAVE_LABELS: IntGaugeVec =
+		register_int_gauge_vec!("integritee_worker_enclave_labels", "Enclave labels for version and fingerprint AKA MRENCLAVE", &["version", "fingerprint"])
 			.unwrap();
 }
 
@@ -263,6 +264,9 @@ impl ReceiveEnclaveMetrics for EnclaveMetricsReceiver {
 	}
 }
 
+pub fn set_static_metrics(version: &str, fingerprint_b58: &str) {
+	ENCLAVE_LABELS.with_label_values([version, fingerprint_b58].as_slice()).set(0)
+}
 // Data structure that matches with REST API JSON
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -349,6 +349,7 @@ pub struct PrometheusMarblerunEventActivation {
 	pub quote: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn start_prometheus_metrics_server<E>(
 	enclave: &Arc<E>,
 	tee_account_id: &AccountId32,
@@ -389,24 +390,22 @@ pub fn start_prometheus_metrics_server<E>(
 				.into(),
 		),
 	)));
-	maybe_target_a_rpc_api.map(|api| {
+	if let Some(api) = maybe_target_a_rpc_api {
 		account_info_providers.push(Arc::new(ParentchainAccountInfoProvider::new(
 			ParentchainId::TargetA,
-			api.clone(),
+			api,
 			AccountAndRole::EnclaveSigner(tee_account_id.clone()),
 		)))
-	});
-	maybe_target_b_rpc_api.map(|api| {
+	};
+	if let Some(api) = maybe_target_b_rpc_api {
 		account_info_providers.push(Arc::new(ParentchainAccountInfoProvider::new(
 			ParentchainId::TargetB,
-			api.clone(),
+			api,
 			AccountAndRole::EnclaveSigner(tee_account_id.clone()),
 		)))
-	});
-	let sidechain_info_provider = Arc::new(ParentchainIntegriteeSidechainInfoProvider::new(
-		integritee_rpc_api.clone(),
-		*shard,
-	));
+	};
+	let sidechain_info_provider =
+		Arc::new(ParentchainIntegriteeSidechainInfoProvider::new(integritee_rpc_api, *shard));
 
 	let metrics_handler =
 		Arc::new(MetricsHandler::new(account_info_providers, sidechain_info_provider));

--- a/service/src/sidechain_setup.rs
+++ b/service/src/sidechain_setup.rs
@@ -79,7 +79,7 @@ impl ParentchainIntegriteeSidechainInfo for ParentchainIntegriteeSidechainInfoPr
 						}
 					})
 					.next()
-					.ok_or(Error::NoWorkerForShardFound(self.shard))
+					.ok_or_else(|| Error::NoWorkerForShardFound(self.shard))
 			})
 	}
 	fn shard(&self) -> ServiceResult<ShardIdentifier> {

--- a/service/src/sidechain_setup.rs
+++ b/service/src/sidechain_setup.rs
@@ -16,23 +16,82 @@
 */
 
 use crate::{
+	account_funding::AccountAndRole,
 	config::Config,
 	error::{Error, ServiceResult},
 	parentchain_handler::HandleParentchain,
 };
 use futures::executor::block_on;
+use itp_api_client_types::ParentchainApi;
 use itp_enclave_api::{enclave_base::EnclaveBase, sidechain::Sidechain};
+use itp_node_api::api_client::{pallet_sidechain::PalletSidechainApi, PalletTeerexApi};
 use itp_settings::{
 	files::{SIDECHAIN_PURGE_INTERVAL, SIDECHAIN_PURGE_LIMIT},
 	sidechain::SLOT_DURATION,
 };
-use itp_types::{Header, ShardIdentifier};
+use itp_types::{
+	parentchain::{AccountId, Balance, ParentchainId},
+	Header, ShardIdentifier, SidechainBlockNumber,
+};
 use its_consensus_slots::start_slot_worker;
 use its_primitives::types::block::SignedBlock as SignedSidechainBlock;
 use its_storage::{interface::FetchBlocks, start_sidechain_pruning_loop, BlockPruner};
 use log::*;
+use sp_runtime::{traits::IdentifyAccount, MultiSigner};
 use std::{sync::Arc, thread};
+use teerex_primitives::AnySigner;
 use tokio::runtime::Handle;
+
+/// Information about an account on a specified parentchain.
+pub trait ParentchainIntegriteeSidechainInfo {
+	fn last_finalized_block_number(&self) -> ServiceResult<SidechainBlockNumber>;
+	fn primary_worker_for_shard(&self) -> ServiceResult<AccountId>;
+	fn shard(&self) -> ServiceResult<ShardIdentifier>;
+}
+
+pub struct ParentchainIntegriteeSidechainInfoProvider {
+	node_api: ParentchainApi,
+	shard: ShardIdentifier,
+}
+
+impl ParentchainIntegriteeSidechainInfo for ParentchainIntegriteeSidechainInfoProvider {
+	fn last_finalized_block_number(&self) -> ServiceResult<SidechainBlockNumber> {
+		self.node_api
+			.latest_sidechain_block_confirmation(&self.shard, None)?
+			.map(|confirmation| confirmation.block_number)
+			.ok_or(Error::MissingLastFinalizedBlock)
+	}
+
+	fn primary_worker_for_shard(&self) -> ServiceResult<AccountId> {
+		self.node_api
+			.primary_worker_for_shard(&self.shard, None)
+			.map_err(|e| e.into())
+			.and_then(|maybe_enclave| {
+				maybe_enclave
+					.iter()
+					.filter_map(|enclave| {
+						if let AnySigner::Known(MultiSigner::Ed25519(signer)) =
+							enclave.instance_signer()
+						{
+							Some(signer.into_account().into())
+						} else {
+							None
+						}
+					})
+					.next()
+					.ok_or(Error::NoWorkerForShardFound(self.shard))
+			})
+	}
+	fn shard(&self) -> ServiceResult<ShardIdentifier> {
+		Ok(self.shard)
+	}
+}
+
+impl ParentchainIntegriteeSidechainInfoProvider {
+	pub fn new(node_api: ParentchainApi, shard: ShardIdentifier) -> Self {
+		ParentchainIntegriteeSidechainInfoProvider { node_api, shard }
+	}
+}
 
 pub(crate) fn sidechain_start_untrusted_rpc_server<SidechainStorage>(
 	config: &Config,

--- a/service/src/tests/mocks/update_worker_peers_mock.rs
+++ b/service/src/tests/mocks/update_worker_peers_mock.rs
@@ -21,7 +21,7 @@ use itp_types::ShardIdentifier;
 pub struct UpdateWorkerPeersMock;
 
 impl UpdateWorkerPeers for UpdateWorkerPeersMock {
-	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()> {
+	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<u32> {
 		Ok(42)
 	}
 }

--- a/service/src/tests/mocks/update_worker_peers_mock.rs
+++ b/service/src/tests/mocks/update_worker_peers_mock.rs
@@ -22,6 +22,6 @@ pub struct UpdateWorkerPeersMock;
 
 impl UpdateWorkerPeers for UpdateWorkerPeersMock {
 	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()> {
-		Ok(())
+		Ok(42)
 	}
 }

--- a/service/src/worker.rs
+++ b/service/src/worker.rs
@@ -128,9 +128,11 @@ pub trait UpdatePeers {
 
 	fn set_peers(&self, peers: Vec<Url>) -> WorkerResult<()>;
 
-	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()> {
+	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<u32> {
 		let peers = self.search_peers(shard)?;
-		self.set_peers(peers)
+		let peers_count = peers.len() as u32;
+		self.set_peers(peers)?;
+		Ok(peers_count)
 	}
 }
 

--- a/service/src/worker_peers_updater.rs
+++ b/service/src/worker_peers_updater.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 /// Updates the peers of the global worker.
 #[cfg_attr(test, automock)]
 pub trait UpdateWorkerPeers {
-	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()>;
+	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<u32>;
 }
 
 pub struct WorkerPeersUpdater<WorkerType> {
@@ -45,7 +45,7 @@ impl<WorkerType> UpdateWorkerPeers for WorkerPeersUpdater<WorkerType>
 where
 	WorkerType: UpdatePeers,
 {
-	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<()> {
+	fn update_peers(&self, shard: ShardIdentifier) -> WorkerResult<u32> {
 		self.worker.update_peers(shard)
 	}
 }

--- a/sidechain/consensus/aura/src/block_importer.rs
+++ b/sidechain/consensus/aura/src/block_importer.rs
@@ -90,8 +90,7 @@ impl<
 		ParentchainBlockImporter,
 		TCS,
 		G,
-	>
-where
+	> where
 	Authority: Pair,
 	Authority::Public: std::fmt::Debug + UncheckedFrom<[u8; 32]>,
 	ParentchainBlock: ParentchainBlockTrait<Hash = H256>,
@@ -182,8 +181,7 @@ impl<
 		ParentchainBlockImporter,
 		TCS,
 		G,
-	>
-where
+	> where
 	Authority: Pair,
 	Authority::Public: std::fmt::Debug + UncheckedFrom<[u8; 32]>,
 	ParentchainBlock: ParentchainBlockTrait<Hash = H256>,

--- a/sidechain/consensus/aura/src/block_importer.rs
+++ b/sidechain/consensus/aura/src/block_importer.rs
@@ -90,7 +90,8 @@ impl<
 		ParentchainBlockImporter,
 		TCS,
 		G,
-	> where
+	>
+where
 	Authority: Pair,
 	Authority::Public: std::fmt::Debug + UncheckedFrom<[u8; 32]>,
 	ParentchainBlock: ParentchainBlockTrait<Hash = H256>,
@@ -181,7 +182,8 @@ impl<
 		ParentchainBlockImporter,
 		TCS,
 		G,
-	> where
+	>
+where
 	Authority: Pair,
 	Authority::Public: std::fmt::Debug + UncheckedFrom<[u8; 32]>,
 	ParentchainBlock: ParentchainBlockTrait<Hash = H256>,
@@ -342,7 +344,7 @@ impl<
 		// Send metric about sidechain block height (i.e. block number)
 		let block_height_metric =
 			EnclaveMetric::SetSidechainBlockHeight(sidechain_block.header().block_number());
-		if let Err(e) = self.ocall_api.update_metric(block_height_metric) {
+		if let Err(e) = self.ocall_api.update_metrics(vec![block_height_metric]) {
 			warn!("Failed to update sidechain block height metric: {:?}", e);
 		}
 

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
+itp-ocall-api = { path = "../../core-primitives/ocall-api", default-features = false }
 itp-import-queue = { path = "../../core-primitives/import-queue", default-features = false }
 itp-rpc = { path = "../../core-primitives/rpc", default-features = false }
 itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-features = false }
@@ -16,7 +17,7 @@ itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-
 itp-types = { path = "../../core-primitives/types", default-features = false }
 itp-utils = { path = "../../core-primitives/utils", default-features = false }
 its-primitives = { path = "../primitives", default-features = false }
-
+itp-enclave-metrics = { path = "../../core-primitives/enclave-metrics", default-features = false }
 # sgx enabled external libraries
 jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 rust-base58_sgx = { package = "rust-base58", rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/rust-base58-sgx", optional = true, default-features = false, features = ["mesalock_sgx"] }

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -9,15 +9,15 @@ edition = "2021"
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 
 # local dependencies
-itp-ocall-api = { path = "../../core-primitives/ocall-api", default-features = false }
+itp-enclave-metrics = { path = "../../core-primitives/enclave-metrics", default-features = false }
 itp-import-queue = { path = "../../core-primitives/import-queue", default-features = false }
+itp-ocall-api = { path = "../../core-primitives/ocall-api", default-features = false }
 itp-rpc = { path = "../../core-primitives/rpc", default-features = false }
 itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-features = false }
 itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-features = false }
 itp-types = { path = "../../core-primitives/types", default-features = false }
 itp-utils = { path = "../../core-primitives/utils", default-features = false }
 its-primitives = { path = "../primitives", default-features = false }
-itp-enclave-metrics = { path = "../../core-primitives/enclave-metrics", default-features = false }
 # sgx enabled external libraries
 jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
 rust-base58_sgx = { package = "rust-base58", rev = "sgx_1.1.3", git = "https://github.com/mesalock-linux/rust-base58-sgx", optional = true, default-features = false, features = ["mesalock_sgx"] }

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -53,7 +53,7 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 	io_handler.add_sync_method("author_submitAndWatchExtrinsic", move |params: Params| {
 		debug!("worker_api_direct rpc was called: author_submitAndWatchExtrinsic");
 		ocall_api
-			.update_metric(EnclaveMetric::RpcRequestsIncrement)
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
 			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let json_value = match author_submit_extrinsic_inner(watch_author.clone(), params) {
 			Ok(hash_value) => RpcReturnValue {

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -135,7 +135,7 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 	});
 
 	let local_author = top_pool_author;
-	let local_ocall_api = ocall_api.clone();
+	let local_ocall_api = ocall_api;
 	io_handler.add_sync_method("author_pendingTrustedCallsFor", move |params: Params| {
 		debug!("worker_api_direct rpc was called: author_pendingTrustedCallsFor");
 		local_ocall_api

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -49,13 +49,17 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 	G: PartialEq + Encode + Decode + Debug + Send + Sync + 'static,
 	OCallApi: EnclaveMetricsOCallApi + Send + Sync + 'static,
 {
-	let watch_author = top_pool_author.clone();
+	let local_author = top_pool_author.clone();
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_submitAndWatchExtrinsic", move |params: Params| {
 		debug!("worker_api_direct rpc was called: author_submitAndWatchExtrinsic");
-		ocall_api
-			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+		local_ocall_api
+			.update_metrics(vec![
+				EnclaveMetric::RpcRequestsIncrement,
+				EnclaveMetric::RpcTrustedCallsIncrement,
+			])
 			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
-		let json_value = match author_submit_extrinsic_inner(watch_author.clone(), params) {
+		let json_value = match author_submit_extrinsic_inner(local_author.clone(), params) {
 			Ok(hash_value) => RpcReturnValue {
 				do_watch: true,
 				value: hash_value.encode(),
@@ -69,10 +73,17 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 		Ok(json!(json_value))
 	});
 
-	let submit_author = top_pool_author.clone();
+	let local_author = top_pool_author.clone();
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_submitExtrinsic", move |params: Params| {
 		debug!("worker_api_direct rpc was called: author_submitExtrinsic");
-		let json_value = match author_submit_extrinsic_inner(submit_author.clone(), params) {
+		local_ocall_api
+			.update_metrics(vec![
+				EnclaveMetric::RpcRequestsIncrement,
+				EnclaveMetric::RpcTrustedCallsIncrement,
+			])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
+		let json_value = match author_submit_extrinsic_inner(local_author.clone(), params) {
 			Ok(hash_value) => RpcReturnValue {
 				do_watch: false,
 				value: hash_value.encode(),
@@ -86,9 +97,13 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 		Ok(json!(json_value))
 	});
 
-	let pending_author = top_pool_author.clone();
+	let local_author = top_pool_author.clone();
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_pendingExtrinsics", move |params: Params| {
 		debug!("worker_api_direct rpc was called: author_pendingExtrinsics");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		match params.parse::<Vec<String>>() {
 			Ok(shards) => {
 				let mut retrieved_operations = vec![];
@@ -101,7 +116,7 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 							return Ok(json!(compute_hex_encoded_return_error(error_msg.as_str())))
 						},
 					};
-					if let Ok(vec_of_operations) = pending_author.pending_tops(shard) {
+					if let Ok(vec_of_operations) = local_author.pending_tops(shard) {
 						retrieved_operations.push(vec_of_operations);
 					}
 				}
@@ -119,9 +134,13 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 		}
 	});
 
-	let pending_author = top_pool_author;
+	let local_author = top_pool_author;
+	let local_ocall_api = ocall_api.clone();
 	io_handler.add_sync_method("author_pendingTrustedCallsFor", move |params: Params| {
 		debug!("worker_api_direct rpc was called: author_pendingTrustedCallsFor");
+		local_ocall_api
+			.update_metrics(vec![EnclaveMetric::RpcRequestsIncrement])
+			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		match params.parse::<(String, String)>() {
 			Ok((shard_base58, account_hex)) => {
 				let shard = match decode_shard_from_base58(shard_base58.as_str()) {
@@ -140,7 +159,7 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 						return Ok(json!(compute_hex_encoded_return_error(error_msg.as_str())))
 					},
 				};
-				let trusted_calls = pending_author.get_pending_trusted_calls_for(shard, &account);
+				let trusted_calls = local_author.get_pending_trusted_calls_for(shard, &account);
 				let json_value = RpcReturnValue {
 					do_watch: false,
 					value: trusted_calls.encode(),


### PR DESCRIPTION
closes #1459 (or what's relevant)

enclave sourced metrics
* [x] rpc request + submitted TrustedCall metrics
* [x] STF execution duration histogram
* [x] STF execution numbers of success and failed calls histogram
* fix top-pool-size which was brittle and drifted in the past
* [x] Runtime total issuance 
* [x] parentchains last processed block taken from parentchain pallet
* [x] AURA execution stages remaining durations histograms per stage  
* [x] state size as in-mem Bytes with shard identifier bs58 as label

service sourced metrics 
* [x] enclave balance on all parentchains with parentchainId and account ss58 as labels
* [x] shard vault balance with shielding-target and account ss58 as labels
* [x] sidechain: number of connected peers
* [x] sidechain: last finalized block as reported by Integritee Network
* [x] MRENCLAVE bs58 of self as label 
* [x] VERSION as label


test locally, add `--enable-metrics`: 
```
./integritee-service -u ws://172.17.0.1 --ws-external --enable-metrics -c run --skip-ra --dev &> worker.log
# other terminal
curl localhost:8787/metrics
```

should roughly result in this: https://gist.github.com/brenzi/2e44db310fce7cde642a4a2e94604067