### PR TITLE
implement PublicGetter undistributed_fees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,6 +2860,7 @@ dependencies = [
  "itp-hashing",
  "itp-node-api",
  "itp-node-api-metadata",
+ "itp-randomness",
  "itp-sgx-externalities",
  "itp-sgx-runtime-primitives",
  "itp-stf-interface",

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -20,6 +20,7 @@ ita-sgx-runtime = { default-features = false, path = "../sgx-runtime" }
 itp-hashing = { default-features = false, path = "../../core-primitives/hashing" }
 itp-node-api = { default-features = false, path = "../../core-primitives/node-api" }
 itp-node-api-metadata = { default-features = false, path = "../../core-primitives/node-api/metadata" }
+itp-randomness = { path = "../../core-primitives/randomness", default-features = false }
 itp-sgx-externalities = { default-features = false, path = "../../core-primitives/substrate-sgx/externalities" }
 itp-sgx-runtime-primitives = { default-features = false, path = "../../core-primitives/sgx-runtime-primitives" }
 itp-stf-interface = { default-features = false, path = "../../core-primitives/stf-interface" }

--- a/cli/src/trusted_base_cli/commands/get_undistributed_fees.rs
+++ b/cli/src/trusted_base_cli/commands/get_undistributed_fees.rs
@@ -1,0 +1,36 @@
+/*
+	Copyright 2021 Integritee AG
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+
+*/
+use crate::{
+	trusted_cli::TrustedCli, trusted_operation::perform_trusted_operation, Cli, CliResult,
+	CliResultOk,
+};
+use ita_stf::{Balance, Getter, PublicGetter, TrustedCallSigned};
+use itp_stf_primitives::types::TrustedOperation;
+
+#[derive(Parser)]
+pub struct GetUndistributedFeesCommand {}
+
+impl GetUndistributedFeesCommand {
+	pub(crate) fn run(&self, cli: &Cli, trusted_args: &TrustedCli) -> CliResult {
+		let top = TrustedOperation::<TrustedCallSigned, Getter>::get(Getter::public(
+			PublicGetter::undistributed_fees,
+		));
+		let fees: Balance = perform_trusted_operation(cli, trusted_args, &top).unwrap();
+		println!("{:?}", fees);
+		Ok(CliResultOk::Balance { balance: fees })
+	}
+}

--- a/cli/src/trusted_base_cli/commands/mod.rs
+++ b/cli/src/trusted_base_cli/commands/mod.rs
@@ -1,15 +1,15 @@
+pub mod add_session_proxy;
 pub mod balance;
 pub mod get_fingerprint;
 pub mod get_header;
 pub mod get_note_buckets_info;
 pub mod get_notes;
 pub mod get_parentchains_info;
+pub mod get_session_proxies;
 pub mod get_shard;
 pub mod get_shard_vault;
 pub mod get_total_issuance;
-
-pub mod add_session_proxy;
-pub mod get_session_proxies;
+pub mod get_undistributed_fees;
 pub mod nonce;
 pub mod note_bloat;
 pub mod transfer;

--- a/cli/src/trusted_base_cli/mod.rs
+++ b/cli/src/trusted_base_cli/mod.rs
@@ -25,7 +25,8 @@ use crate::{
 		get_parentchains_info::GetParentchainsInfoCommand,
 		get_session_proxies::GetSessionProxiesCommand, get_shard::GetShardCommand,
 		get_shard_vault::GetShardVaultCommand, get_total_issuance::GetTotalIssuanceCommand,
-		nonce::NonceCommand, note_bloat::NoteBloatCommand, transfer::TransferCommand,
+		get_undistributed_fees::GetUndistributedFeesCommand, nonce::NonceCommand,
+		note_bloat::NoteBloatCommand, transfer::TransferCommand,
 		unshield_funds::UnshieldFundsCommand, version::VersionCommand,
 		waste_time::WasteTimeCommand, watchdog::WatchdogCommand,
 	},
@@ -80,6 +81,9 @@ pub enum TrustedBaseCommand {
 	/// get total issuance of this shard's native token
 	GetTotalIssuance(GetTotalIssuanceCommand),
 
+	/// get a noisy amount of collected but undistributed fees
+	GetUndistributedFees(GetUndistributedFeesCommand),
+
 	/// get info for all parentchains' sync status
 	GetParentchainsInfo(GetParentchainsInfoCommand),
 
@@ -127,6 +131,7 @@ impl TrustedBaseCommand {
 			TrustedBaseCommand::GetShardVault(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetSidechainHeader(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetTotalIssuance(cmd) => cmd.run(cli, trusted_cli),
+			TrustedBaseCommand::GetUndistributedFees(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::AddSessionProxy(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::GetSessionProxies(cmd) => cmd.run(cli, trusted_cli),
 			TrustedBaseCommand::NoteBloat(cmd) => cmd.run(cli, trusted_cli),

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1733,6 +1733,7 @@ dependencies = [
  "itp-hashing",
  "itp-node-api",
  "itp-node-api-metadata",
+ "itp-randomness",
  "itp-sgx-externalities",
  "itp-sgx-runtime-primitives",
  "itp-stf-interface",


### PR DESCRIPTION
Get the balance of the enclave signer which collets fees. Add uniform noise of 10x TX_FEE for recent caller privacy

testing:
```
decimals=10
tx fee: 100 000 000

execute 3x: ./integritee-cli trusted --shard HrAYWCwM9DCk4GYxzuJK9qa6QZVXgTsUxMXcmfxT8biZ get-undistributed-fees

35 639 820 615                                                                                                                                                                                                                                                                         
35 139 820 615                                                                                                                                                                
35 039 820 615

transfer until nonce = 8

36 039 820 615
36 739 820 615
36 039 820 615

transfer until nonce = 12

37 139 820 615
36 839 820 615
37 039 820 615

```

