### PR TITLE
allow hex output for get-shard and get-fingerprint

### DIFF
--- a/cli/src/trusted_base_cli/commands/get_fingerprint.rs
+++ b/cli/src/trusted_base_cli/commands/get_fingerprint.rs
@@ -28,7 +28,11 @@ use itp_utils::FromHexPrefixed;
 use log::*;
 
 #[derive(Parser)]
-pub struct GetFingerprintCommand {}
+pub struct GetFingerprintCommand {
+	/// also print as hex
+	#[clap(short = 'x', long = "hex")]
+	hex: bool,
+}
 
 impl GetFingerprintCommand {
 	pub(crate) fn run(&self, cli: &Cli, _trusted_args: &TrustedCli) -> CliResult {
@@ -59,6 +63,9 @@ impl GetFingerprintCommand {
 			})?;
 		let fingerprint_b58 = fingerprint.encode().to_base58();
 		println!("{}", fingerprint_b58);
+		if self.hex {
+			println!("0x{}", hex::encode(fingerprint.encode()));
+		}
 		Ok(CliResultOk::FingerprintBase58 { fingerprints: vec![fingerprint_b58] })
 	}
 }

--- a/cli/src/trusted_base_cli/commands/get_shard.rs
+++ b/cli/src/trusted_base_cli/commands/get_shard.rs
@@ -32,7 +32,14 @@ use log::*;
 use sp_core::H256;
 
 #[derive(Parser)]
-pub struct GetShardCommand {}
+pub struct GetShardCommand {
+	/// also print as hex
+	#[clap(short = 'x', long = "hex")]
+	hex: bool,
+	/// also print as ASCII
+	#[clap(short = 'a', long = "ascii")]
+	ascii: bool,
+}
 
 impl GetShardCommand {
 	pub(crate) fn run(&self, cli: &Cli, _trusted_args: &TrustedCli) -> CliResult {
@@ -62,6 +69,12 @@ impl GetShardCommand {
 				CliError::WorkerRpcApi { msg: err.to_string() }
 			})?;
 		println!("{}", shard.encode().to_base58());
+		if self.hex {
+			println!("0x{}", hex::encode(shard));
+		}
+		if self.ascii {
+			println!("{}", String::from_utf8_lossy(&shard.encode()));
+		}
 		Ok(CliResultOk::H256 { hash: shard })
 	}
 }


### PR DESCRIPTION
helpers for easier maintenance:

```
ubuntu@cbef50e3811c:~/worker/bin$ ./integritee-cli -U wss://scv1.paseo.api.incognitee.io -P 443 trusted get-fingerprint -x
5BUCG8UXdgjWDDFQUd5kuRwnubDnMFhYEdbgxDZTnrBx
0x3e1d4de8123172257f2dbeb9c37a6c0f05ac739bb2c3f29915b31741a8647687
ubuntu@cbef50e3811c:~/worker/bin$ ./integritee-cli -U wss://scv1.paseo.api.incognitee.io -P 443 trusted get-shard -xa
5wePd1LYa5M49ghwgZXs55cepKbJKhj5xfzQGfPeMS7c
0x496e636f676e69746565546573746e6574303030303030303030303030303033
IncogniteeTestnet000000000000003
```
