### PR TITLE
log enclave extrinsics to parentchains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3650,6 +3650,7 @@ name = "itp-types"
 version = "0.9.0"
 dependencies = [
  "enclave-bridge-primitives",
+ "frame-support",
  "frame-system",
  "itp-sgx-runtime-primitives",
  "itp-stf-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2633,6 +2633,7 @@ dependencies = [
  "itp-enclave-metrics",
  "itp-node-api",
  "itp-settings",
+ "itp-sgx-temp-dir",
  "itp-stf-interface",
  "itp-storage",
  "itp-time-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-cli"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "array-bytes 6.1.0",
  "base58",
@@ -2607,11 +2607,12 @@ dependencies = [
 
 [[package]]
 name = "integritee-service"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "anyhow",
  "async-trait",
  "base58",
+ "chrono 0.4.26",
  "clap 2.34.0",
  "dirs",
  "enclave-bridge-primitives",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-cli"
-version = "0.14.3"
+version = "0.14.4"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -21,6 +21,7 @@ substrate-api-client = { default-features = false, features = ["sync-api"], git 
 
 # substrate-deps
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -20,8 +20,8 @@ itp-utils = { path = "../../core-primitives/utils", default-features = false }
 substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 # substrate-deps
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2367,6 +2367,7 @@ name = "itp-types"
 version = "0.9.0"
 dependencies = [
  "enclave-bridge-primitives",
+ "frame-support",
  "frame-system",
  "itp-sgx-runtime-primitives",
  "itp-stf-primitives",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runtime"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "array-bytes 6.2.2",
  "cid",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runtime"
-version = "0.14.3"
+version = "0.14.4"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -69,6 +69,7 @@ substrate-api-client = { default-features = false, features = ["std", "sync-api"
 teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 
 # Substrate dependencies
+chrono = "0.4.26"
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
@@ -76,7 +77,6 @@ sp-consensus-grandpa = { git = "https://github.com/paritytech/substrate.git", br
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-chrono = "0.4.26"
 
 [features]
 default = []
@@ -107,3 +107,4 @@ mockall = "0.11"
 itc-parentchain-test = { path = "../core/parentchain/test" }
 its-peer-fetch = { path = "../sidechain/peer-fetch", features = ["mocks"] }
 its-test = { path = "../sidechain/test" }
+itp-sgx-temp-dir = { version = "0.1", path = "../core-primitives/sgx/temp-dir" }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-service"
-version = "0.14.3"
+version = "0.14.4"
 authors = ["Integritee AG <hello@integritee.network>"]
 build = "build.rs"
 edition = "2021"
@@ -76,6 +76,7 @@ sp-consensus-grandpa = { git = "https://github.com/paritytech/substrate.git", br
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+chrono = "0.4.26"
 
 [features]
 default = []

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -170,6 +170,7 @@ pub(crate) fn main() {
 		peer_sidechain_block_fetcher,
 		tokio_handle.clone(),
 		enclave_metrics_receiver,
+		config.data_dir().into(),
 	)));
 
 	let quoting_enclave_target_info = match enclave.qe_get_target_info() {
@@ -490,9 +491,12 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		.expect("our enclave should be registered at this point");
 	trace!("verified that our enclave is registered: {:?}", my_enclave);
 
-	let (we_are_primary_validateer, re_init_parentchain_needed) =
-		match integritee_rpc_api.primary_worker_for_shard(shard, None).unwrap() {
-			Some(primary_enclave) => match primary_enclave.instance_signer() {
+	let (we_are_primary_validateer, re_init_parentchain_needed) = match integritee_rpc_api
+		.primary_worker_for_shard(shard, None)
+		.unwrap()
+	{
+		Some(primary_enclave) =>
+			match primary_enclave.instance_signer() {
 				AnySigner::Known(MultiSigner::Ed25519(primary)) =>
 					if primary.encode() == tee_accountid.encode() {
 						println!("We are primary worker on this shard and we have been previously running.");
@@ -527,24 +531,24 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 					);
 				},
 			},
-			None => {
-				println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
-				enclave.init_shard(shard.encode()).unwrap();
-				if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
-					enclave
-						.init_shard_creation_parentchain_header(
-							shard,
-							&ParentchainId::Integritee,
-							&register_enclave_xt_header,
-						)
-						.unwrap();
-					debug!("shard config should be initialized on integritee network now");
-					(true, true)
-				} else {
-					(true, false)
-				}
-			},
-		};
+		None => {
+			println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
+			enclave.init_shard(shard.encode()).unwrap();
+			if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
+				enclave
+					.init_shard_creation_parentchain_header(
+						shard,
+						&ParentchainId::Integritee,
+						&register_enclave_xt_header,
+					)
+					.unwrap();
+				debug!("shard config should be initialized on integritee network now");
+				(true, true)
+			} else {
+				(true, false)
+			}
+		},
+	};
 	debug!("getting shard creation: {:?}", enclave.get_shard_creation_info(shard));
 	initialization_handler.registered_on_parentchain();
 

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -491,12 +491,9 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		.expect("our enclave should be registered at this point");
 	trace!("verified that our enclave is registered: {:?}", my_enclave);
 
-	let (we_are_primary_validateer, re_init_parentchain_needed) = match integritee_rpc_api
-		.primary_worker_for_shard(shard, None)
-		.unwrap()
-	{
-		Some(primary_enclave) =>
-			match primary_enclave.instance_signer() {
+	let (we_are_primary_validateer, re_init_parentchain_needed) =
+		match integritee_rpc_api.primary_worker_for_shard(shard, None).unwrap() {
+			Some(primary_enclave) => match primary_enclave.instance_signer() {
 				AnySigner::Known(MultiSigner::Ed25519(primary)) =>
 					if primary.encode() == tee_accountid.encode() {
 						println!("We are primary worker on this shard and we have been previously running.");
@@ -531,24 +528,24 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 					);
 				},
 			},
-		None => {
-			println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
-			enclave.init_shard(shard.encode()).unwrap();
-			if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
-				enclave
-					.init_shard_creation_parentchain_header(
-						shard,
-						&ParentchainId::Integritee,
-						&register_enclave_xt_header,
-					)
-					.unwrap();
-				debug!("shard config should be initialized on integritee network now");
-				(true, true)
-			} else {
-				(true, false)
-			}
-		},
-	};
+			None => {
+				println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
+				enclave.init_shard(shard.encode()).unwrap();
+				if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
+					enclave
+						.init_shard_creation_parentchain_header(
+							shard,
+							&ParentchainId::Integritee,
+							&register_enclave_xt_header,
+						)
+						.unwrap();
+					debug!("shard config should be initialized on integritee network now");
+					(true, true)
+				} else {
+					(true, false)
+				}
+			},
+		};
 	debug!("getting shard creation: {:?}", enclave.get_shard_creation_info(shard));
 	initialization_handler.registered_on_parentchain();
 

--- a/service/src/ocall_bridge/component_factory.rs
+++ b/service/src/ocall_bridge/component_factory.rs
@@ -15,7 +15,6 @@
 	limitations under the License.
 
 */
-
 use crate::{
 	globals::tokio_handle::GetTokioHandle,
 	ocall_bridge::{
@@ -38,7 +37,7 @@ use itp_node_api::node_api_factory::CreateNodeApi;
 use its_peer_fetch::FetchBlocksFromPeer;
 use its_primitives::types::block::SignedBlock as SignedSidechainBlock;
 use its_storage::BlockStorage;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 /// Concrete implementation, should be moved out of the OCall Bridge, into the worker
 /// since the OCall bridge itself should not know any concrete types to ensure
@@ -63,6 +62,7 @@ pub struct OCallBridgeComponentFactory<
 	peer_block_fetcher: Arc<PeerBlockFetcher>,
 	tokio_handle: Arc<TokioHandle>,
 	metrics_receiver: Arc<MetricsReceiver>,
+	log_dir: Arc<Path>,
 }
 
 impl<
@@ -98,6 +98,7 @@ impl<
 		peer_block_fetcher: Arc<PeerBlockFetcher>,
 		tokio_handle: Arc<TokioHandle>,
 		metrics_receiver: Arc<MetricsReceiver>,
+		log_dir: Arc<Path>,
 	) -> Self {
 		OCallBridgeComponentFactory {
 			integritee_rpc_api_factory,
@@ -110,6 +111,7 @@ impl<
 			peer_block_fetcher,
 			tokio_handle,
 			metrics_receiver,
+			log_dir,
 		}
 	}
 }
@@ -133,7 +135,8 @@ impl<
 		PeerBlockFetcher,
 		TokioHandle,
 		MetricsReceiver,
-	> where
+	>
+where
 	NodeApi: CreateNodeApi + 'static,
 	Broadcaster: BroadcastBlocks + 'static,
 	EnclaveApi: RemoteAttestationCallBacks + 'static,
@@ -162,6 +165,7 @@ impl<
 			self.integritee_rpc_api_factory.clone(),
 			self.target_a_parentchain_rpc_api_factory.clone(),
 			self.target_b_parentchain_rpc_api_factory.clone(),
+			self.log_dir.clone(),
 		))
 	}
 

