### PR TITLE
support json rpc 2.0 with `author_submitAndWatchExtrinsic` trusted calls

### DIFF
--- a/cli/src/benchmark/mod.rs
+++ b/cli/src/benchmark/mod.rs
@@ -341,7 +341,6 @@ fn wait_for_top_confirmation(
 	let started = Instant::now();
 
 	// the first response of `submitAndWatch` is just the plain top hash
-
 	let submitted = match await_subscription_response(&client.receiver) {
 		Ok(hash) => Some((hash, Instant::now())),
 		Err(e) => {

--- a/cli/src/benchmark/mod.rs
+++ b/cli/src/benchmark/mod.rs
@@ -21,8 +21,8 @@ use crate::{
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_keystore_path, get_pair_from_str},
 	trusted_operation::{
-		await_subscription_response, get_json_request, get_state, perform_trusted_operation,
-		wait_until,
+		await_status, await_subscription_response, get_json_request, get_state,
+		perform_trusted_operation,
 	},
 	Cli, CliResult, CliResultOk, SR25519_KEY_TYPE,
 };
@@ -352,10 +352,10 @@ fn wait_for_top_confirmation(
 	let confirmed = if wait_for_sidechain_block {
 		// We wait for the transaction hash that actually matches the submitted hash
 		loop {
-			let transaction_information = wait_until(&client.receiver, is_sidechain_block);
-			if let Some((hash, _)) = transaction_information {
+			let transaction_information = await_status(&client.receiver, is_sidechain_block).ok();
+			if let Some((hash, _status)) = transaction_information {
 				if hash == submitted.unwrap().0 {
-					break transaction_information
+					break Some((hash, Instant::now()))
 				}
 			}
 		}

--- a/cli/src/evm/commands/evm_call.rs
+++ b/cli/src/evm/commands/evm_call.rs
@@ -19,7 +19,7 @@ use crate::{
 	get_layer_two_evm_nonce, get_layer_two_nonce,
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
-	trusted_operation::perform_trusted_operation,
+	trusted_operation::{perform_trusted_operation, send_direct_request},
 	Cli, CliResult, CliResultOk,
 };
 use ita_stf::{Index, TrustedCall, TrustedGetter};
@@ -31,6 +31,7 @@ use itp_types::AccountId;
 use log::*;
 use sp_core::{crypto::Ss58Codec, Pair, H160, U256};
 use std::{boxed::Box, vec::Vec};
+
 #[derive(Parser)]
 pub struct EvmCallCommands {
 	/// Sender's incognito AccountId in ss58check format, mnemonic or hex seed
@@ -81,7 +82,6 @@ impl EvmCallCommands {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(sender)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(perform_trusted_operation::<()>(cli, trusted_args, &function_call)
-			.map(|_| CliResultOk::None)?)
+		Ok(send_direct_request(cli, trusted_args, &function_call).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/evm/commands/evm_call.rs
+++ b/cli/src/evm/commands/evm_call.rs
@@ -82,6 +82,12 @@ impl EvmCallCommands {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(sender)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(send_direct_request(cli, trusted_args, &function_call).map(|_| CliResultOk::None)?)
+
+		if trusted_args.direct {
+			Ok(send_direct_request(cli, trusted_args, &function_call).map(|_| CliResultOk::None)?)
+		} else {
+			Ok(perform_trusted_operation::<()>(cli, trusted_args, &function_call)
+				.map(|_| CliResultOk::None)?)
+		}
 	}
 }

--- a/cli/src/evm/commands/evm_create.rs
+++ b/cli/src/evm/commands/evm_create.rs
@@ -80,7 +80,11 @@ impl EvmCreateCommands {
 		.sign(&from.into(), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
 
-		send_direct_request(cli, trusted_args, &top)?;
+		if trusted_args.direct {
+			send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?;
+		} else {
+			perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?;
+		}
 
 		let execution_address = evm_create_address(sender_evm_acc, evm_account_nonce);
 		info!("trusted call evm_create executed");

--- a/cli/src/evm/commands/evm_create.rs
+++ b/cli/src/evm/commands/evm_create.rs
@@ -19,7 +19,7 @@ use crate::{
 	get_layer_two_evm_nonce, get_layer_two_nonce,
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
-	trusted_operation::perform_trusted_operation,
+	trusted_operation::{perform_trusted_operation, send_direct_request},
 	Cli, CliResult, CliResultOk,
 };
 use ita_stf::{evm_helpers::evm_create_address, Index, TrustedCall, TrustedGetter};
@@ -33,6 +33,7 @@ use pallet_evm::{AddressMapping, HashedAddressMapping};
 use sp_core::{crypto::Ss58Codec, Pair, H160, U256};
 use sp_runtime::traits::BlakeTwo256;
 use std::vec::Vec;
+
 #[derive(Parser)]
 pub struct EvmCreateCommands {
 	/// Sender's incognito AccountId in ss58check format, mnemonic or hex seed
@@ -79,7 +80,7 @@ impl EvmCreateCommands {
 		.sign(&from.into(), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
 
-		perform_trusted_operation::<()>(cli, trusted_args, &top)?;
+		send_direct_request(cli, trusted_args, &top)?;
 
 		let execution_address = evm_create_address(sender_evm_acc, evm_account_nonce);
 		info!("trusted call evm_create executed");

--- a/cli/src/guess_the_number/commands/guess.rs
+++ b/cli/src/guess_the_number/commands/guess.rs
@@ -23,6 +23,7 @@ use crate::{
 	Cli, CliResult, CliResultOk,
 };
 
+use crate::trusted_operation::send_direct_request;
 use ita_stf::{
 	guess_the_number::GuessTheNumberTrustedCall, Getter, Index, TrustedCall, TrustedCallSigned,
 };
@@ -55,6 +56,6 @@ impl GuessCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/guess_the_number/commands/guess.rs
+++ b/cli/src/guess_the_number/commands/guess.rs
@@ -56,6 +56,12 @@ impl GuessCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+
+		if trusted_args.direct {
+			Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		} else {
+			Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
+				.map(|_| CliResultOk::None)?)
+		}
 	}
 }

--- a/cli/src/guess_the_number/commands/push_by_one_day.rs
+++ b/cli/src/guess_the_number/commands/push_by_one_day.rs
@@ -23,6 +23,7 @@ use crate::{
 	Cli, CliResult, CliResultOk,
 };
 
+use crate::trusted_operation::send_direct_request;
 use ita_stf::{
 	guess_the_number::GuessTheNumberTrustedCall, Getter, Index, TrustedCall, TrustedCallSigned,
 };
@@ -53,6 +54,6 @@ impl PushByOneDayCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/guess_the_number/commands/push_by_one_day.rs
+++ b/cli/src/guess_the_number/commands/push_by_one_day.rs
@@ -54,6 +54,12 @@ impl PushByOneDayCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+
+		if trusted_args.direct {
+			Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		} else {
+			Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
+				.map(|_| CliResultOk::None)?)
+		}
 	}
 }

--- a/cli/src/guess_the_number/commands/set_winnings.rs
+++ b/cli/src/guess_the_number/commands/set_winnings.rs
@@ -59,6 +59,12 @@ impl SetWinningsCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+
+		if trusted_args.direct {
+			Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		} else {
+			Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
+				.map(|_| CliResultOk::None)?)
+		}
 	}
 }

--- a/cli/src/guess_the_number/commands/set_winnings.rs
+++ b/cli/src/guess_the_number/commands/set_winnings.rs
@@ -19,7 +19,7 @@ use crate::{
 	get_layer_two_nonce,
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
-	trusted_operation::perform_trusted_operation,
+	trusted_operation::{perform_trusted_operation, send_direct_request},
 	Cli, CliResult, CliResultOk,
 };
 use ita_parentchain_interface::integritee::Balance;
@@ -59,6 +59,6 @@ impl SetWinningsCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/trusted_base_cli/commands/set_balance.rs
+++ b/cli/src/trusted_base_cli/commands/set_balance.rs
@@ -19,7 +19,7 @@ use crate::{
 	get_layer_two_nonce,
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
-	trusted_operation::send_direct_request,
+	trusted_operation::{perform_trusted_operation, send_direct_request},
 	Cli, CliResult, CliResultOk,
 };
 use ita_parentchain_interface::integritee::Balance;
@@ -59,6 +59,12 @@ impl SetBalanceCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+
+		if trusted_args.direct {
+			Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		} else {
+			Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
+				.map(|_| CliResultOk::None)?)
+		}
 	}
 }

