### PR TITLE
init parentchain genesis hash

### DIFF
--- a/core-primitives/stf-interface/src/parentchain_pallet.rs
+++ b/core-primitives/stf-interface/src/parentchain_pallet.rs
@@ -15,7 +15,7 @@
 
 */
 
-use itp_types::parentchain::{AccountId, ParentchainId};
+use itp_types::parentchain::{AccountId, Hash, ParentchainId};
 
 /// Interface trait of the parentchain pallet.
 pub trait ParentchainPalletInstancesInterface<State, ParentchainHeader> {
@@ -48,6 +48,12 @@ pub trait ParentchainPalletInstancesInterface<State, ParentchainHeader> {
 	fn set_creation_block(
 		state: &mut State,
 		header: ParentchainHeader,
+		parentchain_id: ParentchainId,
+	) -> Result<(), Self::Error>;
+
+	fn set_genesis_hash(
+		state: &mut State,
+		genesis_hash: Hash,
 		parentchain_id: ParentchainId,
 	) -> Result<(), Self::Error>;
 

--- a/core-primitives/types/src/parentchain.rs
+++ b/core-primitives/types/src/parentchain.rs
@@ -91,6 +91,7 @@ impl std::fmt::Display for ParentchainId {
 
 pub trait IdentifyParentchain {
 	fn parentchain_id(&self) -> ParentchainId;
+	fn genesis_hash(&self) -> Option<Hash>;
 }
 
 pub trait FilterEvents {

--- a/core/parentchain/light-client/src/concurrent_access.rs
+++ b/core/parentchain/light-client/src/concurrent_access.rs
@@ -30,7 +30,7 @@ use crate::{
 	LightValidationState, Validator as ValidatorTrait,
 };
 use finality_grandpa::BlockNumberOps;
-use itp_types::parentchain::{IdentifyParentchain, ParentchainId};
+use itp_types::parentchain::{Hash, IdentifyParentchain, ParentchainId};
 use sp_runtime::traits::{Block as ParentchainBlockTrait, NumberFor};
 use std::{marker::PhantomData, sync::Arc};
 
@@ -80,11 +80,17 @@ impl<Validator, ParentchainBlock, LightClientSeal>
 	}
 }
 
-impl<Validator, ParentchainBlock, LightClientSeal: IdentifyParentchain> IdentifyParentchain
-	for ValidatorAccessor<Validator, ParentchainBlock, LightClientSeal>
+impl<
+		Validator: IdentifyParentchain,
+		ParentchainBlock,
+		LightClientSeal: IdentifyParentchain + LightClientSealing,
+	> IdentifyParentchain for ValidatorAccessor<Validator, ParentchainBlock, LightClientSeal>
 {
 	fn parentchain_id(&self) -> ParentchainId {
 		(*self.seal).parentchain_id()
+	}
+	fn genesis_hash(&self) -> Option<Hash> {
+		self.light_validation.read().unwrap().genesis_hash()
 	}
 }
 

--- a/core/parentchain/light-client/src/io.rs
+++ b/core/parentchain/light-client/src/io.rs
@@ -27,7 +27,7 @@ use codec::{Decode, Encode};
 use core::{fmt::Debug, marker::PhantomData};
 use itp_ocall_api::EnclaveOnChainOCallApi;
 use itp_sgx_io::{seal, unseal};
-use itp_types::parentchain::{IdentifyParentchain, ParentchainId};
+use itp_types::parentchain::{Hash, IdentifyParentchain, ParentchainId};
 use log::*;
 use sp_runtime::traits::{Block, Header};
 use std::{
@@ -92,6 +92,9 @@ impl<B, L> LightClientStateSeal<B, L> {
 impl<B, L> IdentifyParentchain for LightClientStateSeal<B, L> {
 	fn parentchain_id(&self) -> ParentchainId {
 		self.parentchain_id
+	}
+	fn genesis_hash(&self) -> Option<Hash> {
+		None
 	}
 }
 
@@ -193,6 +196,9 @@ impl<B, LightClientState> LightClientStateSealSync<B, LightClientState> {
 impl<B, LightClientState> IdentifyParentchain for LightClientStateSealSync<B, LightClientState> {
 	fn parentchain_id(&self) -> ParentchainId {
 		self.seal.parentchain_id
+	}
+	fn genesis_hash(&self) -> Option<Hash> {
+		None
 	}
 }
 

--- a/core/parentchain/light-client/src/light_validation.rs
+++ b/core/parentchain/light-client/src/light_validation.rs
@@ -25,11 +25,11 @@ use codec::Encode;
 use core::iter::Iterator;
 use itp_ocall_api::EnclaveOnChainOCallApi;
 use itp_storage::{Error as StorageError, StorageProof, StorageProofChecker};
-use itp_types::parentchain::{IdentifyParentchain, ParentchainId};
+use itp_types::parentchain::{Hash, IdentifyParentchain, ParentchainId};
 use log::error;
 use sp_runtime::{
 	generic::SignedBlock,
-	traits::{Block as ParentchainBlockTrait, Header as HeaderTrait},
+	traits::{Block as ParentchainBlockTrait, Block as BlockT, Header as HeaderTrait},
 	Justifications, OpaqueExtrinsic,
 };
 use std::{boxed::Box, fmt, sync::Arc, vec::Vec};
@@ -42,11 +42,15 @@ pub struct LightValidation<Block: ParentchainBlockTrait, OcallApi> {
 	finality: Arc<Box<dyn Finality<Block> + Sync + Send + 'static>>,
 }
 
-impl<Block: ParentchainBlockTrait, OcallApi> IdentifyParentchain
-	for LightValidation<Block, OcallApi>
+impl<Block, OcallApi> IdentifyParentchain for LightValidation<Block, OcallApi>
+where
+	Block: BlockT<Hash = Hash> + ParentchainBlockTrait,
 {
 	fn parentchain_id(&self) -> ParentchainId {
 		self.parentchain_id
+	}
+	fn genesis_hash(&self) -> Option<Hash> {
+		self.light_validation_state.genesis_hash().ok()
 	}
 }
 

--- a/core/parentchain/light-client/src/mocks/validator_access_mock.rs
+++ b/core/parentchain/light-client/src/mocks/validator_access_mock.rs
@@ -27,7 +27,7 @@ use crate::{
 	mocks::validator_mock::ValidatorMock,
 };
 use itp_types::{
-	parentchain::{IdentifyParentchain, ParentchainId},
+	parentchain::{Hash, IdentifyParentchain, ParentchainId},
 	Block,
 };
 
@@ -62,5 +62,8 @@ impl ValidatorAccess<Block> for ValidatorAccessMock {
 impl IdentifyParentchain for ValidatorAccessMock {
 	fn parentchain_id(&self) -> ParentchainId {
 		ParentchainId::Integritee
+	}
+	fn genesis_hash(&self) -> Option<Hash> {
+		Some(Hash::default())
 	}
 }

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -778,11 +778,12 @@ where
 	// TODO: #1451: Fix api-client type hacks
 	let head = Header::decode(&mut api_head.encode().as_slice())
 		.expect("Can decode previously encoded header; qed");
-	// we ignore failure
-	let _ = enclave.init_shard_creation_parentchain_header(shard, &parentchain_id, &head);
 
 	let (parentchain_handler, last_synched_header) =
 		init_parentchain(enclave, &node_api, tee_account_id, parentchain_id, shard);
+
+	// we ignore failure
+	let _ = enclave.init_shard_creation_parentchain_header(shard, &parentchain_id, &head);
 
 	if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
 		println!(


### PR DESCRIPTION
trustless write of parentchain genesis hash into parentchain pallet in L2 runtime state upon shard init

# test
bear in mind that starting 3 --dev nodes leads to the same genesis hash. 
```
./target/release/integritee-node --dev --unsafe-rpc-external --rpc-cors all
./target/release/integritee-node --rpc-port 9945 --dev --unsafe-rpc-external --rpc-cors all
./target/release/integritee-node --rpc-port 9946 --dev --unsafe-rpc-external --rpc-cors all

/integritee-service -u ws://172.17.0.1 -c --ws-external run --skip-ra --dev
./integritee-cli trusted --mrenclave $MRENCLAVE get-parentchains-info
ParentchainsInfo { 
  integritee: ParentchainInfo { id: Integritee, genesis_hash: Some(0x6ca6d29ad6c4a200c4af356f74f03d6467dbc8a6e9ef225a2e672a990e1c7ead), block_number: Some(9), now: Some(1729792536000), creation_block_number: Some(4), creation_timestamp: Some(1729792506000) }, 
  target_a: ParentchainInfo { id: TargetA, genesis_hash: None, block_number: None, now: None, creation_block_number: None, creation_timestamp: None }, 
  target_b: ParentchainInfo { id: TargetB, genesis_hash: None, block_number: None, now: None, creation_block_number: None, creation_timestamp: None }, 
  shielding_target: Integritee }

now with target_a
restart node too!

./integritee-service -u ws://172.17.0.1 -c --ws-external --target-a-parentchain-rpc-url ws://172.17.0.1 --target-a-parentchain-rpc-port 9945 run --skip-ra --dev --shielding-target target_a

ParentchainsInfo { 
  integritee: ParentchainInfo { id: Integritee, genesis_hash: Some(0x6ca6d29ad6c4a200c4af356f74f03d6467dbc8a6e9ef225a2e672a990e1c7ead), block_number: Some(8), now: None, creation_block_number: Some(8), creation_timestamp: None }, 
  target_a: ParentchainInfo { id: TargetA, genesis_hash: Some(0x6ca6d29ad6c4a200c4af356f74f03d6467dbc8a6e9ef225a2e672a990e1c7ead), block_number: None, now: None, creation_block_number: Some(11), creation_timestamp: None }, 
  target_b: ParentchainInfo { id: TargetB, genesis_hash: None, block_number: None, now: None, creation_block_number: None, creation_timestamp: None }, 
  shielding_target: TargetA }
  
now with target_a&b
  restart node too!
  
  ./integritee-service -u ws://172.17.0.1 -c --ws-external --target-a-parentchain-rpc-url ws://172.17.0.1 --target-a-parentchain-rpc-port 9945 --target-b-parentchain-rpc-url ws://172.17.0.1 --target-b-parentchain-rpc-port 9946 run --skip-ra --dev --shielding-target target_a
  ./integritee-cli trusted --mrenclave $MRENCLAVE get-parentchains-info
ParentchainsInfo { 
  integritee: ParentchainInfo { id: Integritee, genesis_hash: Some(0x6ca6d29ad6c4a200c4af356f74f03d6467dbc8a6e9ef225a2e672a990e1c7ead), block_number: Some(11), now: Some(1729794522000), creation_block_number: Some(3), creation_timestamp: Some(1729794474000) }, 
  target_a: ParentchainInfo { id: TargetA, genesis_hash: Some(0x6ca6d29ad6c4a200c4af356f74f03d6467dbc8a6e9ef225a2e672a990e1c7ead), block_number: Some(7), now: None, creation_block_number: Some(7), creation_timestamp: None }, 
  target_b: ParentchainInfo { id: TargetB, genesis_hash: Some(0x6ca6d29ad6c4a200c4af356f74f03d6467dbc8a6e9ef225a2e672a990e1c7ead), block_number: None, now: None, creation_block_number: Some(9), creation_timestamp: None }, 
  shielding_target: TargetA }
```
