### PR TITLE
adjust fees per asset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-cli"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "array-bytes 6.1.0",
  "base58",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-service"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/app-libs/assets-map/src/lib.rs
+++ b/app-libs/assets-map/src/lib.rs
@@ -297,8 +297,18 @@ impl AssetTranslation for AssetId {
 		Self: Sized,
 	{
 		if location.parents == 2 {
-			if let X2(junctions) = &location.interior {
-				match junctions.as_slice() {
+			match &location.interior {
+				X1(junctions) => match junctions.as_slice() {
+					[GlobalConsensus(Ethereum { chain_id: ETHEREUM_MAINNET_CHAIN_ID })]
+						if matches!(
+							genesis_hash.into(),
+							ASSET_HUB_POLKADOT_GENESIS_HASH_HEX
+								| ASSET_HUB_LOCAL_TEST_GENESIS_HASH_HEX
+						) =>
+						Some(AssetId::ETH),
+					_ => None,
+				},
+				X2(junctions) => match junctions.as_slice() {
 					[GlobalConsensus(Ethereum { chain_id: ETHEREUM_MAINNET_CHAIN_ID }), AccountKey20 { key: contract, network: None }]
 						if *contract == USDC_E_MAINNET_CONTRACT_ADDRESS
 							&& matches!(
@@ -331,17 +341,9 @@ impl AssetTranslation for AssetId {
 									| ASSET_HUB_LOCAL_TEST_GENESIS_HASH_HEX
 							) =>
 						Some(AssetId::WETH),
-					[GlobalConsensus(Ethereum { chain_id: ETHEREUM_MAINNET_CHAIN_ID })]
-						if matches!(
-							genesis_hash.into(),
-							ASSET_HUB_POLKADOT_GENESIS_HASH_HEX
-								| ASSET_HUB_LOCAL_TEST_GENESIS_HASH_HEX
-						) =>
-						Some(AssetId::ETH),
 					_ => None,
-				}
-			} else {
-				None
+				},
+				_ => None,
 			}
 		} else {
 			None

--- a/app-libs/stf/src/trusted_call.rs
+++ b/app-libs/stf/src/trusted_call.rs
@@ -1004,7 +1004,14 @@ fn get_fee_for(tc: &TrustedCallSigned, fee_asset: Option<AssetId>) -> Fee {
 	}
 	match fee_asset {
 		None => Fee::Native(fee_amount),
-		Some(asset_id) => Fee::Asset(fee_amount, asset_id),
+		Some(asset_id) => match asset_id {
+			AssetId::USDC | AssetId::USDT | AssetId::USDC_E | AssetId::USDT_E =>
+				Fee::Asset(fee_amount, asset_id),
+			// TODO: use TEEracle info from L1 for exchange rates. the hardcoded exchange rates are
+			// just to get started in the right order of magnitude
+			AssetId::ETH | AssetId::WETH => Fee::Asset(fee_amount / 2_000, asset_id),
+			AssetId::BTC | AssetId::WBTC_E => Fee::Asset(fee_amount / 70_000, asset_id),
+		},
 	}
 }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-cli"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runtime"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "array-bytes 6.2.2",
  "cid",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runtime"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-service"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Integritee AG <hello@integritee.network>"]
 build = "build.rs"
 edition = "2021"


### PR DESCRIPTION
only roughly. no price oracles used yet

also fixes bogus ETH location transformation from #1710

## tests

```
tester IncogniteeAHP account starts with 

L1: 0.003 ETH
shield 0.001 ETH
L1: 0.002 ETH
L2: 0.000998248686514887 ETH
send 0.0001 ETH to tester. received
L2: 0.000898248686514887
(fees were charged in DOT)
unshield 0.0005
L1: 0.0025 ETH
L2: 0.000398248686514887

Now testing if fees charged in ETH
send 0.0002 ETH to account without any DOT or other assets (tester2 local)
bal 0.0002
send 0.0001 back
bal 0.000094450000000000
fee 0.00000555 ETH
```