--- a/cli/src/trusted_base_cli/commands/set_balance.rs
+++ b/cli/src/trusted_base_cli/commands/set_balance.rs
@@ -19,7 +19,7 @@ use crate::{
 	get_layer_two_nonce,
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_identifiers, get_pair_from_str},
-	trusted_operation::perform_trusted_operation,
+	trusted_operation::send_direct_request,
 	Cli, CliResult, CliResultOk,
 };
 use ita_parentchain_interface::integritee::Balance;
@@ -59,6 +59,6 @@ impl SetBalanceCommand {
 		)
 		.sign(&KeyPair::Sr25519(Box::new(signer)), nonce, &mrenclave, &shard)
 		.into_trusted_operation(trusted_args.direct);
-		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/trusted_base_cli/commands/transfer.rs
+++ b/cli/src/trusted_base_cli/commands/transfer.rs
@@ -66,16 +66,11 @@ impl TransferCommand {
 				.sign(&KeyPair::Sr25519(Box::new(from)), nonce, &mrenclave, &shard)
 				.into_trusted_operation(trusted_args.direct);
 
-		let mut res;
-
 		if trusted_args.direct {
-			res = Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)?;
+			Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 		} else {
-			res = Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
-				.map(|_| CliResultOk::None)?)?;
+			Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
+				.map(|_| CliResultOk::None)?)
 		}
