### PR TITLE
Support Extrinsiv V5

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -315,7 +315,7 @@ jobs:
           echo "PROJECT=${{ matrix.flavor_id }}-${{ matrix.demo_name }}" >> $GITHUB_ENV
           echo "VERSION=dev.$version" >> $GITHUB_ENV
           echo "WORKER_IMAGE_TAG=integritee-worker:dev.$version" >> $GITHUB_ENV
-          echo "INTEGRITEE_NODE=integritee-node:1.13.0.$version" >> $GITHUB_ENV
+          echo "INTEGRITEE_NODE=integritee-node:1.18.8.$version" >> $GITHUB_ENV
           echo "CLIENT_IMAGE_TAG=integritee-cli:dev.$version" >> $GITHUB_ENV
           if [[ ${{ matrix.sgx_mode }} == 'HW' ]]; then
              echo "SGX_PROVISION=/dev/sgx/provision" >> $GITHUB_ENV
@@ -360,8 +360,8 @@ jobs:
           fi
           docker tag integritee-worker-${{ env.IMAGE_SUFFIX }} ${{ env.WORKER_IMAGE_TAG }}
           docker tag integritee-cli-client-${{ env.IMAGE_SUFFIX }} ${{ env.CLIENT_IMAGE_TAG }}
-          docker pull integritee/integritee-node:1.13.0
-          docker tag integritee/integritee-node:1.13.0 ${{ env.INTEGRITEE_NODE }}
+          docker pull integritee/integritee-node:1.18.8
+          docker tag integritee/integritee-node:1.18.8 ${{ env.INTEGRITEE_NODE }}
           docker images --all
 
       ##

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "ac-primitives",
  "log 0.4.22",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.9.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -8541,7 +8541,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-cli"