--- a/service/src/ocall_bridge/component_factory.rs
+++ b/service/src/ocall_bridge/component_factory.rs
@@ -135,8 +135,7 @@ impl<
 		PeerBlockFetcher,
 		TokioHandle,
 		MetricsReceiver,
-	>
-where
+	> where
 	NodeApi: CreateNodeApi + 'static,
 	Broadcaster: BroadcastBlocks + 'static,
 	EnclaveApi: RemoteAttestationCallBacks + 'static,

--- a/service/src/ocall_bridge/worker_on_chain_ocall.rs
+++ b/service/src/ocall_bridge/worker_on_chain_ocall.rs
@@ -204,6 +204,7 @@ mod tests {
 		api_client::ParentchainApi,
 		node_api_factory::{CreateNodeApi, Result as NodeApiResult},
 	};
+	use itp_sgx_temp_dir::TempDir;
 	use mockall::mock;
 
 	#[test]
@@ -216,8 +217,9 @@ mod tests {
 		}
 
 		let mock_node_api_factory = Arc::new(MockNodeApiFactory::new());
-
-		let on_chain_ocall = WorkerOnChainOCall::new(mock_node_api_factory, None, None);
+		let temp_dir = TempDir::new().unwrap();
+		let on_chain_ocall =
+			WorkerOnChainOCall::new(mock_node_api_factory, None, None, temp_dir.path().into());
 
 		let response = on_chain_ocall
 			.worker_request(Vec::<u8>::new().encode(), ParentchainId::Integritee.encode())


### PR DESCRIPTION
For easier incident response, the OCall Bridge logs encoded extrinsics as hex values into files in folders per parentchain within the working dir

Also, make service listen to events and log System::ExtrinsicFailed if might be relevant