-
-		info!("trusted call transfer executed");
-		Ok(res)
 	}
 }

--- a/cli/src/trusted_base_cli/commands/transfer.rs
+++ b/cli/src/trusted_base_cli/commands/transfer.rs
@@ -65,7 +65,16 @@ impl TransferCommand {
 			TrustedCall::balance_transfer(from.public().into(), to, self.amount)
 				.sign(&KeyPair::Sr25519(Box::new(from)), nonce, &mrenclave, &shard)
 				.into_trusted_operation(trusted_args.direct);
-		let res = send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?;
+
+		let mut res;
+
+		if trusted_args.direct {
+			res = Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)?;
+		} else {
+			res = Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
+				.map(|_| CliResultOk::None)?)?;
+		}
+
 		info!("trusted call transfer executed");
 		Ok(res)
 	}

--- a/cli/src/trusted_base_cli/commands/transfer.rs
+++ b/cli/src/trusted_base_cli/commands/transfer.rs
@@ -19,7 +19,7 @@ use crate::{
 	get_layer_two_nonce,
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_accountid_from_str, get_identifiers, get_pair_from_str},
-	trusted_operation::perform_trusted_operation,
+	trusted_operation::{perform_trusted_operation, send_direct_request},
 	Cli, CliResult, CliResultOk,
 };
 use base58::ToBase58;
@@ -65,8 +65,7 @@ impl TransferCommand {
 			TrustedCall::balance_transfer(from.public().into(), to, self.amount)
 				.sign(&KeyPair::Sr25519(Box::new(from)), nonce, &mrenclave, &shard)
 				.into_trusted_operation(trusted_args.direct);
-		let res =
-			perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?;
+		let res = send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?;
 		info!("trusted call transfer executed");
 		Ok(res)
 	}

--- a/cli/src/trusted_base_cli/commands/unshield_funds.rs
+++ b/cli/src/trusted_base_cli/commands/unshield_funds.rs
@@ -64,6 +64,12 @@ impl UnshieldFundsCommand {
 			TrustedCall::balance_unshield(from.public().into(), to, self.amount, shard)
 				.sign(&KeyPair::Sr25519(Box::new(from)), nonce, &mrenclave, &shard)
 				.into_trusted_operation(trusted_args.direct);
-		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+
+		if trusted_args.direct {
+			Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		} else {
+			Ok(perform_trusted_operation::<()>(cli, trusted_args, &top)
+				.map(|_| CliResultOk::None)?)
+		}
 	}
 }