-version = "0.16.7"
+version = "0.17.0"
 dependencies = [
  "array-bytes 6.1.0",
  "base58",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "integritee-service"
-version = "0.16.7"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "ac-primitives",
  "log 0.4.22",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.9.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#84655ae1c4cf0ea7f45aee7ce7935dae027f9ae6"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
 dependencies = [
  "ac-primitives",
  "log 0.4.22",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#84655ae1c4cf0ea7f45aee7ce7935dae027f9ae6"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,10 +50,11 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#84655ae1c4cf0ea7f45aee7ce7935dae027f9ae6"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
 dependencies = [
  "frame-system",
  "impl-serde",
+ "impl-trait-for-tuples",
  "pallet-assets",
  "pallet-balances",
  "parity-scale-codec",
@@ -235,7 +236,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1717,7 +1718,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1729,7 +1730,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1739,7 +1740,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1908,7 +1909,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2520,13 +2521,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5157,7 +5158,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5685,7 +5686,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5841,14 +5842,14 @@ checksum = "0e99670bafb56b9a106419397343bdbc8b8742c3cc449fec6345f86173f47cd4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -5934,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -6162,7 +6163,7 @@ checksum = "2dfaf0c85b766276c797f3791f5bc6d5bd116b41d53049af2789666b0c0bc9fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6859,7 +6860,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7323,7 +7324,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7482,7 +7483,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-core-hashing",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7492,7 +7493,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7654,7 +7655,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7783,7 +7784,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7911,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#84655ae1c4cf0ea7f45aee7ce7935dae027f9ae6"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7949,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.9.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#84655ae1c4cf0ea7f45aee7ce7935dae027f9ae6"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -7992,9 +7993,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8136,7 +8137,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8231,7 +8232,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8351,7 +8352,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8540,7 +8541,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
@@ -8829,7 +8830,7 @@ dependencies = [
  "once_cell 1.18.0",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -8863,7 +8864,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9477,7 +9478,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "ac-primitives",
  "log 0.4.22",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "frame-system",
  "impl-serde",
@@ -7912,7 +7912,7 @@ dependencies = [
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "substrate-client-keystore"
 version = "0.9.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#a9de489c1a556b36994f10e4989555121a01e4d2"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -8541,7 +8541,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",

--- a/app-libs/parentchain-interface/Cargo.toml
+++ b/app-libs/parentchain-interface/Cargo.toml
@@ -27,7 +27,7 @@ hex-literal = "0.4.1"
 log = { version = "0.4", default-features = false }
 regex = { optional = true, version = "1.9.5" }
 
-substrate-api-client = { default-features = false, git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
 
 # substrate dep
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/app-libs/parentchain-interface/Cargo.toml
+++ b/app-libs/parentchain-interface/Cargo.toml
@@ -27,7 +27,7 @@ hex-literal = "0.4.1"
 log = { version = "0.4", default-features = false }
 regex = { optional = true, version = "1.9.5" }
 
-substrate-api-client = { default-features = false, git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-api-client = { default-features = false, git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
 
 # substrate dep
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -71,3 +71,78 @@ where
 		})
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ita_sgx_runtime::opaque::UncheckedExtrinsic;
+	use itp_api_client_types::{ParentchainSignature, ParentchainTxExtension, Signature};
+	use itp_utils::FromHexPrefixed;
+	use sp_core::crypto::AccountId32;
+	use sp_runtime::{generic::Era, OpaqueExtrinsic};
+
+	#[test]
+	#[allow(deprecated)]
+	fn can_parse_v4_extrinsic() {
+		use substrate_api_client::ac_primitives::extrinsics::deprecated::UncheckedExtrinsicV4 as XTV4;
+
+		let ex_v4: XTV4<Address, _, ParentchainSignature, ()> = XTV4::new_unsigned([1u8, 2u8]);
+
+		let encoded = ex_v4.encode();
+
+		let parsed = ExtrinsicParser::<ParentchainTxExtension>::parse(&encoded).unwrap();
+
+		match parsed.preamble {
+			Preamble::Bare(4) => (),
+			other => panic!("unexpected preamble: {:?}", other),
+		};
+
+		assert_eq!(parsed.call_index, [1, 2]);
+	}
+
+	#[test]
+	fn can_parse_v5_extrinsic() {
+		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
+
+		let address = Address::Id(AccountId32::new([0; 32]));
+		let extension = ParentchainTxExtension::new(Era::Immortal, 1, Default::default());
+		let signature = ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
+
+		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
+			XTV5::new_signed(
+				[1u8, 2u8, 0, 0, 0],
+				address.clone(),
+				signature.clone(),
+				extension.clone(),
+			);
+
+		let encoded = ex_v5.encode();
+
+		let parsed = ExtrinsicParser::<ParentchainTxExtension>::parse(&encoded).unwrap();
+
+		match &parsed.preamble {
+			Preamble::Signed(addr, sig, ext) => {
+				assert_eq!(addr, &address);
+				assert_eq!(sig, &signature);
+				assert_eq!(ext, &extension);
+			},
+			other => panic!("unexpected preamble: {:?}", other),
+		};
+
+		assert_eq!(parsed.call_index, [1, 2]);
+	}
+
+	// #[test]
+	// fn can_parse_register_enclave() {
+	// 	let encoded = "0x81028400d345e01893ae2c5c600675fe7b901e0b32641b3b4405772ed5eb227228ab535700d0168da6e0bd8c5657616e8b4641d47f2cd7bcbe9f76846d6a65e006d995fff1ef2b42f7e3418c9dec75bb7bae07ece61dc0255ad19879cefae88bb8c575180515000000320080fec01d23e7fe3f1db1b7740e3bc01013b330797b2ae97b589604393fc1d005f101487773733a2f2f302e302e302e303a323030300000";
+	// 	let xt = OpaqueExtrinsic::from_hex(encoded).unwrap();
+	//
+	// 	let parsed = ExtrinsicParser::<ParentchainTxExtension>::parse(&encoded.as_bytes()).unwrap();
+	//
+	// 	match parsed.preamble {
+	// 		Preamble::General(_, _) => (),
+	// 		other => panic!("unexpected preamble: {:?}", other),
+	// 	};
+	//
+	// }
+}

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -17,28 +17,29 @@
 
 use codec::{Decode, Encode};
 use core::marker::PhantomData;
+use itp_api_client_types::Preamble;
 use itp_node_api::api_client::{
-	Address, CallIndex, PairSignature, Signature, UncheckedExtrinsicV4,
+	Address, CallIndex, PairSignature, UncheckedExtrinsic,
 };
 
 pub struct ExtrinsicParser<SignedExtra> {
 	_phantom: PhantomData<SignedExtra>,
 }
 
-/// Partially interpreted extrinsic containing the `signature` and the `call_index` whereas
+/// Partially interpreted extrinsic containing the `preamble` and the `call_index` whereas
 /// the `call_args` remain in encoded form.
 ///
 /// Intended for usage, where the actual `call_args` form is unknown.
-pub struct SemiOpaqueExtrinsic<'a, SignedExtra> {
+pub struct SemiOpaqueExtrinsic<'a, TxExtension> {
 	/// Signature of the Extrinsic.
-	pub signature: Signature<SignedExtra>,
+	pub preamble: Preamble<TxExtension>,
 	/// Call index of the dispatchable.
 	pub call_index: CallIndex,
 	/// Encoded arguments of the dispatchable corresponding to the `call_index`.
 	pub call_args: &'a [u8],
 }
 
-/// Trait to extract signature and call indexes of an encoded [UncheckedExtrinsicV4].
+/// Trait to extract signature and call indexes of an encoded [UncheckedExtrinsic].
 pub trait ParseExtrinsic {
 	/// Signed extra of the extrinsic.
 	type SignedExtra;
@@ -58,7 +59,7 @@ where
 
 		// `()` is a trick to stop decoding after the call index. So the remaining bytes
 		//  of `call` after decoding only contain the parentchain's dispatchable's arguments.
-		let xt = UncheckedExtrinsicV4::<
+		let xt = UncheckedExtrinsic::<
             Address,
             (CallIndex, ()),
             PairSignature,
@@ -66,7 +67,7 @@ where
         >::decode(call_mut)?;
 
 		Ok(SemiOpaqueExtrinsic {
-			signature: xt.signature,
+			preamble: xt.preamble,
 			call_index: xt.function.0,
 			call_args: call_mut,
 		})

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -221,7 +221,8 @@ mod tests {
 		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
 
 		// We only care about the preamble, so we use the `()` to stop decoding after the preamble.
-		let ex_v5: XTV5<Address, (), ParentchainSignature, ParentchainTxExtension> = XTV5::from_hex("0x280503000bc02a05399901").unwrap();
+		let ex_v5: XTV5<Address, (), ParentchainSignature, ParentchainTxExtension> =
+			XTV5::from_hex("0x280503000bc02a05399901").unwrap();
 
 		match &ex_v5.preamble {
 			Preamble::Bare(version) => assert_eq!(version, &5),

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -18,9 +18,7 @@
 use codec::{Decode, Encode};
 use core::marker::PhantomData;
 use itp_api_client_types::Preamble;
-use itp_node_api::api_client::{
-	Address, CallIndex, PairSignature, UncheckedExtrinsic,
-};
+use itp_node_api::api_client::{Address, CallIndex, PairSignature, UncheckedExtrinsic};
 
 pub struct ExtrinsicParser<SignedExtra> {
 	_phantom: PhantomData<SignedExtra>,

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -75,15 +75,15 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use ita_sgx_runtime::opaque::UncheckedExtrinsic;
-	use itp_api_client_types::{ParentchainSignature, ParentchainTxExtension, Signature};
-	use itp_utils::FromHexPrefixed;
+	use itp_api_client_types::{ParentchainPlainTip, ParentchainSignature, ParentchainTxExtension};
+	use itp_types::Nonce;
 	use sp_core::crypto::AccountId32;
 	use sp_runtime::{generic::Era, OpaqueExtrinsic};
+	use substrate_api_client::ac_primitives::GenericTxExtension;
 
 	#[test]
 	#[allow(deprecated)]
-	fn can_parse_v4_extrinsic() {
+	fn can_parse_v4_unsigned_extrinsic() {
 		use substrate_api_client::ac_primitives::extrinsics::deprecated::UncheckedExtrinsicV4 as XTV4;
 
 		let ex_v4: XTV4<Address, _, ParentchainSignature, ()> = XTV4::new_unsigned([1u8, 2u8]);
@@ -101,13 +101,55 @@ mod tests {
 	}
 
 	#[test]
-	fn can_parse_v5_extrinsic() {
+	#[allow(deprecated)]
+	fn can_parse_v4_signed_extrinsic() {
+		use substrate_api_client::ac_primitives::extrinsics::deprecated::UncheckedExtrinsicV4 as XTV4;
+
+		let (address, extension, signature) = get_default_signer_data();
+
+		let ex_v4: XTV4<Address, _, ParentchainSignature, ParentchainTxExtension> =
+			XTV4::new_signed([1u8, 2u8], address.clone(), signature.clone(), extension.clone());
+
+		let encoded = ex_v4.encode();
+
+		let parsed = ExtrinsicParser::<ParentchainTxExtension>::parse(&encoded).unwrap();
+
+		match &parsed.preamble {
+			Preamble::Signed(addr, sig, ext) => {
+				assert_eq!(addr, &address);
+				assert_eq!(sig, &signature);
+				assert_eq!(ext, &extension);
+			},
+			other => panic!("unexpected preamble: {:?}", other),
+		};
+
+		assert_eq!(parsed.call_index, [1, 2]);
+	}
+
+	#[test]
+	fn can_parse_v5_bare_extrinsic() {
 		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
 
-		let address = Address::Id(AccountId32::new([0; 32]));
-		let extension = ParentchainTxExtension::new(Era::Immortal, 1, Default::default());
-		let signature =
-			ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
+		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
+			XTV5::new_bare([1u8, 2u8, 0, 0, 0]);
+
+		let encoded = ex_v5.encode();
+
+		let parsed = ExtrinsicParser::<ParentchainTxExtension>::parse(&encoded).unwrap();
+
+		match &parsed.preamble {
+			Preamble::Bare(5) => {},
+			other => panic!("unexpected preamble: {:?}", other),
+		};
+
+		assert_eq!(parsed.call_index, [1, 2]);
+	}
+
+	#[test]
+	fn can_parse_v5_signed_extrinsic() {
+		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
+
+		let (address, extension, signature) = get_default_signer_data();
 
 		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
 			XTV5::new_signed(
@@ -137,10 +179,7 @@ mod tests {
 	fn opaque_extrinsic_works() {
 		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
 
-		let address = Address::Id(AccountId32::new([0; 32]));
-		let extension = ParentchainTxExtension::new(Era::Immortal, 1, Default::default());
-		let signature =
-			ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
+		let (address, extension, signature) = get_default_signer_data();
 
 		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
 			XTV5::new_signed(
@@ -160,17 +199,13 @@ mod tests {
 		assert_eq!(ex_v5, decoded);
 	}
 
-	// #[test]
-	// fn can_parse_register_enclave() {
-	// 	let encoded = "0x81028400d345e01893ae2c5c600675fe7b901e0b32641b3b4405772ed5eb227228ab535700d0168da6e0bd8c5657616e8b4641d47f2cd7bcbe9f76846d6a65e006d995fff1ef2b42f7e3418c9dec75bb7bae07ece61dc0255ad19879cefae88bb8c575180515000000320080fec01d23e7fe3f1db1b7740e3bc01013b330797b2ae97b589604393fc1d005f101487773733a2f2f302e302e302e303a323030300000";
-	// 	let xt = OpaqueExtrinsic::from_hex(encoded).unwrap();
-	//
-	// 	let parsed = ExtrinsicParser::<ParentchainTxExtension>::parse(&encoded.as_bytes()).unwrap();
-	//
-	// 	match parsed.preamble {
-	// 		Preamble::General(_, _) => (),
-	// 		other => panic!("unexpected preamble: {:?}", other),
-	// 	};
-	//
-	// }
+	fn get_default_signer_data(
+	) -> (Address, GenericTxExtension<ParentchainPlainTip, Nonce>, ParentchainSignature) {
+		let address = Address::Id(AccountId32::new([0; 32]));
+		let extension = ParentchainTxExtension::new(Era::Immortal, 1, Default::default());
+		let signature =
+			ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
+
+		(address, extension, signature)
+	}
 }

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -200,6 +200,22 @@ mod tests {
 	}
 
 	#[test]
+	fn can_parse_asset_hub_transaction_v4() {
+		use itp_utils::FromHexPrefixed;
+		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
+
+		// We only care about the preamble, so we use the `()` to stop decoding after the preamble.
+		let ex_v5: XTV5<Address, (), ParentchainSignature, ParentchainTxExtension> = XTV5::from_hex("0x4d0284007c77c5f95a72c19e051233b3b1e01df74ec13cb161b109fc5f16ce1c65316f2401f63f850629722493607fb04dfa64d9bd62c454ea325b96d71938d0a52f513c4b35681b9c323b9a09b9f7227e10a5707624afbeb2232759505119da68fa6de08b2400040000000a0300b1df638e78cd896db34d8e62722fd755360d61dac2f3b048e24cd26a5ace35690b008cb6611e01").unwrap();
+
+		match &ex_v5.preamble {
+			// If the preamble is signed, it means that an XT V4 was sent
+			Preamble::Signed(..) => {},
+			Preamble::General(..) => panic!("unexpected preamble belonging to XT V5"),
+			other => panic!("unexpected preamble: {:?}", other),
+		};
+	}
+
+	#[test]
 	fn opaque_extrinsic_works() {
 		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
 

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -176,6 +176,30 @@ mod tests {
 	}
 
 	#[test]
+	fn can_parse_v5_general_transaction() {
+		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
+
+		let (_, extension, _) = get_default_signer_data();
+
+		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
+			XTV5::new_transaction([1u8, 2u8, 0, 0, 0], extension.clone());
+
+		let encoded = ex_v5.encode();
+
+		let parsed = ExtrinsicParser::<ParentchainTxExtension>::parse(&encoded).unwrap();
+
+		match &parsed.preamble {
+			Preamble::General(extension_version, ext) => {
+				assert_eq!(extension_version, &0);
+				assert_eq!(ext, &extension);
+			},
+			other => panic!("unexpected preamble: {:?}", other),
+		};
+
+		assert_eq!(parsed.call_index, [1, 2]);
+	}
+
+	#[test]
 	fn opaque_extrinsic_works() {
 		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
 

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -132,6 +132,31 @@ mod tests {
 		assert_eq!(parsed.call_index, [1, 2]);
 	}
 
+	#[test]
+	fn opaque_extrinsic_works() {
+		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
+
+		let address = Address::Id(AccountId32::new([0; 32]));
+		let extension = ParentchainTxExtension::new(Era::Immortal, 1, Default::default());
+		let signature = ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
+
+		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
+			XTV5::new_signed(
+				[1u8, 2u8, 0, 0, 0],
+				address.clone(),
+				signature.clone(),
+				extension.clone(),
+			);
+
+		let encoded = ex_v5.encode();
+		let opaque = OpaqueExtrinsic::from_bytes(&encoded).unwrap();
+
+		assert_eq!(encoded, opaque.encode());
+
+		let decoded : XTV5<Address, [u8; 5], ParentchainSignature, ParentchainTxExtension> = Decode::decode(&mut opaque.encode().as_slice()).unwrap();
+		assert_eq!(ex_v5, decoded);
+	}
+
 	// #[test]
 	// fn can_parse_register_enclave() {
 	// 	let encoded = "0x81028400d345e01893ae2c5c600675fe7b901e0b32641b3b4405772ed5eb227228ab535700d0168da6e0bd8c5657616e8b4641d47f2cd7bcbe9f76846d6a65e006d995fff1ef2b42f7e3418c9dec75bb7bae07ece61dc0255ad19879cefae88bb8c575180515000000320080fec01d23e7fe3f1db1b7740e3bc01013b330797b2ae97b589604393fc1d005f101487773733a2f2f302e302e302e303a323030300000";

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -216,6 +216,20 @@ mod tests {
 	}
 
 	#[test]
+	fn can_parse_integritee_bare_transaction_v5() {
+		use itp_utils::FromHexPrefixed;
+		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
+
+		// We only care about the preamble, so we use the `()` to stop decoding after the preamble.
+		let ex_v5: XTV5<Address, (), ParentchainSignature, ParentchainTxExtension> = XTV5::from_hex("0x280503000bc02a05399901").unwrap();
+
+		match &ex_v5.preamble {
+			Preamble::Bare(version) => assert_eq!(version, &5),
+			other => panic!("unexpected preamble: {:?}", other),
+		};
+	}
+
+	#[test]
 	fn opaque_extrinsic_works() {
 		use substrate_api_client::ac_primitives::extrinsics::UncheckedExtrinsic as XTV5;
 

--- a/app-libs/parentchain-interface/src/extrinsic_parser.rs
+++ b/app-libs/parentchain-interface/src/extrinsic_parser.rs
@@ -106,7 +106,8 @@ mod tests {
 
 		let address = Address::Id(AccountId32::new([0; 32]));
 		let extension = ParentchainTxExtension::new(Era::Immortal, 1, Default::default());
-		let signature = ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
+		let signature =
+			ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
 
 		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
 			XTV5::new_signed(
@@ -138,7 +139,8 @@ mod tests {
 
 		let address = Address::Id(AccountId32::new([0; 32]));
 		let extension = ParentchainTxExtension::new(Era::Immortal, 1, Default::default());
-		let signature = ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
+		let signature =
+			ParentchainSignature::Ed25519([0u8; 64].encode().as_slice().try_into().unwrap());
 
 		let ex_v5: XTV5<Address, _, ParentchainSignature, ParentchainTxExtension> =
 			XTV5::new_signed(
@@ -153,7 +155,8 @@ mod tests {
 
 		assert_eq!(encoded, opaque.encode());
 
-		let decoded : XTV5<Address, [u8; 5], ParentchainSignature, ParentchainTxExtension> = Decode::decode(&mut opaque.encode().as_slice()).unwrap();
+		let decoded: XTV5<Address, [u8; 5], ParentchainSignature, ParentchainTxExtension> =
+			Decode::decode(&mut opaque.encode().as_slice()).unwrap();
 		assert_eq!(ex_v5, decoded);
 	}
 

--- a/app-libs/parentchain-interface/src/integritee/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/integritee/api_client_types.rs
@@ -29,6 +29,7 @@ pub use itp_types::parentchain::{
 	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
 };
 use sp_runtime::generic;
+use sp_runtime::traits::MaybeSerialize;
 
 pub type IntegriteeRuntimeConfig = ParentchainRuntimeConfig<IntegriteeTip>;
 
@@ -40,7 +41,7 @@ pub type IntegriteeAdditionalParams = GenericAdditionalParams<IntegriteeRuntimeC
 pub type IntegriteeSignedExtra = GenericTxExtension<IntegriteeTip, Index>;
 pub type IntegriteeSignature = Signature<IntegriteeSignedExtra>;
 
-pub type IntegriteeUncheckedExtrinsic<Call> =
+pub type IntegriteeUncheckedExtrinsic<Call: MaybeSerialize> =
 	UncheckedExtrinsic<Address, Call, PairSignature, IntegriteeSignedExtra>;
 
 /// Signature type of the [UncheckedExtrinsic].

--- a/app-libs/parentchain-interface/src/integritee/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/integritee/api_client_types.rs
@@ -29,7 +29,6 @@ pub use itp_types::parentchain::{
 	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
 };
 use sp_runtime::generic;
-use sp_runtime::traits::MaybeSerialize;
 
 pub type IntegriteeRuntimeConfig = ParentchainRuntimeConfig<IntegriteeTip>;
 
@@ -41,7 +40,7 @@ pub type IntegriteeAdditionalParams = GenericAdditionalParams<IntegriteeRuntimeC
 pub type IntegriteeSignedExtra = GenericTxExtension<IntegriteeTip, Index>;
 pub type IntegriteeSignature = Signature<IntegriteeSignedExtra>;
 
-pub type IntegriteeUncheckedExtrinsic<Call: MaybeSerialize> =
+pub type IntegriteeUncheckedExtrinsic<Call> =
 	UncheckedExtrinsic<Address, Call, PairSignature, IntegriteeSignedExtra>;
 
 /// Signature type of the [UncheckedExtrinsic].

--- a/app-libs/parentchain-interface/src/integritee/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/integritee/api_client_types.rs
@@ -21,8 +21,8 @@
 //! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
 
 use crate::{
-	GenericAdditionalParams, GenericExtrinsicParams, GenericSignedExtra, ParentchainRuntimeConfig,
-	PlainTip, UncheckedExtrinsicV4,
+	GenericAdditionalParams, GenericExtrinsicParams, GenericTxExtension, ParentchainRuntimeConfig,
+	PlainTip, UncheckedExtrinsic,
 };
 use itp_types::parentchain::Header;
 pub use itp_types::parentchain::{
@@ -37,13 +37,13 @@ pub type IntegriteeTip = PlainTip<Balance>;
 pub type IntegriteeExtrinsicParams = GenericExtrinsicParams<IntegriteeRuntimeConfig, IntegriteeTip>;
 pub type IntegriteeAdditionalParams = GenericAdditionalParams<IntegriteeRuntimeConfig, Hash>;
 
-pub type IntegriteeSignedExtra = GenericSignedExtra<IntegriteeTip, Index>;
+pub type IntegriteeSignedExtra = GenericTxExtension<IntegriteeTip, Index>;
 pub type IntegriteeSignature = Signature<IntegriteeSignedExtra>;
 
 pub type IntegriteeUncheckedExtrinsic<Call> =
-	UncheckedExtrinsicV4<Address, Call, PairSignature, IntegriteeSignedExtra>;
+	UncheckedExtrinsic<Address, Call, PairSignature, IntegriteeSignedExtra>;
 
-/// Signature type of the [UncheckedExtrinsicV4].
+/// Signature type of the [UncheckedExtrinsic].
 pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
 
 pub type Block = generic::Block<Header, IntegriteeUncheckedExtrinsic<([u8; 2])>>;

--- a/app-libs/parentchain-interface/src/integritee/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/integritee/api_client_types.rs
@@ -28,7 +28,7 @@ use itp_types::parentchain::Header;
 pub use itp_types::parentchain::{
 	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
 };
-use sp_runtime::generic;
+use sp_runtime::{generic, MultiSignature};
 
 pub type IntegriteeRuntimeConfig = ParentchainRuntimeConfig<IntegriteeTip>;
 
@@ -38,13 +38,10 @@ pub type IntegriteeExtrinsicParams = GenericExtrinsicParams<IntegriteeRuntimeCon
 pub type IntegriteeAdditionalParams = GenericAdditionalParams<IntegriteeRuntimeConfig, Hash>;
 
 pub type IntegriteeSignedExtra = GenericTxExtension<IntegriteeTip, Index>;
-pub type IntegriteeSignature = Signature<IntegriteeSignedExtra>;
+pub type IntegriteeSignature = MultiSignature;
 
 pub type IntegriteeUncheckedExtrinsic<Call> =
 	UncheckedExtrinsic<Address, Call, PairSignature, IntegriteeSignedExtra>;
-
-/// Signature type of the [UncheckedExtrinsic].
-pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
 
 pub type Block = generic::Block<Header, IntegriteeUncheckedExtrinsic<([u8; 2])>>;
 

--- a/app-libs/parentchain-interface/src/integritee/mod.rs
+++ b/app-libs/parentchain-interface/src/integritee/mod.rs
@@ -38,7 +38,7 @@ use itc_parentchain_indirect_calls_executor::{
 	filter_metadata::FilterIntoDataFrom,
 	IndirectDispatch,
 };
-use itp_api_client_types::ParentchainSignedExtra;
+use itp_api_client_types::ParentchainTxExtension;
 use itp_node_api::metadata::{
 	pallet_enclave_bridge::EnclaveBridgeCallIndexes, pallet_timestamp::TimestampCallIndexes,
 };
@@ -54,7 +54,7 @@ pub use itp_types::parentchain::{AccountId, Balance, Hash};
 pub type Signature = sp_runtime::MultiSignature;
 
 /// Parses the extrinsics corresponding to the parentchain.
-pub type ParentchainExtrinsicParser = ExtrinsicParser<ParentchainSignedExtra>;
+pub type ParentchainExtrinsicParser = ExtrinsicParser<ParentchainTxExtension>;
 
 /// The default indirect call (extrinsic-triggered) of the Integritee-Parachain.
 #[derive(Debug, Clone, Encode, Decode, Eq, PartialEq)]

--- a/app-libs/parentchain-interface/src/lib.rs
+++ b/app-libs/parentchain-interface/src/lib.rs
@@ -39,8 +39,8 @@ pub use substrate_api_client::{
 	ac_primitives::{
 		config::Config,
 		extrinsics::{
-			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericAdditionalSigned,
-			GenericExtrinsicParams, GenericSignedExtra, PlainTip, UncheckedExtrinsicV4,
+			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericImplicit,
+			GenericExtrinsicParams, GenericTxExtension, PlainTip, UncheckedExtrinsic,
 		},
 		serde_impls::StorageKey,
 		signer::{SignExtrinsic, StaticExtrinsicSigner},

--- a/app-libs/parentchain-interface/src/lib.rs
+++ b/app-libs/parentchain-interface/src/lib.rs
@@ -39,8 +39,8 @@ pub use substrate_api_client::{
 	ac_primitives::{
 		config::Config,
 		extrinsics::{
-			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericImplicit,
-			GenericExtrinsicParams, GenericTxExtension, PlainTip, UncheckedExtrinsic,
+			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericExtrinsicParams,
+			GenericImplicit, GenericTxExtension, PlainTip, UncheckedExtrinsic,
 		},
 		serde_impls::StorageKey,
 		signer::{SignExtrinsic, StaticExtrinsicSigner},

--- a/app-libs/parentchain-interface/src/target_a/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/target_a/api_client_types.rs
@@ -21,8 +21,8 @@
 //! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
 
 use crate::{
-	GenericAdditionalParams, GenericExtrinsicParams, GenericSignedExtra, ParentchainRuntimeConfig,
-	PlainTip, UncheckedExtrinsicV4,
+	GenericAdditionalParams, GenericExtrinsicParams, GenericTxExtension, ParentchainRuntimeConfig,
+	PlainTip, UncheckedExtrinsic,
 };
 pub use itp_types::parentchain::{
 	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
@@ -36,13 +36,13 @@ pub type TargetATip = PlainTip<Balance>;
 pub type TargetAExtrinsicParams = GenericExtrinsicParams<TargetARuntimeConfig, TargetATip>;
 pub type TargetAAdditionalParams = GenericAdditionalParams<TargetARuntimeConfig, Hash>;
 
-pub type TargetASignedExtra = GenericSignedExtra<TargetATip, Index>;
+pub type TargetASignedExtra = GenericTxExtension<TargetATip, Index>;
 pub type TargetASignature = Signature<TargetASignedExtra>;
 
 pub type TargetAUncheckedExtrinsic<Call> =
-	UncheckedExtrinsicV4<Address, Call, PairSignature, TargetASignedExtra>;
+	UncheckedExtrinsic<Address, Call, PairSignature, TargetASignedExtra>;
 
-/// Signature type of the [UncheckedExtrinsicV4].
+/// Signature type of the [UncheckedExtrinsic].
 pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
 
 #[cfg(feature = "std")]

--- a/app-libs/parentchain-interface/src/target_a/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/target_a/api_client_types.rs
@@ -20,6 +20,7 @@
 //! You need to update this if you have a signed extension in your node that
 //! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
 
+use sp_runtime::MultiSignature;
 use crate::{
 	GenericAdditionalParams, GenericExtrinsicParams, GenericTxExtension, ParentchainRuntimeConfig,
 	PlainTip, UncheckedExtrinsic,
@@ -37,13 +38,10 @@ pub type TargetAExtrinsicParams = GenericExtrinsicParams<TargetARuntimeConfig, T
 pub type TargetAAdditionalParams = GenericAdditionalParams<TargetARuntimeConfig, Hash>;
 
 pub type TargetASignedExtra = GenericTxExtension<TargetATip, Index>;
-pub type TargetASignature = Signature<TargetASignedExtra>;
+pub type TargetASignature = MultiSignature;
 
 pub type TargetAUncheckedExtrinsic<Call> =
 	UncheckedExtrinsic<Address, Call, PairSignature, TargetASignedExtra>;
-
-/// Signature type of the [UncheckedExtrinsic].
-pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
 
 #[cfg(feature = "std")]
 pub use api::*;

--- a/app-libs/parentchain-interface/src/target_a/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/target_a/api_client_types.rs
@@ -20,7 +20,6 @@
 //! You need to update this if you have a signed extension in your node that
 //! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
 
-use sp_runtime::MultiSignature;
 use crate::{
 	GenericAdditionalParams, GenericExtrinsicParams, GenericTxExtension, ParentchainRuntimeConfig,
 	PlainTip, UncheckedExtrinsic,
@@ -28,6 +27,7 @@ use crate::{
 pub use itp_types::parentchain::{
 	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
 };
+use sp_runtime::MultiSignature;
 
 pub type TargetARuntimeConfig = ParentchainRuntimeConfig<TargetATip>;
 

--- a/app-libs/parentchain-interface/src/target_b/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/target_b/api_client_types.rs
@@ -21,8 +21,8 @@
 //! is different from the integritee-node, e.g., if you use the `pallet_asset_tx_payment`.
 
 use crate::{
-	AssetTip, GenericAdditionalParams, GenericExtrinsicParams, GenericSignedExtra,
-	ParentchainRuntimeConfig, UncheckedExtrinsicV4,
+	AssetTip, GenericAdditionalParams, GenericExtrinsicParams, GenericTxExtension,
+	ParentchainRuntimeConfig, UncheckedExtrinsic,
 };
 pub use itp_types::parentchain::{
 	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
@@ -37,13 +37,13 @@ pub type TargetBTip = AssetTip<Balance>;
 pub type TargetBExtrinsicParams = GenericExtrinsicParams<TargetBRuntimeConfig, TargetBTip>;
 pub type TargetBAdditionalParams = GenericAdditionalParams<TargetBRuntimeConfig, Hash>;
 
-pub type TargetBSignedExtra = GenericSignedExtra<TargetBTip, Index>;
+pub type TargetBSignedExtra = GenericTxExtension<TargetBTip, Index>;
 pub type TargetBSignature = Signature<TargetBSignedExtra>;
 
 pub type TargetBUncheckedExtrinsic<Call> =
-	UncheckedExtrinsicV4<Address, Call, PairSignature, TargetBSignedExtra>;
+	UncheckedExtrinsic<Address, Call, PairSignature, TargetBSignedExtra>;
 
-/// Signature type of the [UncheckedExtrinsicV4].
+/// Signature type of the [UncheckedExtrinsic].
 pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
 
 #[cfg(feature = "std")]

--- a/app-libs/parentchain-interface/src/target_b/api_client_types.rs
+++ b/app-libs/parentchain-interface/src/target_b/api_client_types.rs
@@ -27,6 +27,7 @@ use crate::{
 pub use itp_types::parentchain::{
 	AccountData, AccountId, AccountInfo, Address, Balance, Hash, Index, Signature as PairSignature,
 };
+use sp_runtime::MultiSignature;
 
 pub type TargetBRuntimeConfig = ParentchainRuntimeConfig<TargetBTip>;
 
@@ -38,13 +39,10 @@ pub type TargetBExtrinsicParams = GenericExtrinsicParams<TargetBRuntimeConfig, T
 pub type TargetBAdditionalParams = GenericAdditionalParams<TargetBRuntimeConfig, Hash>;
 
 pub type TargetBSignedExtra = GenericTxExtension<TargetBTip, Index>;
-pub type TargetBSignature = Signature<TargetBSignedExtra>;
+pub type TargetBSignature = MultiSignature;
 
 pub type TargetBUncheckedExtrinsic<Call> =
 	UncheckedExtrinsic<Address, Call, PairSignature, TargetBSignedExtra>;
-
-/// Signature type of the [UncheckedExtrinsic].
-pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
 
 #[cfg(feature = "std")]
 pub use api::*;

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,8 +42,8 @@ teeracle-primitives = { git = "https://github.com/integritee-network/pallets.git
 
 # `default-features = false` to remove the jsonrpsee dependency.
 # disable unsupported jsonrpcsee
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
-substrate-client-keystore = { git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-client-keystore = { git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
 
 # substrate dependencies
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-cli"
-version = "0.16.7"
+version = "0.17.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,8 +42,8 @@ teeracle-primitives = { git = "https://github.com/integritee-network/pallets.git
 
 # `default-features = false` to remove the jsonrpsee dependency.
 # disable unsupported jsonrpcsee
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
-substrate-client-keystore = { git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
+substrate-client-keystore = { git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
 
 # substrate dependencies
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/cli/src/assets/commands/transfer.rs
+++ b/cli/src/assets/commands/transfer.rs
@@ -70,7 +70,8 @@ impl TransferCommand {
 					location,
 					MultiAddress::<AccountId, ()>::Id(to_account),
 					Compact(self.amount)
-				).expect("Could not compose `transfer` call (call not found in metadata)");
+				)
+				.expect("Could not compose `transfer` call (call not found in metadata)");
 				info!("encoded call: {}", hex::encode(xt.function.encode()));
 				api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap()
 			},
@@ -90,7 +91,8 @@ impl TransferCommand {
 					Compact(native_asset_id),
 					MultiAddress::<AccountId, ()>::Id(to_account),
 					Compact(self.amount)
-				).expect("Could not compose `transfer` call (call not found in metadata)");
+				)
+				.expect("Could not compose `transfer` call (call not found in metadata)");
 				info!("encoded call: {}", hex::encode(xt.function.encode()));
 				api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap()
 			},

--- a/cli/src/assets/commands/transfer.rs
+++ b/cli/src/assets/commands/transfer.rs
@@ -70,7 +70,7 @@ impl TransferCommand {
 					location,
 					MultiAddress::<AccountId, ()>::Id(to_account),
 					Compact(self.amount)
-				);
+				).expect("Could not compose `transfer` call (call not found in metadata)");
 				info!("encoded call: {}", hex::encode(xt.function.encode()));
 				api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap()
 			},
@@ -90,7 +90,7 @@ impl TransferCommand {
 					Compact(native_asset_id),
 					MultiAddress::<AccountId, ()>::Id(to_account),
 					Compact(self.amount)
-				);
+				).expect("Could not compose `transfer` call (call not found in metadata)");
 				info!("encoded call: {}", hex::encode(xt.function.encode()));
 				api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap()
 			},

--- a/cli/src/base_cli/commands/shield_funds.rs
+++ b/cli/src/base_cli/commands/shield_funds.rs
@@ -73,7 +73,8 @@ impl ShieldFundsCommand {
 			shard,
 			encrypted_recevier,
 			self.amount
-		).expect("Could not compose `shield_fund` extrinsic (call not found in metadata)");
+		)
+		.expect("Could not compose `shield_fund` extrinsic (call not found in metadata)");
 
 		match chain_api.submit_and_watch_extrinsic_until(xt, XtStatus::Finalized) {
 			Ok(xt_report) => {

--- a/cli/src/base_cli/commands/shield_funds.rs
+++ b/cli/src/base_cli/commands/shield_funds.rs
@@ -73,7 +73,7 @@ impl ShieldFundsCommand {
 			shard,
 			encrypted_recevier,
 			self.amount
-		);
+		).expect("Could not compose `shield_fund` extrinsic (call not found in metadata)");
 
 		match chain_api.submit_and_watch_extrinsic_until(xt, XtStatus::Finalized) {
 			Ok(xt_report) => {

--- a/cli/src/base_cli/commands/transfer.rs
+++ b/cli/src/base_cli/commands/transfer.rs
@@ -51,7 +51,9 @@ impl TransferCommand {
 			debug!("using AssetTip API");
 			let mut api = get_target_b_chain_api(cli);
 			api.set_signer(from_account.into());
-			let xt = api.balance_transfer_allow_death(to_account.clone().into(), self.amount);
+			let xt = api
+				.balance_transfer_allow_death(to_account.clone().into(), self.amount)
+				.unwrap();
 			debug!("encoded call: {}", hex_encode(xt.function.encode().as_slice()));
 			debug!("encoded extrinsic will be sent: {}", hex_encode(xt.encode().as_slice()));
 			let tx_report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap();
@@ -63,7 +65,9 @@ impl TransferCommand {
 		} else {
 			debug!("using PlainTip API");
 			api.set_signer(from_account.into());
-			let xt = api.balance_transfer_allow_death(to_account.clone().into(), self.amount);
+			let xt = api
+				.balance_transfer_allow_death(to_account.clone().into(), self.amount)
+				.unwrap();
 			debug!("encoded call: {}", hex_encode(xt.function.encode().as_slice()));
 			debug!("encoded extrinsic will be sent: {}", hex_encode(xt.encode().as_slice()));
 			let tx_report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock).unwrap();

--- a/cli/src/oracle/commands/add_to_whitelist.rs
+++ b/cli/src/oracle/commands/add_to_whitelist.rs
@@ -56,10 +56,12 @@ impl AddToWhitelistCmd {
 			ADD_TO_WHITELIST,
 			market_data_source,
 			mrenclave
-		);
+		)
+		.expect("Could not compose `add_to_whitelist` call (call in metadata not found)");
 
 		// compose the extrinsic
-		let xt = compose_extrinsic!(api, "Sudo", "sudo", call);
+		let xt = compose_extrinsic!(api, "Sudo", "sudo", call)
+			.expect("Could not compose `sudo` extrinsic (call in metadata not found)");
 
 		let report = api.submit_and_watch_extrinsic_until(xt, XtStatus::Finalized).unwrap();
 		println!("[+] Add to whitelist got finalized. Hash: {:?}\n", report.extrinsic_hash);

--- a/cli/src/trusted_operation.rs
+++ b/cli/src/trusted_operation.rs
@@ -176,7 +176,8 @@ fn send_indirect_request<T: Decode + Debug>(
 	chain_api.set_signer(signer.into());
 
 	let request = Request { shard, cyphertext: call_encrypted };
-	let xt = compose_extrinsic!(&chain_api, ENCLAVE_BRIDGE, "invoke", request);
+	let xt = compose_extrinsic!(&chain_api, ENCLAVE_BRIDGE, "invoke", request)
+		.expect("failed to compose `invoke` call");
 
 	let invocation_block_hash = match chain_api
 		.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)

--- a/core-primitives/extrinsics-factory/Cargo.toml
+++ b/core-primitives/extrinsics-factory/Cargo.toml
@@ -10,7 +10,7 @@ log = { version = "0.4", default-features = false }
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
 
 # local dependencies
 itp-node-api = { path = "../node-api", default-features = false }

--- a/core-primitives/extrinsics-factory/Cargo.toml
+++ b/core-primitives/extrinsics-factory/Cargo.toml
@@ -10,7 +10,7 @@ log = { version = "0.4", default-features = false }
 # sgx dependencies
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
 sgx_types = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git" }
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
 
 # local dependencies
 itp-node-api = { path = "../node-api", default-features = false }

--- a/core-primitives/extrinsics-factory/src/lib.rs
+++ b/core-primitives/extrinsics-factory/src/lib.rs
@@ -160,10 +160,7 @@ where
 					"[ExtrinsicsFactory] TransactionExtension: {:?}",
 					extrinsic_params.transaction_extension()
 				);
-				log::trace!(
-					"[ExtrinsicsFactory] Implicit: {:?}",
-					extrinsic_params.implicit()
-				);
+				log::trace!("[ExtrinsicsFactory] Implicit: {:?}", extrinsic_params.implicit());
 
 				let xt = compose_extrinsic_offline!(&self.signer, call, extrinsic_params).encode();
 				nonce_value += 1;

--- a/core-primitives/extrinsics-factory/src/lib.rs
+++ b/core-primitives/extrinsics-factory/src/lib.rs
@@ -157,12 +157,12 @@ where
 				);
 
 				log::trace!(
-					"[ExtrinsicsFactory] SignedExtra: {:?}",
-					extrinsic_params.signed_extra()
+					"[ExtrinsicsFactory] TransactionExtension: {:?}",
+					extrinsic_params.transaction_extension()
 				);
 				log::trace!(
-					"[ExtrinsicsFactory] AdditionalParams: {:?}",
-					extrinsic_params.additional_signed()
+					"[ExtrinsicsFactory] Implicit: {:?}",
+					extrinsic_params.implicit()
 				);
 
 				let xt = compose_extrinsic_offline!(&self.signer, call, extrinsic_params).encode();
@@ -255,11 +255,11 @@ pub mod tests {
 	//
 	// 	let opaque_calls =
 	// 		[OpaqueCall(vec![3u8; 42]), OpaqueCall(vec![12u8, 78]), OpaqueCall(vec![15u8, 12])];
-	// 	let xts: Vec<UncheckedExtrinsicV4<OpaqueCall>> = extrinsics_factory
+	// 	let xts: Vec<UncheckedExtrinsic<OpaqueCall>> = extrinsics_factory
 	// 		.create_extrinsics(&opaque_calls)
 	// 		.unwrap()
 	// 		.iter()
-	// 		.map(|mut x| UncheckedExtrinsicV4::<OpaqueCall>::decode(&mut x))
+	// 		.map(|mut x| UncheckedExtrinsic::<OpaqueCall>::decode(&mut x))
 	// 		.collect();
 	//
 	// 	assert_eq!(xts.len(), opaque_calls.len());

--- a/core-primitives/extrinsics-factory/src/lib.rs
+++ b/core-primitives/extrinsics-factory/src/lib.rs
@@ -121,6 +121,8 @@ where
 	NodeRuntimeConfig: Config<Hash = H256>,
 	u128: From<Tip>,
 	Tip: Copy + Default + Encode + Debug,
+	<Signer as SignExtrinsic<AccountId>>::Signature: Debug,
+	<Signer as SignExtrinsic<AccountId>>::ExtrinsicAddress: Debug,
 {
 	type Config = NodeRuntimeConfig;
 
@@ -162,9 +164,12 @@ where
 				);
 				log::trace!("[ExtrinsicsFactory] Implicit: {:?}", extrinsic_params.implicit());
 
-				let xt = compose_extrinsic_offline!(&self.signer, call, extrinsic_params).encode();
+				let xt = compose_extrinsic_offline!(&self.signer, call, extrinsic_params);
+
+				log::trace!("[ExtrinsicsFactory] xt: {:?}", xt);
+
 				nonce_value += 1;
-				xt
+				xt.encode()
 			})
 			.map(|xt| {
 				OpaqueExtrinsic::from_bytes(&xt)
@@ -184,14 +189,19 @@ where
 
 #[cfg(test)]
 pub mod tests {
-
 	use super::*;
+	use codec::Decode;
 	use itp_node_api::{
-		api_client::{AssetRuntimeConfig, PairSignature, StaticExtrinsicSigner},
+		api_client::{
+			AssetRuntimeConfig, AssetTip, AssetTxExtension, PairSignature, ParentchainSignature,
+			Preamble, StaticExtrinsicSigner, UncheckedExtrinsic,
+		},
 		metadata::provider::NodeMetadataRepository,
 	};
 	use itp_nonce_cache::{GetNonce, Nonce, NonceCache, NonceValue};
+	use itp_types::Address;
 	use sp_core::{ed25519, Pair};
+	use sp_runtime::generic::Era;
 
 	#[test]
 	pub fn creating_xts_increases_nonce_for_each_xt() {
@@ -220,12 +230,13 @@ pub mod tests {
 		*nonce_cache1.load_for_mutation().unwrap() = Nonce(42);
 
 		let node_metadata_repo = Arc::new(NodeMetadataRepository::new(NodeMetadata::default()));
-		let extrinsics_factory = ExtrinsicsFactory::<_, _, _, AssetRuntimeConfig, u128>::new(
-			test_genesis_hash(),
-			StaticExtrinsicSigner::<_, PairSignature>::new(test_account()),
-			nonce_cache1.clone(),
-			node_metadata_repo,
-		);
+		let extrinsics_factory =
+			ExtrinsicsFactory::<_, _, _, AssetRuntimeConfig, AssetTip<u128>>::new(
+				test_genesis_hash(),
+				StaticExtrinsicSigner::<_, PairSignature>::new(test_account()),
+				nonce_cache1.clone(),
+				node_metadata_repo,
+			);
 
 		let nonce_cache2 = Arc::new(NonceCache::default());
 		let extrinsics_factory = extrinsics_factory.with_signer(
@@ -241,6 +252,32 @@ pub mod tests {
 		assert_eq!(opaque_calls.len(), xts.len());
 		assert_eq!(nonce_cache2.get_nonce().unwrap(), Nonce(opaque_calls.len() as NonceValue));
 		assert_eq!(nonce_cache1.get_nonce().unwrap(), Nonce(42));
+
+		let decoded: UncheckedExtrinsic<Address, [u8; 42], ParentchainSignature, AssetTxExtension> =
+			Decode::decode(&mut &xts[0].encode()[..]).unwrap();
+		let decoded2: UncheckedExtrinsic<Address, [u8; 2], ParentchainSignature, AssetTxExtension> =
+			Decode::decode(&mut &xts[1].encode()[..]).unwrap();
+
+		match decoded.preamble {
+			Preamble::Signed(_addr, _sig, ext) => {
+				assert_eq!(ext.nonce, 0);
+				assert_eq!(ext.era, Era::Immortal);
+				assert_eq!(ext.tip, AssetTip::new(0));
+			},
+			other => panic!("Unexpected preamble: {:?}", other),
+		}
+
+		match decoded2.preamble {
+			Preamble::Signed(_addr, _sig, ext) => {
+				assert_eq!(ext.nonce, 1);
+				assert_eq!(ext.era, Era::Immortal);
+				assert_eq!(ext.tip, AssetTip::new(0));
+			},
+			other => panic!("Unexpected preamble: {:?}", other),
+		}
+
+		assert_eq!(decoded.function, [3u8; 42]);
+		assert_eq!(decoded2.function, [12, 78]);
 	}
 
 	// #[test]

--- a/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -13,7 +13,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "po
 
 # scs
 # `default-features = false` to remove the jsonrpsee dependency.
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
 
 # local deps
 itp-api-client-types = { path = "../api-client-types" }

--- a/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -13,7 +13,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "po
 
 # scs
 # `default-features = false` to remove the jsonrpsee dependency.
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
 
 # local deps
 itp-api-client-types = { path = "../api-client-types" }

--- a/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/core-primitives/node-api/api-client-types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 itp-types = { default-features = false, path = "../../types" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
 
 [features]
 default = ["std"]

--- a/core-primitives/node-api/api-client-types/Cargo.toml
+++ b/core-primitives/node-api/api-client-types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 itp-types = { default-features = false, path = "../../types" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
 
 [features]
 default = ["std"]

--- a/core-primitives/node-api/api-client-types/src/lib.rs
+++ b/core-primitives/node-api/api-client-types/src/lib.rs
@@ -33,8 +33,9 @@ pub use substrate_api_client::{
 	ac_primitives::{
 		config::{AssetRuntimeConfig, Config, DefaultRuntimeConfig},
 		extrinsics::{
-			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericImplicit,
-			GenericExtrinsicParams, GenericTxExtension, PlainTip, UncheckedExtrinsic, Preamble as GenericPreamble,
+			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericExtrinsicParams,
+			GenericImplicit, GenericTxExtension, PlainTip, Preamble as GenericPreamble,
+			UncheckedExtrinsic,
 		},
 		serde_impls::StorageKey,
 		signer::{SignExtrinsic, StaticExtrinsicSigner},

--- a/core-primitives/node-api/api-client-types/src/lib.rs
+++ b/core-primitives/node-api/api-client-types/src/lib.rs
@@ -61,8 +61,8 @@ pub type ParentchainAssetTip = AssetTip<Balance>;
 pub type ParentchainExtrinsicParams =
 	GenericExtrinsicParams<DefaultRuntimeConfig, ParentchainPlainTip>;
 pub type ParentchainAdditionalParams = GenericAdditionalParams<ParentchainPlainTip, Hash>;
-pub use DefaultRuntimeConfig as ParentchainRuntimeConfig;
 use sp_runtime::MultiSignature;
+pub use DefaultRuntimeConfig as ParentchainRuntimeConfig;
 // Pay in asset fees.
 //
 // This needs to be used if the node uses the `pallet_asset_tx_payment`.

--- a/core-primitives/node-api/api-client-types/src/lib.rs
+++ b/core-primitives/node-api/api-client-types/src/lib.rs
@@ -62,7 +62,7 @@ pub type ParentchainExtrinsicParams =
 	GenericExtrinsicParams<DefaultRuntimeConfig, ParentchainPlainTip>;
 pub type ParentchainAdditionalParams = GenericAdditionalParams<ParentchainPlainTip, Hash>;
 pub use DefaultRuntimeConfig as ParentchainRuntimeConfig;
-
+use sp_runtime::MultiSignature;
 // Pay in asset fees.
 //
 // This needs to be used if the node uses the `pallet_asset_tx_payment`.
@@ -72,10 +72,10 @@ pub use DefaultRuntimeConfig as ParentchainRuntimeConfig;
 pub type ParentchainUncheckedExtrinsic<Call> =
 	UncheckedExtrinsic<Address, Call, PairSignature, ParentchainTxExtension>;
 pub type ParentchainTxExtension = GenericTxExtension<ParentchainPlainTip, Index>;
-pub type ParentchainSignature = Signature<ParentchainTxExtension>;
+pub type ParentchainSignature = Signature;
 
-/// Signature type of the [UncheckedExtrinsic].
-pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
+/// Signature type of the [UncheckedExtrinsicV5].
+pub type Signature = MultiSignature;
 
 pub type Preamble<TxExtension> = GenericPreamble<Address, PairSignature, TxExtension>;
 

--- a/core-primitives/node-api/api-client-types/src/lib.rs
+++ b/core-primitives/node-api/api-client-types/src/lib.rs
@@ -72,6 +72,7 @@ use sp_runtime::MultiSignature;
 pub type ParentchainUncheckedExtrinsic<Call> =
 	UncheckedExtrinsic<Address, Call, PairSignature, ParentchainTxExtension>;
 pub type ParentchainTxExtension = GenericTxExtension<ParentchainPlainTip, Index>;
+pub type AssetTxExtension = GenericTxExtension<ParentchainAssetTip, Index>;
 pub type ParentchainSignature = Signature;
 
 /// Signature type of the [UncheckedExtrinsicV5].

--- a/core-primitives/node-api/api-client-types/src/lib.rs
+++ b/core-primitives/node-api/api-client-types/src/lib.rs
@@ -33,8 +33,8 @@ pub use substrate_api_client::{
 	ac_primitives::{
 		config::{AssetRuntimeConfig, Config, DefaultRuntimeConfig},
 		extrinsics::{
-			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericAdditionalSigned,
-			GenericExtrinsicParams, GenericSignedExtra, PlainTip, UncheckedExtrinsicV4,
+			AssetTip, CallIndex, ExtrinsicParams, GenericAdditionalParams, GenericImplicit,
+			GenericExtrinsicParams, GenericTxExtension, PlainTip, UncheckedExtrinsic, Preamble as GenericPreamble,
 		},
 		serde_impls::StorageKey,
 		signer::{SignExtrinsic, StaticExtrinsicSigner},
@@ -69,12 +69,14 @@ pub use DefaultRuntimeConfig as ParentchainRuntimeConfig;
 // pub type ParentchainAdditionalParams = GenericAdditionalParams<AssetRuntimeConfig, Hash>;
 
 pub type ParentchainUncheckedExtrinsic<Call> =
-	UncheckedExtrinsicV4<Address, Call, PairSignature, ParentchainSignedExtra>;
-pub type ParentchainSignedExtra = GenericSignedExtra<ParentchainPlainTip, Index>;
-pub type ParentchainSignature = Signature<ParentchainSignedExtra>;
+	UncheckedExtrinsic<Address, Call, PairSignature, ParentchainTxExtension>;
+pub type ParentchainTxExtension = GenericTxExtension<ParentchainPlainTip, Index>;
+pub type ParentchainSignature = Signature<ParentchainTxExtension>;
 
-/// Signature type of the [UncheckedExtrinsicV4].
+/// Signature type of the [UncheckedExtrinsic].
 pub type Signature<SignedExtra> = Option<(Address, PairSignature, SignedExtra)>;
+
+pub type Preamble<TxExtension> = GenericPreamble<Address, PairSignature, TxExtension>;
 
 #[cfg(feature = "std")]
 pub use substrate_api_client::{

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -17,7 +17,7 @@ itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-fe
 itp-utils = { path = "../../core-primitives/utils", default-features = false }
 
 # scs
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
 
 # substrate-deps
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/core-primitives/types/Cargo.toml
+++ b/core-primitives/types/Cargo.toml
@@ -17,7 +17,7 @@ itp-stf-primitives = { path = "../../core-primitives/stf-primitives", default-fe
 itp-utils = { path = "../../core-primitives/utils", default-features = false }
 
 # scs
-substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
 
 # substrate-deps
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.42" }

--- a/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -11,7 +11,7 @@ use itp_node_api::{
 	metadata::NodeMetadataTrait,
 };
 use itp_sgx_runtime_primitives::types::{AccountId, Balance};
-use itp_stf_primitives::{traits::IndirectExecutor};
+use itp_stf_primitives::traits::IndirectExecutor;
 use itp_test::mock::stf_mock::{GetterMock, TrustedCallMock, TrustedCallSignedMock};
 use itp_types::{
 	parentchain::{ExtrinsicStatus, FilterEvents, HandleParentchainEvents},

--- a/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -7,11 +7,11 @@ use codec::{Decode, Encode};
 use core::marker::PhantomData;
 
 use itp_node_api::{
-	api_client::{CallIndex, PairSignature, UncheckedExtrinsicV4},
+	api_client::{CallIndex, PairSignature, UncheckedExtrinsic},
 	metadata::NodeMetadataTrait,
 };
 use itp_sgx_runtime_primitives::types::{AccountId, Balance};
-use itp_stf_primitives::{traits::IndirectExecutor, types::Signature};
+use itp_stf_primitives::{traits::IndirectExecutor};
 use itp_test::mock::stf_mock::{GetterMock, TrustedCallMock, TrustedCallSignedMock};
 use itp_types::{
 	parentchain::{ExtrinsicStatus, FilterEvents, HandleParentchainEvents},
@@ -73,54 +73,54 @@ where
 pub struct ExtrinsicParser<SignedExtra> {
 	_phantom: PhantomData<SignedExtra>,
 }
-use itp_api_client_types::ParentchainSignedExtra;
+use itp_api_client_types::{ParentchainTxExtension, Preamble};
 use itp_stf_primitives::types::TrustedOperation;
 
 /// Parses the extrinsics corresponding to the parentchain.
-pub type MockParentchainExtrinsicParser = ExtrinsicParser<ParentchainSignedExtra>;
+pub type MockParentchainExtrinsicParser = ExtrinsicParser<ParentchainTxExtension>;
 
-/// Partially interpreted extrinsic containing the `signature` and the `call_index` whereas
+/// Partially interpreted extrinsic containing the `preamble` and the `call_index` whereas
 /// the `call_args` remain in encoded form.
 ///
 /// Intended for usage, where the actual `call_args` form is unknown.
-pub struct SemiOpaqueExtrinsic<'a> {
+pub struct SemiOpaqueExtrinsic<'a, TxExtension> {
 	/// Signature of the Extrinsic.
-	pub signature: Signature,
+	pub preamble: Preamble<TxExtension>,
 	/// Call index of the dispatchable.
 	pub call_index: CallIndex,
 	/// Encoded arguments of the dispatchable corresponding to the `call_index`.
 	pub call_args: &'a [u8],
 }
 
-/// Trait to extract signature and call indexes of an encoded [UncheckedExtrinsicV4].
+/// Trait to extract signature and call indexes of an encoded [UncheckedExtrinsic].
 pub trait ParseExtrinsic {
 	/// Signed extra of the extrinsic.
-	type SignedExtra;
+	type TxExtension;
 
-	fn parse(encoded_call: &[u8]) -> Result<SemiOpaqueExtrinsic, codec::Error>;
+	fn parse(encoded_call: &[u8]) -> Result<SemiOpaqueExtrinsic<Self::TxExtension>, codec::Error>;
 }
 
-impl<SignedExtra> ParseExtrinsic for ExtrinsicParser<SignedExtra>
+impl<TxExtension> ParseExtrinsic for ExtrinsicParser<TxExtension>
 where
-	SignedExtra: Decode + Encode,
+	TxExtension: Decode + Encode,
 {
-	type SignedExtra = SignedExtra;
+	type TxExtension = TxExtension;
 
 	/// Extract a call index of an encoded call.
-	fn parse(encoded_call: &[u8]) -> Result<SemiOpaqueExtrinsic, codec::Error> {
+	fn parse(encoded_call: &[u8]) -> Result<SemiOpaqueExtrinsic<Self::TxExtension>, codec::Error> {
 		let call_mut = &mut &encoded_call[..];
 
 		// `()` is a trick to stop decoding after the call index. So the remaining bytes
 		//  of `call` after decoding only contain the parentchain's dispatchable's arguments.
-		let xt = UncheckedExtrinsicV4::<
+		let xt = UncheckedExtrinsic::<
             Address,
             (CallIndex, ()),
             PairSignature,
-            Self::SignedExtra,
+            Self::TxExtension,
         >::decode(call_mut)?;
 
 		Ok(SemiOpaqueExtrinsic {
-			signature: xt.signature.unwrap().1,
+			preamble: xt.preamble,
 			call_index: xt.function.0,
 			call_args: call_mut,
 		})

--- a/core/parentchain/indirect-calls-executor/src/mock.rs
+++ b/core/parentchain/indirect-calls-executor/src/mock.rs
@@ -84,7 +84,7 @@ pub type MockParentchainExtrinsicParser = ExtrinsicParser<ParentchainTxExtension
 ///
 /// Intended for usage, where the actual `call_args` form is unknown.
 pub struct SemiOpaqueExtrinsic<'a, TxExtension> {
-	/// Signature of the Extrinsic.
+	/// Preamble of the Extrinsic.
 	pub preamble: Preamble<TxExtension>,
 	/// Call index of the dispatchable.
 	pub call_index: CallIndex,

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   "integritee-node-${VERSION}":
-    image: "${INTEGRITEE_NODE:-integritee/integritee-node:1.13.0}"
+    image: "${INTEGRITEE_NODE:-integritee/integritee-node:1.18.8}"
     hostname: integritee-node
     devices:
       - "${SGX_PROVISION:-/dev/null}:/dev/sgx/provision"

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "ac-primitives",
  "log",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,9 +50,10 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "impl-serde",
+ "impl-trait-for-tuples",
  "parity-scale-codec",
  "primitive-types",
  "scale-info",
@@ -182,8 +183,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -194,7 +195,7 @@ checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -616,7 +617,7 @@ dependencies = [
  "fnv 1.0.7",
  "ident_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "strsim",
  "syn 1.0.109",
 ]
@@ -628,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -655,7 +656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79116f119dd1dba1abf1f3405f03b9b0e79a27a3883864bfebded8a3dc768cd"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -667,7 +668,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -992,7 +993,7 @@ dependencies = [
  "blake2",
  "fs-err",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -1158,8 +1159,8 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro-warning",
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1170,8 +1171,8 @@ dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1180,8 +1181,8 @@ version = "3.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1308,7 +1309,7 @@ source = "git+https://github.com/mesalock-linux/futures-rs-sgx#d54882f24ddf7d613
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -1594,13 +1595,13 @@ dependencies = [
 
 [[package]]
 name = "impl-trait-for-tuples"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 1.0.109",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2781,7 +2782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -3204,7 +3205,7 @@ checksum = "2a296c3079b5fefbc499e1de58dc26c09b1b9a5952d26694ee89f04a43ebbb3e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -3295,7 +3296,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
  "version_check",
 ]
@@ -3307,7 +3308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "version_check",
 ]
 
@@ -3330,15 +3331,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e99670bafb56b9a106419397343bdbc8b8742c3cc449fec6345f86173f47cd4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -3365,9 +3366,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -3457,8 +3458,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfaf0c85b766276c797f3791f5bc6d5bd116b41d53049af2789666b0c0bc9fa"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3549,7 +3550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -3656,7 +3657,7 @@ dependencies = [
  "darling",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -3683,7 +3684,7 @@ dependencies = [
  "darling",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -3709,7 +3710,7 @@ checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -3818,7 +3819,7 @@ version = "1.0.118"
 source = "git+https://github.com/mesalock-linux/serde-sgx#db0226f1d5d70fca6b96af2c285851502204e21c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -3829,8 +3830,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4200,8 +4201,8 @@ dependencies = [
  "expander",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4307,9 +4308,9 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "sp-core-hashing",
- "syn 2.0.39",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4318,8 +4319,8 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.42#ff24c60ac7d9f87727ecdd0ded9a80c56e4f4b65"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4414,8 +4415,8 @@ dependencies = [
  "Inflector",
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4503,8 +4504,8 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.4
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4545,7 +4546,7 @@ checksum = "bfc443bad666016e012538782d9e3006213a7db43e9fb1dda91657dc06a6fa08"
 dependencies = [
  "Inflector",
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "serde 1.0.192",
  "serde_json 1.0.108",
  "unicode-xid 0.2.4",
@@ -4566,7 +4567,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-retracted-check-metadata-hash#eddca35c73b5e2e3d0371fa923a0ba605c2f0d61"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -4619,18 +4620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "unicode-ident",
 ]
 
@@ -4698,7 +4699,7 @@ version = "1.0.9"
 source = "git+https://github.com/mesalock-linux/thiserror-sgx?tag=sgx_1.1.3#c2f806b88616e06aab0af770366a76885d974fdc"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote 1.0.40",
  "syn 1.0.109",
 ]
 
@@ -5011,8 +5012,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
- "syn 2.0.39",
+ "quote 1.0.40",
+ "syn 2.0.106",
 ]
 
 [[patch.unused]]

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "ac-primitives",
  "log",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "impl-serde",
  "impl-trait-for-tuples",
@@ -4567,7 +4567,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=v0.9.42-tag-v0.14.0-integritee-patch#946f3ae82c5d48023107c1890728582561e94725"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ac-compose-macros"
 version = "0.4.2"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "ac-primitives",
  "log",
@@ -25,7 +25,7 @@ dependencies = [
 [[package]]
 name = "ac-node-api"
 version = "0.5.1"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "ac-primitives",
  "bitvec",
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 name = "ac-primitives"
 version = "0.9.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "impl-serde",
  "impl-trait-for-tuples",
@@ -4567,7 +4567,7 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 [[package]]
 name = "substrate-api-client"
 version = "0.14.0"
-source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#eb52c9be2f20981b15db59c592d1937ed820f8f9"
+source = "git+https://github.com/encointer/substrate-api-client.git?branch=cl/extrinsic-v5-v0.9.42#0e28c1156d34391e96340fba3b2c6d47d166346d"
 dependencies = [
  "ac-compose-macros",
  "ac-node-api",
@@ -4820,7 +4820,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.7",
  "static_assertions",
 ]

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-runtime"
-version = "0.16.7"
+version = "0.17.0"
 dependencies = [
  "array-bytes 6.2.2",
  "cid",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enclave-runtime"
-version = "0.16.7"
+version = "0.17.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 edition = "2021"
 

--- a/enclave-runtime/src/test/top_pool_tests.rs
+++ b/enclave-runtime/src/test/top_pool_tests.rs
@@ -211,7 +211,7 @@ fn create_shielding_call_extrinsic<ShieldingKey: ShieldingCryptoEncrypt>(
 			),
 			Address::Address32([1u8; 32]),
 			MultiSignature::Ed25519(signature),
-			default_extra_for_test.signed_extra(),
+			default_extra_for_test.transaction_extension(),
 		)
 		.encode()
 		.as_slice(),

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integritee-service"
-version = "0.16.7"
+version = "0.17.0"
 authors = ["Integritee AG <hello@integritee.network>"]
 build = "build.rs"
 edition = "2021"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -65,7 +65,7 @@ sgx-verify = { git = "https://github.com/integritee-network/pallets.git", branch
 # `default-features = false` to remove the jsonrpsee dependency.
 enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 # disable unsupported jsonrpcsee
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-retracted-check-metadata-hash" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
 teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 
 # Substrate dependencies

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -65,7 +65,7 @@ sgx-verify = { git = "https://github.com/integritee-network/pallets.git", branch
 # `default-features = false` to remove the jsonrpsee dependency.
 enclave-bridge-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 # disable unsupported jsonrpcsee
-substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "cl/extrinsic-v5-v0.9.42" }
+substrate-api-client = { default-features = false, features = ["std", "sync-api"], git = "https://github.com/encointer/substrate-api-client.git", branch = "v0.9.42-tag-v0.14.0-integritee-patch" }
 teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.13.0-polkadot-v0.9.42" }
 
 # Substrate dependencies

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -211,7 +211,7 @@ where
 			Some(vec![0u8; MAX_URL_LEN]),
 			SgxAttestationMethod::Dcap { proxied: false }
 		)
-		.ok_or_else(|| ApiClientError::ExtrinsicNotFound)?
+		.ok_or(ApiClientError::ExtrinsicNotFound)?
 		.encode()
 		.into();
 		let tx_fee =
@@ -339,7 +339,7 @@ where
 {
 	let encoded_xt: Bytes = api
 		.balance_transfer_allow_death(AccountId::from([0u8; 32]).into(), 1000000000000)
-		.ok_or_else(|| ApiClientError::ExtrinsicNotFound)?
+		.ok_or(ApiClientError::ExtrinsicNotFound)?
 		.encode()
 		.into();
 	let tx_fee = api

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -292,7 +292,7 @@ where
 	println!("[{:?}] send extrinsic: bootstrap funding Enclave from Alice's funds", parentchain_id);
 	let xt = api
 		.balance_transfer_allow_death(MultiAddress::Id(accountid.clone()), funding_amount)
-		.ok_or(Error::Custom("Could not create funding extrinsic".into()))?;
+		.ok_or_else(|| Error::Custom("Could not create funding extrinsic".into()))?;
 	let xt_report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)?;
 	info!(
 		"[{:?}] L1 extrinsic success. extrinsic hash: {:?} / status: {:?}",

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -290,7 +290,8 @@ where
 	api.set_signer(alice.into());
 
 	println!("[{:?}] send extrinsic: bootstrap funding Enclave from Alice's funds", parentchain_id);
-	let xt = api.balance_transfer_allow_death(MultiAddress::Id(accountid.clone()), funding_amount);
+	let xt = api.balance_transfer_allow_death(MultiAddress::Id(accountid.clone()), funding_amount)
+		.ok_or(Error::Custom("Could not create funding extrinsic".into()))?;
 	let xt_report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)?;
 	info!(
 		"[{:?}] L1 extrinsic success. extrinsic hash: {:?} / status: {:?}",

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -18,6 +18,7 @@
 use crate::error::{Error, ServiceResult};
 use codec::Encode;
 use ita_parentchain_interface::{Config, ParentchainRuntimeConfig};
+use itp_api_client_types::ApiClientError;
 use itp_node_api::api_client::{AccountApi, TEEREX};
 use itp_settings::worker::REGISTERING_FEE_FACTOR_FOR_INIT_FUNDS;
 use itp_types::{
@@ -210,6 +211,7 @@ where
 			Some(vec![0u8; MAX_URL_LEN]),
 			SgxAttestationMethod::Dcap { proxied: false }
 		)
+		.ok_or_else(|| ApiClientError::ExtrinsicNotFound)?
 		.encode()
 		.into();
 		let tx_fee =
@@ -337,6 +339,7 @@ where
 {
 	let encoded_xt: Bytes = api
 		.balance_transfer_allow_death(AccountId::from([0u8; 32]).into(), 1000000000000)
+		.ok_or_else(|| ApiClientError::ExtrinsicNotFound)?
 		.encode()
 		.into();
 	let tx_fee = api

--- a/service/src/account_funding.rs
+++ b/service/src/account_funding.rs
@@ -290,7 +290,8 @@ where
 	api.set_signer(alice.into());
 
 	println!("[{:?}] send extrinsic: bootstrap funding Enclave from Alice's funds", parentchain_id);
-	let xt = api.balance_transfer_allow_death(MultiAddress::Id(accountid.clone()), funding_amount)
+	let xt = api
+		.balance_transfer_allow_death(MultiAddress::Id(accountid.clone()), funding_amount)
 		.ok_or(Error::Custom("Could not create funding extrinsic".into()))?;
 	let xt_report = api.submit_and_watch_extrinsic_until(xt, XtStatus::InBlock)?;
 	info!(

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -1142,6 +1142,13 @@ where
 	Tip: Copy + Default + Encode + Debug + Send + Sync + 'static,
 	Client: Request + Subscribe + Clone + Send + Sync + 'static,
 {
+	// use itp_api_client_types::UncheckedExtrinsic;
+	// let xt: UncheckedExtrinsic::<Address, (), ParentchainSignature, ParentchainTxExtension> = Decode::decode(&mut &extrinsic[..])?;
+	// log::info!("Sending integritee xt; {:?}", xt);
+	// log::info!("Sending integritee preamble; {:?}", xt.preamble.encode());
+	// log::info!("Sending integritee xt; {:?}", extrinsic);
+	// log::info!("Sending integritee xt; {}", serde_json::to_string(&sp_core::Bytes(extrinsic.clone())).unwrap());
+
 	let timeout = Duration::from_secs(5 * 60);
 	let (sender, receiver) = mpsc::channel();
 	let local_fee_payer = fee_payer.clone();

--- a/service/src/main_impl.rs
+++ b/service/src/main_impl.rs
@@ -1142,13 +1142,6 @@ where
 	Tip: Copy + Default + Encode + Debug + Send + Sync + 'static,
 	Client: Request + Subscribe + Clone + Send + Sync + 'static,
 {
-	// use itp_api_client_types::UncheckedExtrinsic;
-	// let xt: UncheckedExtrinsic::<Address, (), ParentchainSignature, ParentchainTxExtension> = Decode::decode(&mut &extrinsic[..])?;
-	// log::info!("Sending integritee xt; {:?}", xt);
-	// log::info!("Sending integritee preamble; {:?}", xt.preamble.encode());
-	// log::info!("Sending integritee xt; {:?}", extrinsic);
-	// log::info!("Sending integritee xt; {}", serde_json::to_string(&sp_core::Bytes(extrinsic.clone())).unwrap());
-
 	let timeout = Duration::from_secs(5 * 60);
 	let (sender, receiver) = mpsc::channel();
 	let local_fee_payer = fee_payer.clone();


### PR DESCRIPTION
This PR mostly consists of an api-client update to get the backwards compatible support for the Extrinsic V5. Closes #1723.



### Tests
* If the integration tests work, we can be sure that the Enclave Successfully sends Extrinsics V5 and can also handle Extrinsics V5 upon importing the block.
* Have some unit tests for parsing an Extrinsic V4 in the extrinsic parser