### PR TITLE
make ParentchainApi generic to support Asset Hub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
+ "sp-version",
  "substrate-api-client",
 ]
 

--- a/app-libs/parentchain-interface/Cargo.toml
+++ b/app-libs/parentchain-interface/Cargo.toml
@@ -25,11 +25,12 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 log = { version = "0.4", default-features = false }
 regex = { optional = true, version = "1.9.5" }
 
-substrate-api-client = { optional = true, default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
 
 # substrate dep
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
+sp-version = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
 
 [dev-dependencies]
 env_logger = "0.9.0"
@@ -62,7 +63,8 @@ std = [
     "regex",
     "sp-core/std",
     "sp-runtime/std",
-    "substrate-api-client",
+    "substrate-api-client/std",
+    "substrate-api-client/sync-api",
 ]
 sgx = [
     "sgx_tstd",

--- a/app-libs/parentchain-interface/src/event_subscriber.rs
+++ b/app-libs/parentchain-interface/src/event_subscriber.rs
@@ -18,12 +18,18 @@ extern crate alloc;
 use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, Ordering};
 use itp_api_client_types::ParentchainApi;
-use itp_types::parentchain::{AddedSgxEnclave, BalanceTransfer, ExtrinsicFailed, ParentchainId};
+use itp_node_api::api_client::AccountApi;
+use itp_types::parentchain::{
+	AddedSgxEnclave, BalanceTransfer, ExtrinsicFailed, Hash, ParentchainId,
+};
 use log::warn;
+use sp_core::crypto::AccountId32;
 use sp_runtime::DispatchError;
 use substrate_api_client::SubscribeEvents;
 
-pub fn subscribe_to_parentchain_events(
+pub fn subscribe_to_parentchain_events<
+	ParentchainApi: AccountApi<AccountId = AccountId32> + SubscribeEvents<Hash = Hash>,
+>(
 	api: &ParentchainApi,
 	parentchain_id: ParentchainId,
 	shutdown_flag: Arc<AtomicBool>,

--- a/app-libs/parentchain-interface/src/integritee/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/integritee/api_client_types.rs
@@ -1,0 +1,95 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Contains semi-generic type definitions to talk to the node without depending on an implementation of Runtime.
+//!
+//! You need to update this if you have a signed extension in your node that
+//! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
+
+pub use itp_types::parentchain::{
+	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
+};
+use sp_runtime::generic;
+use substrate_api_client::ac_primitives::{PlainTipExtrinsicParams, WithExtrinsicParams};
+pub use substrate_api_client::{
+	ac_node_api::{
+		metadata::{InvalidMetadataError, Metadata, MetadataError},
+		EventDetails, Events, StaticEvent,
+	},
+	ac_primitives::{
+		config::{AssetRuntimeConfig, Config},
+		extrinsics::{
+			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericAdditionalSigned,
+			GenericExtrinsicParams, GenericSignedExtra, PlainTip, UncheckedExtrinsicV4,
+		},
+		serde_impls::StorageKey,
+		signer::{SignExtrinsic, StaticExtrinsicSigner},
+	},
+	rpc::Request,
+	storage_key, Api,
+};
+
+// traits from the api-client
+pub mod traits {
+	pub use substrate_api_client::{GetAccountInformation, GetChainInfo, GetStorage};
+}
+
+pub type IntegriteeTip = PlainTip<Balance>;
+pub type IntegriteeRuntimeConfig =
+	WithExtrinsicParams<AssetRuntimeConfig, PlainTipExtrinsicParams<AssetRuntimeConfig>>;
+
+// Configuration for the ExtrinsicParams.
+//
+// Pay in asset fees.
+//
+// This needs to be used if the node uses the `pallet_asset_tx_payment`.
+pub type IntegriteeExtrinsicParams = GenericExtrinsicParams<IntegriteeRuntimeConfig, IntegriteeTip>;
+pub type IntegriteeAdditionalParams = GenericAdditionalParams<IntegriteeRuntimeConfig, Hash>;
+
+pub type IntegriteeSignedExtra = GenericSignedExtra<IntegriteeTip, Index>;
+pub type IntegriteeSignature = Signature<IntegriteeSignedExtra>;
+
+pub type IntegriteeUncheckedExtrinsic<Call> =
+	UncheckedExtrinsicV4<Address, Call, PairSignature, IntegriteeSignedExtra>;
+
+/// Signature type of the [UncheckedExtrinsicV4].
+pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
+
+pub type Block = generic::Block<Header, IntegriteeUncheckedExtrinsic<([u8; 2])>>;
+
+#[cfg(feature = "std")]
+pub use api::*;
+use itp_types::parentchain::Header;
+
+#[cfg(feature = "std")]
+mod api {
+	use super::IntegriteeRuntimeConfig;
+	use crate::ParentchainApiTrait;
+	use itp_node_api::api_client::AccountApi;
+	use itp_types::parentchain::{AccountId, Balance, Hash, Index};
+	pub use substrate_api_client::{
+		api::Error as ApiClientError,
+		rpc::{tungstenite_client::TungsteniteRpcClient, Error as RpcClientError},
+	};
+	use substrate_api_client::{
+		Api, GetBalance, GetChainInfo, GetStorage, GetTransactionPayment, SubscribeEvents,
+	};
+
+	pub type IntegriteeApi = Api<IntegriteeRuntimeConfig, TungsteniteRpcClient>;
+
+	impl ParentchainApiTrait for IntegriteeApi {}
+}

--- a/app-libs/parentchain-interface/src/integritee/api_factory.rs
+++ b/app-libs/parentchain-interface/src/integritee/api_factory.rs
@@ -1,0 +1,45 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use super::api_client_types::IntegriteeApi;
+use itp_api_client_types::TungsteniteRpcClient;
+use itp_node_api::node_api_factory::{CreateNodeApi, NodeApiFactoryError, Result};
+use sp_core::sr25519;
+
+/// Node API factory implementation.
+pub struct IntegriteeNodeApiFactory {
+	node_url: String,
+	signer: sr25519::Pair,
+}
+
+impl IntegriteeNodeApiFactory {
+	pub fn new(url: String, signer: sr25519::Pair) -> Self {
+		Self { node_url: url, signer }
+	}
+}
+
+impl CreateNodeApi<IntegriteeApi> for IntegriteeNodeApiFactory {
+	fn create_api(&self) -> Result<IntegriteeApi> {
+		let rpc_client = TungsteniteRpcClient::new(self.node_url.as_str(), 5)
+			.map_err(NodeApiFactoryError::FailedToCreateRpcClient)?;
+		let mut api =
+			IntegriteeApi::new(rpc_client).map_err(NodeApiFactoryError::FailedToCreateNodeApi)?;
+		api.set_signer(self.signer.clone().into());
+		Ok(api)
+	}
+}

--- a/app-libs/parentchain-interface/src/integritee/mod.rs
+++ b/app-libs/parentchain-interface/src/integritee/mod.rs
@@ -15,6 +15,9 @@
 
 */
 
+pub mod api_client_types;
+#[cfg(feature = "std")]
+pub mod api_factory;
 mod event_filter;
 mod event_handler;
 

--- a/app-libs/parentchain-interface/src/lib.rs
+++ b/app-libs/parentchain-interface/src/lib.rs
@@ -22,6 +22,17 @@
 extern crate sgx_tstd as std;
 
 use codec::{Decode, Encode};
+use itp_node_api::api_client::{AccountApi, ChainApi};
+use itp_types::parentchain::{AccountId, Balance, Hash, Header, Index};
+use sp_runtime::{
+	generic::{Block, UncheckedExtrinsic},
+	MultiAddress,
+};
+use sp_version::GetRuntimeVersionAt;
+use substrate_api_client::{
+	ac_primitives::Properties, extrinsic::BalancesExtrinsics, GetAccountInformation, GetBalance,
+	GetStorage, GetTransactionPayment, SubmitAndWatch, SubscribeEvents, SystemApi,
+};
 
 #[cfg(feature = "std")]
 pub mod event_subscriber;
@@ -53,4 +64,19 @@ pub fn decode_and_log_error<V: Decode>(encoded: &mut &[u8]) -> Option<V> {
 			None
 		},
 	}
+}
+
+/// a trait to aggreagate all traits we need in the service
+pub trait ParentchainApiTrait:
+	AccountApi<AccountId = AccountId, Balance = Balance, Index = Index>
+	+ GetBalance<Balance = Balance>
+	+ GetStorage
+	+ SystemApi<Properties = Properties>
+	+ BalancesExtrinsics<Address = MultiAddress<AccountId, Index>, Balance = Balance>
+	+ ChainApi
+	+ GetAccountInformation<Index = Index>
+	+ SubscribeEvents
+	+ GetTransactionPayment<Balance = Balance>
+	+ SubmitAndWatch<Hash = Hash> //+ GetRuntimeVersionAt<Block<Header, UncheckedExtrinsic<A>>>
+{
 }

--- a/app-libs/parentchain-interface/src/target_a/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/target_a/api_client_types.rs
@@ -1,0 +1,91 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Contains semi-generic type definitions to talk to the node without depending on an implementation of Runtime.
+//!
+//! You need to update this if you have a signed extension in your node that
+//! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
+
+pub use itp_types::parentchain::{
+	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
+};
+use substrate_api_client::ac_primitives::{PlainTipExtrinsicParams, WithExtrinsicParams};
+pub use substrate_api_client::{
+	ac_node_api::{
+		metadata::{InvalidMetadataError, Metadata, MetadataError},
+		EventDetails, Events, StaticEvent,
+	},
+	ac_primitives::{
+		config::{AssetRuntimeConfig, Config},
+		extrinsics::{
+			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericAdditionalSigned,
+			GenericExtrinsicParams, GenericSignedExtra, PlainTip, UncheckedExtrinsicV4,
+		},
+		serde_impls::StorageKey,
+		signer::{SignExtrinsic, StaticExtrinsicSigner},
+	},
+	rpc::Request,
+	storage_key, Api,
+};
+
+// traits from the api-client
+pub mod traits {
+	pub use substrate_api_client::{GetAccountInformation, GetChainInfo, GetStorage};
+}
+
+pub type TargetATip = PlainTip<Balance>;
+pub type TargetARuntimeConfig =
+	WithExtrinsicParams<AssetRuntimeConfig, PlainTipExtrinsicParams<AssetRuntimeConfig>>;
+
+// Configuration for the ExtrinsicParams.
+//
+// Pay in asset fees.
+//
+// This needs to be used if the node uses the `pallet_asset_tx_payment`.
+pub type TargetAExtrinsicParams = GenericExtrinsicParams<TargetARuntimeConfig, TargetATip>;
+pub type TargetAAdditionalParams = GenericAdditionalParams<TargetARuntimeConfig, Hash>;
+
+pub type TargetASignedExtra = GenericSignedExtra<TargetATip, Index>;
+pub type TargetASignature = Signature<TargetASignedExtra>;
+
+pub type TargetAUncheckedExtrinsic<Call> =
+	UncheckedExtrinsicV4<Address, Call, PairSignature, TargetASignedExtra>;
+
+/// Signature type of the [UncheckedExtrinsicV4].
+pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
+
+#[cfg(feature = "std")]
+pub use api::*;
+
+#[cfg(feature = "std")]
+mod api {
+	use super::TargetARuntimeConfig;
+	use crate::ParentchainApiTrait;
+	use itp_node_api::api_client::AccountApi;
+	use itp_types::parentchain::{AccountId, Balance, Hash, Index};
+	pub use substrate_api_client::{
+		api::Error as ApiClientError,
+		rpc::{tungstenite_client::TungsteniteRpcClient, Error as RpcClientError},
+	};
+	use substrate_api_client::{
+		Api, GetBalance, GetChainInfo, GetStorage, GetTransactionPayment, SubscribeEvents,
+	};
+
+	pub type TargetAApi = Api<TargetARuntimeConfig, TungsteniteRpcClient>;
+
+	//impl ParentchainApiTrait for TargetAApi {}
+}

--- a/app-libs/parentchain-interface/src/target_a/api_factory.rs
+++ b/app-libs/parentchain-interface/src/target_a/api_factory.rs
@@ -1,0 +1,45 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use super::api_client_types::TargetAApi;
+use itp_api_client_types::TungsteniteRpcClient;
+use itp_node_api::node_api_factory::{CreateNodeApi, NodeApiFactoryError, Result};
+use sp_core::sr25519;
+
+/// Node API factory implementation.
+pub struct TargetANodeApiFactory {
+	node_url: String,
+	signer: sr25519::Pair,
+}
+
+impl TargetANodeApiFactory {
+	pub fn new(url: String, signer: sr25519::Pair) -> Self {
+		Self { node_url: url, signer }
+	}
+}
+
+impl CreateNodeApi<TargetAApi> for TargetANodeApiFactory {
+	fn create_api(&self) -> Result<TargetAApi> {
+		let rpc_client = TungsteniteRpcClient::new(self.node_url.as_str(), 5)
+			.map_err(NodeApiFactoryError::FailedToCreateRpcClient)?;
+		let mut api =
+			TargetAApi::new(rpc_client).map_err(NodeApiFactoryError::FailedToCreateNodeApi)?;
+		api.set_signer(self.signer.clone().into());
+		Ok(api)
+	}
+}

--- a/app-libs/parentchain-interface/src/target_a/mod.rs
+++ b/app-libs/parentchain-interface/src/target_a/mod.rs
@@ -14,6 +14,10 @@
 	limitations under the License.
 
 */
+
+pub mod api_client_types;
+#[cfg(feature = "std")]
+pub mod api_factory;
 mod event_filter;
 mod event_handler;
 

--- a/app-libs/parentchain-interface/src/target_b/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/target_b/api_client_types.rs
@@ -1,0 +1,91 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+//! Contains semi-generic type definitions to talk to the node without depending on an implementation of Runtime.
+//!
+//! You need to update this if you have a signed extension in your node that
+//! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
+
+pub use itp_types::parentchain::{
+	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
+};
+use substrate_api_client::ac_primitives::{AssetTipExtrinsicParams, WithExtrinsicParams};
+pub use substrate_api_client::{
+	ac_node_api::{
+		metadata::{InvalidMetadataError, Metadata, MetadataError},
+		EventDetails, Events, StaticEvent,
+	},
+	ac_primitives::{
+		config::{AssetRuntimeConfig, Config},
+		extrinsics::{
+			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericAdditionalSigned,
+			GenericExtrinsicParams, GenericSignedExtra, PlainTip, UncheckedExtrinsicV4,
+		},
+		serde_impls::StorageKey,
+		signer::{SignExtrinsic, StaticExtrinsicSigner},
+	},
+	rpc::Request,
+	storage_key, Api,
+};
+
+// traits from the api-client
+pub mod traits {
+	pub use substrate_api_client::{GetAccountInformation, GetChainInfo, GetStorage};
+}
+
+pub type TargetBTip = AssetTip<Balance>;
+pub type TargetBRuntimeConfig =
+	WithExtrinsicParams<AssetRuntimeConfig, AssetTipExtrinsicParams<AssetRuntimeConfig>>;
+
+// Configuration for the ExtrinsicParams.
+//
+// Pay in asset fees.
+//
+// This needs to be used if the node uses the `pallet_asset_tx_payment`.
+pub type TargetBExtrinsicParams = GenericExtrinsicParams<TargetBRuntimeConfig, TargetBTip>;
+pub type TargetBAdditionalParams = GenericAdditionalParams<TargetBRuntimeConfig, Hash>;
+
+pub type TargetBSignedExtra = GenericSignedExtra<TargetBTip, Index>;
+pub type TargetBSignature = Signature<TargetBSignedExtra>;
+
+pub type TargetBUncheckedExtrinsic<Call> =
+	UncheckedExtrinsicV4<Address, Call, PairSignature, TargetBSignedExtra>;
+
+/// Signature type of the [UncheckedExtrinsicV4].
+pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
+
+#[cfg(feature = "std")]
+pub use api::*;
+
+#[cfg(feature = "std")]
+mod api {
+	use super::TargetBRuntimeConfig;
+	use crate::ParentchainApiTrait;
+	use itp_node_api::api_client::{AccountApi, ApiResult};
+	use itp_types::parentchain::{AccountId, Balance, Hash, Index};
+	pub use substrate_api_client::{
+		api::Error as ApiClientError,
+		rpc::{tungstenite_client::TungsteniteRpcClient, Error as RpcClientError},
+	};
+	use substrate_api_client::{
+		Api, GetBalance, GetChainInfo, GetStorage, GetTransactionPayment, SubscribeEvents,
+	};
+
+	pub type TargetBApi = Api<TargetBRuntimeConfig, TungsteniteRpcClient>;
+
+	impl ParentchainApiTrait for TargetBApi {}
+}

--- a/app-libs/parentchain-interface/src/target_b/api_factory.rs
+++ b/app-libs/parentchain-interface/src/target_b/api_factory.rs
@@ -1,0 +1,45 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Copyright (C) 2017-2019 Baidu, Inc. All Rights Reserved.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+
+use super::api_client_types::TargetBApi;
+use itp_api_client_types::TungsteniteRpcClient;
+use itp_node_api::node_api_factory::{CreateNodeApi, NodeApiFactoryError, Result};
+use sp_core::sr25519;
+
+/// Node API factory implementation.
+pub struct TargetBNodeApiFactory {
+	node_url: String,
+	signer: sr25519::Pair,
+}
+
+impl TargetBNodeApiFactory {
+	pub fn new(url: String, signer: sr25519::Pair) -> Self {
+		Self { node_url: url, signer }
+	}
+}
+
+impl CreateNodeApi<TargetBApi> for TargetBNodeApiFactory {
+	fn create_api(&self) -> Result<TargetBApi> {
+		let rpc_client = TungsteniteRpcClient::new(self.node_url.as_str(), 5)
+			.map_err(NodeApiFactoryError::FailedToCreateRpcClient)?;
+		let mut api =
+			TargetBApi::new(rpc_client).map_err(NodeApiFactoryError::FailedToCreateNodeApi)?;
+		api.set_signer(self.signer.clone().into());
+		Ok(api)
+	}
+}

--- a/app-libs/parentchain-interface/src/target_b/mod.rs
+++ b/app-libs/parentchain-interface/src/target_b/mod.rs
@@ -15,6 +15,9 @@
 
 */
 
+pub mod api_client_types;
+#[cfg(feature = "std")]
+pub mod api_factory;
 mod event_filter;
 mod event_handler;
 
@@ -33,10 +36,25 @@ use itc_parentchain_indirect_calls_executor::{
 	filter_metadata::FilterIntoDataFrom,
 	IndirectDispatch,
 };
-use itp_api_client_types::ParentchainSignedExtra;
+use itp_api_client_types::{
+	AssetRuntimeConfig, AssetTip, GenericAdditionalParams, GenericExtrinsicParams,
+	GenericSignedExtra, PairSignature, ParentchainPlainTip, Signature, UncheckedExtrinsicV4,
+};
 use itp_node_api::metadata::pallet_timestamp::TimestampCallIndexes;
 use itp_stf_primitives::traits::IndirectExecutor;
+use itp_types::parentchain::{Address, Balance, Hash, Index};
 use log::*;
+
+// We assume Asset Hub here (or any similar parachain)
+// Pay in asset fees.
+// This needs to be used if the node uses the `pallet_asset_tx_payment`.
+pub type ParentchainExtrinsicParams = GenericExtrinsicParams<AssetRuntimeConfig, AssetTip<Balance>>;
+pub type ParentchainAdditionalParams = GenericAdditionalParams<AssetRuntimeConfig, Hash>;
+
+pub type ParentchainUncheckedExtrinsic<Call> =
+	UncheckedExtrinsicV4<Address, Call, PairSignature, ParentchainSignedExtra>;
+pub type ParentchainSignedExtra = GenericSignedExtra<ParentchainPlainTip, Index>;
+pub type ParentchainSignature = Signature<ParentchainSignedExtra>;
 
 /// Parses the extrinsics corresponding to the parentchain.
 pub type ParentchainExtrinsicParser = ExtrinsicParser<ParentchainSignedExtra>;

--- a/core-primitives/node-api/api-client-extensions/src/account.rs
+++ b/core-primitives/node-api/api-client-extensions/src/account.rs
@@ -14,11 +14,9 @@
 	limitations under the License.
 
 */
-
 use crate::ApiResult;
-use itp_api_client_types::{
-	traits::GetAccountInformation, Api, Config, ParentchainRuntimeConfig, Request,
-};
+use itp_api_client_types::{traits::GetAccountInformation, Api, Config, Request};
+use substrate_api_client::ac_primitives::AccountData;
 
 /// ApiClient extension that contains some convenience methods around accounts.
 // Todo: make generic over `Config` type instead?
@@ -31,9 +29,11 @@ pub trait AccountApi {
 	fn get_free_balance(&self, who: &Self::AccountId) -> ApiResult<Self::Balance>;
 }
 
-impl<Client> AccountApi for Api<ParentchainRuntimeConfig, Client>
+impl<Client, ParentchainRuntimeConfig> AccountApi for Api<ParentchainRuntimeConfig, Client>
 where
 	Client: Request,
+	ParentchainRuntimeConfig:
+		Config<AccountData = AccountData<<ParentchainRuntimeConfig as Config>::Balance>>,
 {
 	type AccountId = <ParentchainRuntimeConfig as Config>::AccountId;
 	type Index = <ParentchainRuntimeConfig as Config>::Index;

--- a/core-primitives/node-api/factory/src/lib.rs
+++ b/core-primitives/node-api/factory/src/lib.rs
@@ -20,7 +20,7 @@ use itp_api_client_types::{ParentchainApi, TungsteniteRpcClient};
 use sp_core::sr25519;
 
 /// Trait to create a node API, based on a node URL and signer.
-pub trait CreateNodeApi {
+pub trait CreateNodeApi<ParentchainApi> {
 	fn create_api(&self) -> Result<ParentchainApi>;
 }
 
@@ -61,7 +61,7 @@ impl NodeApiFactory {
 	}
 }
 
-impl CreateNodeApi for NodeApiFactory {
+impl CreateNodeApi<ParentchainApi> for NodeApiFactory {
 	fn create_api(&self) -> Result<ParentchainApi> {
 		let rpc_client = TungsteniteRpcClient::new(self.node_url.as_str(), 5)
 			.map_err(NodeApiFactoryError::FailedToCreateRpcClient)?;

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1682,6 +1682,8 @@ dependencies = [
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
+ "sp-version",
+ "substrate-api-client",
 ]
 
 [[package]]

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -55,7 +55,7 @@ use sgx_types::*;
 use sp_runtime::traits::{Header as HeaderT, IdentifyAccount};
 use substrate_api_client::{
 	api::XtStatus, rpc::HandleSubscription, GetAccountInformation, GetBalance, GetChainInfo,
-	SubmitAndWatch, SubscribeChain, SubscribeEvents,
+	GetStorage, SubmitAndWatch, SubscribeChain, SubscribeEvents,
 };
 
 use teerex_primitives::{AnySigner, MultiEnclave};
@@ -72,8 +72,13 @@ use crate::{
 	sidechain_setup::ParentchainIntegriteeSidechainInfoProvider,
 };
 use enclave_bridge_primitives::ShardIdentifier;
+use ita_parentchain_interface::{
+	integritee::{api_client_types::IntegriteeApi, api_factory::IntegriteeNodeApiFactory},
+	ParentchainApiTrait,
+};
 use itc_parentchain::primitives::ParentchainId;
-use itp_types::parentchain::{AccountId, Balance};
+use itp_node_api::api_client::ChainApi;
+use itp_types::parentchain::{AccountId, Balance, Index};
 use sp_core::crypto::{AccountId32, Ss58Codec};
 use sp_keyring::AccountKeyring;
 use sp_runtime::MultiSigner;
@@ -95,8 +100,13 @@ use tokio::{runtime::Handle, task::JoinHandle, time::Instant};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(feature = "link-binary")]
-pub type EnclaveWorker =
-	Worker<Config, NodeApiFactory, Enclave, InitializationHandler<WorkerModeProvider>>;
+pub type EnclaveWorker = Worker<
+	Config,
+	IntegriteeNodeApiFactory,
+	IntegriteeApi,
+	Enclave,
+	InitializationHandler<WorkerModeProvider>,
+>;
 
 pub(crate) fn main() {
 	// Setup logging
@@ -502,9 +512,12 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 		.expect("our enclave should be registered at this point");
 	trace!("verified that our enclave is registered: {:?}", my_enclave);
 
-	let (we_are_primary_validateer, re_init_parentchain_needed) =
-		match integritee_rpc_api.primary_worker_for_shard(shard, None).unwrap() {
-			Some(primary_enclave) => match primary_enclave.instance_signer() {
+	let (we_are_primary_validateer, re_init_parentchain_needed) = match integritee_rpc_api
+		.primary_worker_for_shard(shard, None)
+		.unwrap()
+	{
+		Some(primary_enclave) =>
+			match primary_enclave.instance_signer() {
 				AnySigner::Known(MultiSigner::Ed25519(primary)) =>
 					if primary.encode() == tee_accountid.encode() {
 						println!("We are primary worker on this shard and we have been previously running.");
@@ -539,24 +552,24 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 					);
 				},
 			},
-			None => {
-				println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
-				enclave.init_shard(shard.encode()).unwrap();
-				if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
-					enclave
-						.init_shard_creation_parentchain_header(
-							shard,
-							&ParentchainId::Integritee,
-							&register_enclave_xt_header,
-						)
-						.unwrap();
-					debug!("shard config should be initialized on integritee network now");
-					(true, true)
-				} else {
-					(true, false)
-				}
-			},
-		};
+		None => {
+			println!("We are the primary worker on this shard and the shard is untouched. Will initialize it");
+			enclave.init_shard(shard.encode()).unwrap();
+			if WorkerModeProvider::worker_mode() != WorkerMode::Teeracle {
+				enclave
+					.init_shard_creation_parentchain_header(
+						shard,
+						&ParentchainId::Integritee,
+						&register_enclave_xt_header,
+					)
+					.unwrap();
+				debug!("shard config should be initialized on integritee network now");
+				(true, true)
+			} else {
+				(true, false)
+			}
+		},
+	};
 	debug!("getting shard creation: {:?}", enclave.get_shard_creation_info(shard));
 	initialization_handler.registered_on_parentchain();
 
@@ -651,10 +664,14 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	}
 
 	let maybe_target_a_rpc_api = if let Some(url) = config.target_a_parentchain_rpc_endpoint() {
-		let (api, mut handles) = init_target_parentchain(
+		println!("Initializing parentchain TargetA with url: {}", url);
+		let api = NodeApiFactory::new(url, AccountKeyring::Alice.pair())
+			.create_api()
+			.unwrap_or_else(|_| panic!("[TargetA] Failed to create parentchain node API"));
+		let mut handles = init_target_parentchain(
 			&enclave,
 			&tee_accountid,
-			url,
+			&api,
 			shard,
 			ParentchainId::TargetA,
 			is_development_mode,
@@ -667,10 +684,17 @@ fn start_worker<E, T, D, InitializationHandler, WorkerModeProvider>(
 	};
 
 	let maybe_target_b_rpc_api = if let Some(url) = config.target_b_parentchain_rpc_endpoint() {
-		let (api, mut handles) = init_target_parentchain(
+		println!("Initializing parentchain TargetB with url: {}", url);
+		let api = ita_parentchain_interface::target_b::api_factory::TargetBNodeApiFactory::new(
+			url,
+			AccountKeyring::Alice.pair(),
+		)
+		.create_api()
+		.unwrap_or_else(|_| panic!("[TargetB] Failed to create parentchain node API"));
+		let mut handles = init_target_parentchain(
 			&enclave,
 			&tee_accountid,
-			url,
+			&api,
 			shard,
 			ParentchainId::TargetB,
 			is_development_mode,
@@ -787,32 +811,22 @@ fn init_provided_shard_vault<E: EnclaveBase>(
 	}
 }
 
-fn init_target_parentchain<E>(
+fn init_target_parentchain<E, ParentchainApi: ParentchainApiTrait>(
 	enclave: &Arc<E>,
 	tee_account_id: &AccountId32,
-	url: String,
+	node_api: &ParentchainApi,
 	shard: &ShardIdentifier,
 	parentchain_id: ParentchainId,
 	is_development_mode: bool,
 	shutdown_flag: Arc<AtomicBool>,
-) -> (ParentchainApi, Vec<thread::JoinHandle<()>>)
+) -> Vec<thread::JoinHandle<()>>
 where
 	E: EnclaveBase + Sidechain,
 {
-	println!("Initializing parentchain {:?} with url: {}", parentchain_id, url);
-	let node_api = NodeApiFactory::new(url, AccountKeyring::Alice.pair())
-		.create_api()
-		.unwrap_or_else(|_| panic!("[{:?}] Failed to create parentchain node API", parentchain_id));
-
-	setup_reasonable_account_funding(
-		&node_api,
-		tee_account_id,
-		parentchain_id,
-		is_development_mode,
-	)
-	.unwrap_or_else(|_| {
-		panic!("[{:?}] Could not fund parentchain enclave account", parentchain_id)
-	});
+	setup_reasonable_account_funding(node_api, tee_account_id, parentchain_id, is_development_mode)
+		.unwrap_or_else(|_| {
+			panic!("[{:?}] Could not fund parentchain enclave account", parentchain_id)
+		});
 
 	// we attempt to set shard creation for this parentchain in case it hasn't been done before
 	let api_head = node_api.get_header(None).unwrap().unwrap();
@@ -855,16 +869,16 @@ where
 		.name(format!("{:?}_parentchain_event_subscription", parentchain_id))
 		.spawn(move || {
 			ita_parentchain_interface::event_subscriber::subscribe_to_parentchain_events(
-				&node_api_clone,
+				node_api_clone,
 				parentchain_id,
 				shutdown_flag,
 			)
 		})
 		.unwrap();
-	(node_api, handles)
+	handles
 }
 
-fn init_parentchain<E>(
+fn init_parentchain<E, ParentchainApi: ParentchainApiTrait>(
 	enclave: &Arc<E>,
 	node_api: &ParentchainApi,
 	tee_account_id: &AccountId32,

--- a/service/src/ocall_bridge/component_factory.rs
+++ b/service/src/ocall_bridge/component_factory.rs
@@ -135,8 +135,9 @@ impl<
 		PeerBlockFetcher,
 		TokioHandle,
 		MetricsReceiver,
-	> where
-	NodeApi: CreateNodeApi + 'static,
+	>
+where
+	NodeApi: CreateNodeApi<NodeApi> + 'static,
 	Broadcaster: BroadcastBlocks + 'static,
 	EnclaveApi: RemoteAttestationCallBacks + 'static,
 	Storage: BlockStorage<SignedSidechainBlock> + 'static,

--- a/service/src/parentchain_handler.rs
+++ b/service/src/parentchain_handler.rs
@@ -19,12 +19,11 @@
 use crate::error::{Error, ServiceResult};
 use codec::{Decode, Encode};
 use humantime::format_duration;
-use ita_parentchain_interface::integritee::Header;
+use ita_parentchain_interface::{integritee::Header, ParentchainApiTrait};
 use itc_parentchain::{
 	light_client::light_client_init_params::{GrandpaParams, SimpleParams},
 	primitives::{ParentchainId, ParentchainInitParams},
 };
-use itp_api_client_types::ParentchainApi;
 use itp_enclave_api::{enclave_base::EnclaveBase, sidechain::Sidechain};
 use itp_node_api::api_client::ChainApi;
 use itp_storage::StorageProof;
@@ -74,9 +73,10 @@ pub(crate) struct ParentchainHandler<ParentchainApi, EnclaveApi> {
 
 // #TODO: #1451: Reintroduce `ParentchainApi: ChainApi` once there is no trait bound conflict
 // any more with the api-clients own trait definitions.
-impl<EnclaveApi> ParentchainHandler<ParentchainApi, EnclaveApi>
+impl<EnclaveApi, ParentchainApi> ParentchainHandler<ParentchainApi, EnclaveApi>
 where
 	EnclaveApi: EnclaveBase,
+	ParentchainApi: ParentchainApiTrait,
 {
 	pub fn new(
 		parentchain_api: ParentchainApi,
@@ -142,9 +142,11 @@ where
 	}
 }
 
-impl<EnclaveApi> HandleParentchain for ParentchainHandler<ParentchainApi, EnclaveApi>
+impl<EnclaveApi, ParentchainApi> HandleParentchain
+	for ParentchainHandler<ParentchainApi, EnclaveApi>
 where
 	EnclaveApi: Sidechain + EnclaveBase,
+	ParentchainApi: ParentchainApiTrait,
 {
 	fn init_parentchain_components(&self) -> ServiceResult<Header> {
 		Ok(self

--- a/service/src/prometheus_metrics.rs
+++ b/service/src/prometheus_metrics.rs
@@ -34,13 +34,17 @@ use codec::{Decode, Encode};
 use core::time::Duration;
 use enclave_bridge_primitives::ShardIdentifier;
 use frame_support::scale_info::TypeInfo;
+use ita_parentchain_interface::{
+	integritee::api_client_types::IntegriteeApi, target_a::api_client_types::TargetAApi,
+	target_b::api_client_types::TargetBApi,
+};
 #[cfg(feature = "attesteer")]
 use itc_rest_client::{
 	http_client::{DefaultSend, HttpClient},
 	rest_client::{RestClient, Url as URL},
 	RestGet, RestPath,
 };
-use itp_api_client_types::ParentchainApi;
+
 use itp_enclave_api::{enclave_base::EnclaveBase, sidechain::Sidechain};
 use itp_enclave_metrics::EnclaveMetric;
 use itp_types::{parentchain::ParentchainId, EnclaveFingerprint};
@@ -354,16 +358,16 @@ pub fn start_prometheus_metrics_server<E>(
 	enclave: &Arc<E>,
 	tee_account_id: &AccountId32,
 	shard: &ShardIdentifier,
-	integritee_rpc_api: ParentchainApi,
-	maybe_target_a_rpc_api: Option<ParentchainApi>,
-	maybe_target_b_rpc_api: Option<ParentchainApi>,
+	integritee_rpc_api: IntegriteeApi,
+	maybe_target_a_rpc_api: Option<TargetAApi>,
+	maybe_target_b_rpc_api: Option<TargetBApi>,
 	shielding_target: Option<ParentchainId>,
 	tokio_handle: &Handle,
 	metrics_server_port: u16,
 ) where
 	E: EnclaveBase + Sidechain,
 {
-	let mut account_info_providers: Vec<Arc<ParentchainAccountInfoProvider>> = vec![];
+	let mut account_info_providers: Vec<Arc<ParentchainAccountInfoProvider<_>>> = vec![];
 	account_info_providers.push(Arc::new(ParentchainAccountInfoProvider::new(
 		ParentchainId::Integritee,
 		integritee_rpc_api.clone(),


### PR DESCRIPTION
This is WIP. just wanted to know how far away we are. And we're not exactly near. reachable, but with effort

challenges:
* supertrait must use extrinsic type (and block type) which introduces yet another type argument and may prevent some super-generic treatment