--- a/cli/src/trusted_base_cli/commands/unshield_funds.rs
+++ b/cli/src/trusted_base_cli/commands/unshield_funds.rs
@@ -19,7 +19,7 @@ use crate::{
 	get_layer_two_nonce,
 	trusted_cli::TrustedCli,
 	trusted_command_utils::{get_accountid_from_str, get_identifiers, get_pair_from_str},
-	trusted_operation::perform_trusted_operation,
+	trusted_operation::{perform_trusted_operation, send_direct_request},
 	Cli, CliResult, CliResultOk,
 };
 use ita_parentchain_interface::integritee::Balance;
@@ -31,6 +31,7 @@ use itp_stf_primitives::{
 use log::*;
 use sp_core::{crypto::Ss58Codec, Pair};
 use std::boxed::Box;
+
 #[derive(Parser)]
 pub struct UnshieldFundsCommand {
 	/// Sender's incognito AccountId in ss58check format, mnemonic or hex seed
@@ -63,6 +64,6 @@ impl UnshieldFundsCommand {
 			TrustedCall::balance_unshield(from.public().into(), to, self.amount, shard)
 				.sign(&KeyPair::Sr25519(Box::new(from)), nonce, &mrenclave, &shard)
 				.into_trusted_operation(trusted_args.direct);
-		Ok(perform_trusted_operation::<()>(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
+		Ok(send_direct_request(cli, trusted_args, &top).map(|_| CliResultOk::None)?)
 	}
 }

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -280,6 +280,11 @@ pub(crate) fn send_direct_request(
 	trusted_args: &TrustedCli,
 	operation_call: &TrustedOperation<TrustedCallSigned, Getter>,
 ) -> TrustedOpResult<Hash> {
+	if !matches!(operation_call, TrustedOperation::direct_call(_)) {
+		return Err(TrustedOperationError::Default {
+			msg: "can only use direct_calls in this function".into(),
+		})
+	}
 	let encryption_key = get_shielding_key(cli).unwrap();
 	let shard = read_shard(trusted_args).unwrap();
 	let jsonrpc_call: String = get_json_request(shard, operation_call, encryption_key);

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -301,11 +301,12 @@ pub(crate) fn send_direct_request(
 		into_default_trusted_op_err("failed to receive rpc response")
 	})?;
 
-	let response = RpcResponse::from_hex(&response_string)
-		.map_err(|e| into_default_trusted_op_err(format!("{e:?}")))?;
+	let response: RpcResponse = serde_json::from_str(&response_string).map_err(|e| {
+		into_default_trusted_op_err(format!("Error deserializing RpcResponse: {e:?}"))
+	})?;
 
 	let top_hash = Hash::from_hex(&response.result)
-		.map_err(|e| into_default_trusted_op_err(format!("{e:?}")))?;
+		.map_err(|e| into_default_trusted_op_err(format!("Error decoding top hash: {e:?}")))?;
 
 	debug!("subscribing to updates for top with hash: {top_hash:?}");
 

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -327,7 +327,7 @@ pub(crate) fn await_status(
 	loop {
 		debug!("waiting for update");
 		let (subscription_update, direct_request_status) =
-			await_status_update(&receiver).map_err(|e| {
+			await_status_update(receiver).map_err(|e| {
 				error!("Error getting status update: {:?}", e);
 				e
 			})?;

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -365,16 +365,16 @@ pub(crate) fn await_status_update(
 	receiver: &Receiver<String>,
 ) -> TrustedOpResult<(RpcSubscriptionUpdate, DirectRequestStatus)> {
 	let response = receiver.recv().map_err(|e| {
-		into_default_trusted_op_err(format!("failed to receive rpc response: {e:?}"))
+		into_default_trusted_op_err(format!("error receiving subscription update: {e:?}"))
 	})?;
-	debug!("received response");
+	debug!("received subscription update");
 
 	let subscription_update: RpcSubscriptionUpdate =
 		serde_json::from_str(&response).map_err(|e| {
-			into_default_trusted_op_err(format!("Error deserializing subscription update: {e:?}"))
+			into_default_trusted_op_err(format!("error deserializing subscription update: {e:?}"))
 		})?;
 
-	trace!("successfully decoded rpc response: {:?}", subscription_update);
+	trace!("successfully decoded subscription update: {:?}", subscription_update);
 
 	let direct_request_status = DirectRequestStatus::from_hex(&subscription_update.params.result)
 		.map_err(|e| {

--- a/core-primitives/rpc/src/lib.rs
+++ b/core-primitives/rpc/src/lib.rs
@@ -62,6 +62,27 @@ pub struct RpcResponse {
 	pub id: Id,
 }
 
+#[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize)]
+pub struct RpcSubscriptionUpdate {
+	pub jsonrpc: String,
+	pub id: Id,
+	pub method: String,
+	pub params: SubscriptionParams,
+}
+
+#[derive(Clone, Encode, Decode, Debug, Serialize, Deserialize)]
+pub struct SubscriptionParams {
+	pub error: Option<String>,
+	pub result: String,
+	pub subscription: String,
+}
+
+impl RpcSubscriptionUpdate {
+	pub fn new(method: String, params: SubscriptionParams) -> Self {
+		Self { jsonrpc: "2.0".to_owned(), id: Id::Number(1), method, params }
+	}
+}
+
 #[derive(Clone, Encode, Decode, Serialize, Deserialize)]
 pub struct RpcRequest {
 	pub jsonrpc: String,

--- a/core-primitives/types/src/lib.rs
+++ b/core-primitives/types/src/lib.rs
@@ -82,7 +82,7 @@ pub enum DirectRequestStatus {
 	Error,
 }
 
-#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Encode, Decode, Copy)]
 pub enum TrustedOperationStatus {
 	/// TrustedOperation is submitted to the top pool.
 	Submitted,

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -109,10 +109,12 @@ where
 
 		if do_watch {
 			// We just store back the initial response, which is the top hash.
-			// This was implemented before we added the `RpcSubscriptionUpdate`
-			// and should probably be refactored in the future, see #1624.
+			// This was implemented before we added the `RpcSubscriptionUpdate`,
+			// which can't be stored due to type incompatibilities.
+			// This should probably be refactored in the future, see #1624.
 			//
-			// But for now this is fine, as we only use it to track ongoing connections.
+			// But for now this is fine, as we only use the connection token
+			// to track ongoing connections, the response is ignored.
 			self.connection_registry.store(hash, connection_token, rpc_response);
 		}
 

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -108,6 +108,11 @@ where
 		self.encode_and_send_subscription_update(connection_token, &sub)?;
 
 		if do_watch {
+			// We just store back the initial response, which is the top hash.
+			// This was implemented before we added the `RpcSubscriptionUpdate`
+			// and should probably be refactored in the future.
+			//
+			// But for now this is fine, as we only use it to track ongoing connections.
 			self.connection_registry.store(hash, connection_token, rpc_response);
 		}
 

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -19,10 +19,10 @@ use crate::{
 	response_channel::ResponseChannel, DirectRpcError, DirectRpcResult, RpcConnectionRegistry,
 	RpcHash, SendRpcResponse,
 };
-use alloc::{format, string::ToString};
+use alloc::string::ToString;
 use itp_rpc::{RpcResponse, RpcReturnValue, RpcSubscriptionUpdate, SubscriptionParams};
 use itp_types::{DirectRequestStatus, TrustedOperationStatus};
-use itp_utils::{FromHexPrefixed, ToHexPrefixed};
+use itp_utils::ToHexPrefixed;
 use log::*;
 use std::{sync::Arc, vec::Vec};
 

--- a/core/direct-rpc-server/src/rpc_responder.rs
+++ b/core/direct-rpc-server/src/rpc_responder.rs
@@ -110,7 +110,7 @@ where
 		if do_watch {
 			// We just store back the initial response, which is the top hash.
 			// This was implemented before we added the `RpcSubscriptionUpdate`
-			// and should probably be refactored in the future.
+			// and should probably be refactored in the future, see #1624.
 			//
 			// But for now this is fine, as we only use it to track ongoing connections.
 			self.connection_registry.store(hash, connection_token, rpc_response);

--- a/core/direct-rpc-server/src/rpc_watch_extractor.rs
+++ b/core/direct-rpc-server/src/rpc_watch_extractor.rs
@@ -66,7 +66,7 @@ where
 					return Ok(Some(hash))
 				}
 
-				return Err(DirectRpcError::Other(format!("{:?}", e).into())).into()
+				return Err(DirectRpcError::Other(format!("{:?}", e).into()))
 			},
 		};
 

--- a/core/direct-rpc-server/src/rpc_watch_extractor.rs
+++ b/core/direct-rpc-server/src/rpc_watch_extractor.rs
@@ -21,7 +21,7 @@ use codec::Decode;
 use itp_rpc::{RpcResponse, RpcReturnValue};
 use itp_types::DirectRequestStatus;
 use itp_utils::FromHexPrefixed;
-use log::info;
+use log::debug;
 use std::marker::PhantomData;
 
 pub struct RpcWatchExtractor<Hash>
@@ -59,10 +59,14 @@ where
 		let rpc_return_value = match RpcReturnValue::from_hex(&rpc_response.result) {
 			Ok(return_value) => return_value,
 			Err(e) => {
-				// if the return value is a hash
+				// `author_submitAndWatchExtrinsic` does currently only return the top hash
+				// as the first subscription response in order to comply with JSON RPC 2.0.
+				//
+				// We support this for now with this hack here, but it should be properly
+				// refactored in #1624.
 				if let Ok(hash) = Self::Hash::from_hex(&rpc_response.result) {
-					// fixme: hack to support json rpc 2.0 spec without rpc-server refactor.
-					info!("Returning hash as connection token");
+					// fixme: fix hack in #1624.
+					debug!("returning hash as connection token: {hash:?}");
 					return Ok(Some(hash))
 				}
 

--- a/local-setup/config/two-workers.json
+++ b/local-setup/config/two-workers.json
@@ -63,8 +63,7 @@
       ],
       "subcommand_flags": [
         "--skip-ra",
-        "--dev",
-        "--request-state"
+        "--dev"
       ]
     }
   ]

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -60,14 +60,7 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 			])
 			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let json_value = match author_submit_extrinsic_inner(local_author.clone(), params) {
-			Ok(hash_value) => RpcReturnValue {
-				do_watch: true,
-				value: hash_value.encode(),
-				status: DirectRequestStatus::TrustedOperationStatus(
-					TrustedOperationStatus::Submitted,
-				),
-			}
-			.to_hex(),
+			Ok(hash_value) => hash_value.to_hex(),
 			Err(error) => compute_hex_encoded_return_error(error.as_str()),
 		};
 		Ok(json!(json_value))

--- a/sidechain/rpc-handler/src/direct_top_pool_api.rs
+++ b/sidechain/rpc-handler/src/direct_top_pool_api.rs
@@ -60,6 +60,9 @@ pub fn add_top_pool_direct_rpc_methods<R, TCS, G, OCallApi>(
 			])
 			.unwrap_or_else(|e| error!("failed to update prometheus metric: {:?}", e));
 		let json_value = match author_submit_extrinsic_inner(local_author.clone(), params) {
+			// Only return hash to support JSON RPC 2.0.
+			// Other methods will follow this pattern when
+			// we tackle #1624.
 			Ok(hash_value) => hash_value.to_hex(),
 			Err(error) => compute_hex_encoded_return_error(error.as_str()),
 		};


### PR DESCRIPTION
* tl;dr; we can subscribe to tops from the js now without any client workarounds. 🥳 Related PR: https://github.com/encointer/encointer-js/pull/116

### Changes
* The crucial change was that websocket clients expect that the `result` of the first RPC response must only contain the subscription ID if it is a subscription, and nothing else. This ID will be used to match subsequent messages to the corresponding subscriptions.
* This also affected the client a little bit, but as the only `send_direct_request` use case is `author_submitAndWatchExtrinsic` currently this could be changed relatively easy. But this change hasn't been integrated holistically enough, we can improve the cli code in some places. Marked as a todo #1625.

### Notes:
* While implementing this, I noticed that our rpc-server doesn't really try to comply with JSON RPC 2.0 even though adhering to that standard is quite straightforward, we mostly just have to change some data types. I created an issue for that #1624.
* This also breaks the benchmarks currently. We shall fix this later see #1626