### PR TITLE
enable ipfs ocall test but only write and forget

### DIFF
--- a/enclave-runtime/src/test/ipfs_tests.rs
+++ b/enclave-runtime/src/test/ipfs_tests.rs
@@ -24,7 +24,7 @@ use std::{fs::File, io::Read, vec::Vec};
 #[allow(unused)]
 pub fn test_ocall_read_write_ipfs() {
 	info!("testing IPFS read/write. Hopefully ipfs daemon is running...");
-	let enc_state: Vec<u8> = vec![20; 10];
+	let enc_state: Vec<u8> = vec![20; 1024];
 
 	let cid = OcallApi.write_ipfs(enc_state.as_slice()).unwrap();
 

--- a/enclave-runtime/src/test/ipfs_tests.rs
+++ b/enclave-runtime/src/test/ipfs_tests.rs
@@ -24,7 +24,7 @@ use std::{fs::File, io::Read, vec::Vec};
 #[allow(unused)]
 pub fn test_ocall_read_write_ipfs() {
 	info!("testing IPFS read/write. Hopefully ipfs daemon is running...");
-	let enc_state: Vec<u8> = vec![20; 1024];
+	let enc_state: Vec<u8> = vec![20; 100*1024];
 
 	let cid = OcallApi.write_ipfs(enc_state.as_slice()).unwrap();
 

--- a/enclave-runtime/src/test/ipfs_tests.rs
+++ b/enclave-runtime/src/test/ipfs_tests.rs
@@ -28,15 +28,15 @@ fn test_ocall_read_write_ipfs() {
 
 	let cid = OcallApi.write_ipfs(enc_state.as_slice()).unwrap();
 
-	OcallApi.read_ipfs(&cid).unwrap();
-
-	let cid_str = std::str::from_utf8(&cid.0).unwrap();
-	let mut f = File::open(cid_str).unwrap();
-	let mut content_buf = Vec::new();
-	f.read_to_end(&mut content_buf).unwrap();
-	info!("reading file {:?} of size {} bytes", f, &content_buf.len());
-
-	let mut ipfs_content = IpfsContent::new(cid_str, content_buf);
-	let verification = ipfs_content.verify();
-	assert!(verification.is_ok());
+	// OcallApi.read_ipfs(&cid).unwrap();
+	//
+	// let cid_str = std::str::from_utf8(&cid.0).unwrap();
+	// let mut f = File::open(cid_str).unwrap();
+	// let mut content_buf = Vec::new();
+	// f.read_to_end(&mut content_buf).unwrap();
+	// info!("reading file {:?} of size {} bytes", f, &content_buf.len());
+	//
+	// let mut ipfs_content = IpfsContent::new(cid_str, content_buf);
+	// let verification = ipfs_content.verify();
+	// assert!(verification.is_ok());
 }

--- a/enclave-runtime/src/test/ipfs_tests.rs
+++ b/enclave-runtime/src/test/ipfs_tests.rs
@@ -22,9 +22,9 @@ use log::*;
 use std::{fs::File, io::Read, vec::Vec};
 
 #[allow(unused)]
-fn test_ocall_read_write_ipfs() {
+pub fn test_ocall_read_write_ipfs() {
 	info!("testing IPFS read/write. Hopefully ipfs daemon is running...");
-	let enc_state: Vec<u8> = vec![20; 4 * 512 * 1024];
+	let enc_state: Vec<u8> = vec![20; 10];
 
 	let cid = OcallApi.write_ipfs(enc_state.as_slice()).unwrap();
 

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -166,7 +166,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		// ipfs::test_creates_ipfs_content_struct_works,
 		// ipfs::test_verification_ok_for_correct_content,
 		// ipfs::test_verification_fails_for_incorrect_content,
-		// test_ocall_read_write_ipfs,
+		test_ocall_read_write_ipfs,
 
 		// Teeracle tests
 		run_teeracle_tests,
@@ -429,7 +429,8 @@ fn test_create_state_diff() {
 	assert_eq!(
 		sender_acc_info.data.free,
 		ita_stf::test_genesis::ENDOWED_ACC_FUNDS
-			- TX_AMOUNT - 1_000_000_000_000 / ita_stf::STF_TX_FEE_UNIT_DIVIDER
+			- TX_AMOUNT
+			- 1_000_000_000_000 / ita_stf::STF_TX_FEE_UNIT_DIVIDER
 	);
 }
 

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -25,6 +25,7 @@ use crate::{
 		fixtures::test_setup::{
 			enclave_call_signer, test_setup, TestStf, TestStfExecutor, TestTopPoolAuthor,
 		},
+		ipfs_tests,
 		mocks::types::TestStateKeyRepo,
 		sidechain_aura_tests, sidechain_event_tests, state_getter_tests, top_pool_tests,
 	},
@@ -166,7 +167,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		// ipfs::test_creates_ipfs_content_struct_works,
 		// ipfs::test_verification_ok_for_correct_content,
 		// ipfs::test_verification_fails_for_incorrect_content,
-		test_ocall_read_write_ipfs,
+		ipfs_tests::test_ocall_read_write_ipfs,
 
 		// Teeracle tests
 		run_teeracle_tests,

--- a/service/src/ocall_bridge/ipfs_ocall.rs
+++ b/service/src/ocall_bridge/ipfs_ocall.rs
@@ -21,82 +21,85 @@ use futures::TryStreamExt;
 use ipfs_api::IpfsClient;
 use log::*;
 use std::{
-	fs::File,
-	io::{Cursor, Write},
-	str,
-	sync::mpsc::channel,
+    fs::File,
+    io::{Cursor, Write},
+    str,
+    sync::mpsc::channel,
 };
 
 pub struct IpfsOCall;
 
 impl IpfsBridge for IpfsOCall {
-	fn write_to_ipfs(&self, data: &'static [u8]) -> OCallBridgeResult<Cid> {
-		debug!("    Entering ocall_write_ipfs");
-		Ok(write_to_ipfs(data))
-	}
+    fn write_to_ipfs(&self, data: &'static [u8]) -> OCallBridgeResult<Cid> {
+        debug!("    Entering ocall_write_ipfs");
+        Ok(write_to_ipfs(data))
+    }
 
-	fn read_from_ipfs(&self, cid: Cid) -> OCallBridgeResult<()> {
-		debug!("Entering ocall_read_ipfs");
+    fn read_from_ipfs(&self, cid: Cid) -> OCallBridgeResult<()> {
+        debug!("Entering ocall_read_ipfs");
 
-		let result = read_from_ipfs(cid);
-		match result {
-			Ok(res) => {
-				let filename = str::from_utf8(&cid).unwrap();
-				create_file(filename, &res).map_err(OCallBridgeError::IpfsError)
-			},
-			Err(_) => Err(OCallBridgeError::IpfsError("failed to read from IPFS".to_string())),
-		}
-	}
+        let result = read_from_ipfs(cid);
+        match result {
+            Ok(res) => {
+                let filename = str::from_utf8(&cid).unwrap();
+                create_file(filename, &res).map_err(OCallBridgeError::IpfsError)
+            }
+            Err(_) => Err(OCallBridgeError::IpfsError("failed to read from IPFS".to_string())),
+        }
+    }
 }
 
 fn create_file(filename: &str, result: &[u8]) -> Result<(), String> {
-	match File::create(filename) {
-		Ok(mut f) => f
-			.write_all(result)
-			.map_or_else(|e| Err(format!("failed writing to file: {}", e)), |_| Ok(())),
-		Err(e) => Err(format!("failed to create file: {}", e)),
-	}
+    match File::create(filename) {
+        Ok(mut f) => f
+            .write_all(result)
+            .map_or_else(|e| Err(format!("failed writing to file: {}", e)), |_| Ok(())),
+        Err(e) => Err(format!("failed to create file: {}", e)),
+    }
 }
 
 #[tokio::main]
 async fn write_to_ipfs(data: &'static [u8]) -> Cid {
-	// Creates an `IpfsClient` connected to the endpoint specified in ~/.ipfs/api.
-	// If not found, tries to connect to `localhost:5001`.
-	let client = IpfsClient::default();
+    // Creates an `IpfsClient` connected to the endpoint specified in ~/.ipfs/api.
+    // If not found, tries to connect to `localhost:5001`.
+    let client = IpfsClient::default();
 
-	match client.version().await {
-		Ok(version) => info!("version: {:?}", version.version),
-		Err(e) => eprintln!("error getting version: {}", e),
-	}
+    match client.version().await {
+        Ok(version) => info!("version: {:?}", version.version),
+        Err(e) => eprintln!("error getting version: {}", e),
+    }
 
-	let datac = Cursor::new(data);
-	let (tx, rx) = channel();
+    let datac = Cursor::new(data);
+    let (tx, rx) = channel();
 
-	match client.add(datac).await {
-		Ok(res) => {
-			info!("Result Hash {}", res.hash);
-			tx.send(res.hash.into_bytes()).unwrap();
-		},
-		Err(e) => eprintln!("error adding file: {}", e),
-	}
-	let mut cid: Cid = [0; 46];
-	cid.clone_from_slice(&rx.recv().unwrap());
-	cid
+    match client.add(datac).await {
+        Ok(res) => {
+            info!("Result Hash {}", res.hash);
+            tx.send(res.hash.into_bytes()).unwrap();
+        }
+        Err(e) => {
+            eprintln!("error adding file: {}", e);
+            return [0; 46];
+        }
+    }
+    let mut cid: Cid = [0; 46];
+    cid.clone_from_slice(&rx.recv().unwrap());
+    cid
 }
 
 #[tokio::main]
 pub async fn read_from_ipfs(cid: Cid) -> Result<Vec<u8>, String> {
-	// Creates an `IpfsClient` connected to the endpoint specified in ~/.ipfs/api.
-	// If not found, tries to connect to `localhost:5001`.
-	let client = IpfsClient::default();
-	let h = str::from_utf8(&cid).unwrap();
+    // Creates an `IpfsClient` connected to the endpoint specified in ~/.ipfs/api.
+    // If not found, tries to connect to `localhost:5001`.
+    let client = IpfsClient::default();
+    let h = str::from_utf8(&cid).unwrap();
 
-	info!("Fetching content from: {}", h);
+    info!("Fetching content from: {}", h);
 
-	client
-		.cat(h)
-		.map_ok(|chunk| chunk.to_vec())
-		.map_err(|e| e.to_string())
-		.try_concat()
-		.await
+    client
+        .cat(h)
+        .map_ok(|chunk| chunk.to_vec())
+        .map_err(|e| e.to_string())
+        .try_concat()
+        .await
 }


### PR DESCRIPTION
we never enabled ipfs ocall test because it needs an ipfs node running. The question, however, is if the test would make the enclave crash irrespective of the ipfs node availability